### PR TITLE
Fixes crash re-rendering inventory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3463,24 +3463,29 @@
       },
       "dependencies": {
         "@patternfly/react-core": {
-          "version": "1.44.3",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-1.44.3.tgz",
-          "integrity": "sha512-eJqD6GjQUSiy6fEjnG8ZuYlFALo/zvjp9g/OaPsliANnj535BaETP6gLwJg89jXz4pcVFhaOOzLqfNQOFHpk8A==",
+          "version": "1.48.0",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-1.48.0.tgz",
+          "integrity": "sha512-TV1NLewA3MzRs/KB5zf7EmXhsNjFKNFav8g4GsVUBT7k2BllWczwge5MmR74f06QJbcc2eO3TneH3E+Ep+OtyQ==",
           "requires": {
-            "@patternfly/react-icons": "^2.9.5",
+            "@patternfly/react-icons": "^2.9.7",
             "@patternfly/react-styles": "^2.3.0",
-            "@patternfly/react-tokens": "^1.0.0",
+            "@patternfly/react-tokens": "^1.9.6",
             "@tippy.js/react": "^1.1.1",
             "exenv": "^1.2.2",
             "focus-trap-react": "^4.0.1"
           },
           "dependencies": {
             "@patternfly/react-icons": {
-              "version": "2.9.5",
-              "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-2.9.5.tgz",
-              "integrity": "sha512-5e/BD2ER5jifUjUgbIilApOfhVldlAjhQdh7EwH/M3M+qzIb+2qKxV/xQ6hWD3AA71lcYIxvPMMHgdWIAl5oPQ=="
+              "version": "2.9.7",
+              "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-2.9.7.tgz",
+              "integrity": "sha512-hHEFX2YYdea4Pp0Vlqk3AXJa3ptX+HAWtsXRD3rETCQhUBEnhhDH4Sjg9wCVf1hX7CDsi0tWkAefogVSU/LPsA=="
             }
           }
+        },
+        "@patternfly/react-tokens": {
+          "version": "1.9.6",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-1.9.6.tgz",
+          "integrity": "sha512-+Ryqfm7Sxzf/RAJA9zDiNVWZhIQBkSGbDxO02e6BdLK4FKGz2iSahdIz0YDVzklsra8BNW76HGsama2v92jAjQ=="
         },
         "react": {
           "version": "16.7.0",
@@ -10017,8 +10022,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10039,14 +10043,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10061,20 +10063,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10191,8 +10190,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10204,7 +10202,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10219,7 +10216,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10227,14 +10223,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -10253,7 +10247,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10334,8 +10327,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10347,7 +10339,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10433,8 +10424,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10470,7 +10460,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10490,7 +10479,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10534,14 +10522,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -20264,9 +20250,9 @@
       }
     },
     "tippy.js": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-3.4.0.tgz",
-      "integrity": "sha512-mI5Fyn/E/nXRrGQKk/5M6baw9hcc6h3I11zMe5YR2LYitwmymGw9n+J3BstdOXcqx15+p0EFv3DpwSHNhePl3A==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-3.4.1.tgz",
+      "integrity": "sha512-ZiyGP9WZyCCcjxKM4G88cm4U1r1ytjeMDGa5FSKPaPzwc/3yZJVZsb1ffcmqUMCpryRp5LNxRNGKLzbs11sb/Q==",
       "requires": {
         "popper.js": "^1.14.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3441,25 +3441,30 @@
       "optional": true
     },
     "@red-hat-insights/insights-frontend-components": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.29.1.tgz",
-      "integrity": "sha512-R0cbquM5phZ3Idm40wnGyfBWsvpQGDOSRNu5Ssr+YWF74IawAErlqQyfT81kIpr1gPAMjHeiIcw0pDqwCIhMRg==",
+      "version": "3.33.4",
+      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.33.4.tgz",
+      "integrity": "sha512-napjDrxPj1xpa25zaTztnkF0D+t6MdAPHENFmTxvjrwxS0osP2W7lUCr/tsEoLgR8JSMXY3to3avsskvWn6S1Q==",
       "requires": {
         "@patternfly/react-core": "^1.36.0",
         "@patternfly/react-icons": "^2.8.0",
+        "apollo-boost": "^0.1.23",
         "bootstrap-sass": "^3.3.7",
         "c3": "^0.6.7",
         "classnames": "^2.2.5",
         "d3": "^5.7.0",
         "font-awesome-sass": "^4.7.0",
+        "graphql": "^14.0.2",
+        "graphql-tag": "^2.10.0",
         "patternfly-react": "^2.19.1",
         "prop-types": "^15.6.2",
         "react": "^16.5.1",
+        "react-apollo": "^2.3.3",
         "react-dom": "^16.5.1",
         "react-redux": "^5.0.7",
         "react-router-dom": "^4.2.2",
         "redux": "^3.7.2",
-        "redux-promise-middleware": "^5.1.1"
+        "redux-promise-middleware": "^5.1.1",
+        "urijs": "^1.19.1"
       },
       "dependencies": {
         "@patternfly/react-core": {
@@ -3487,6 +3492,90 @@
           "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-1.9.6.tgz",
           "integrity": "sha512-+Ryqfm7Sxzf/RAJA9zDiNVWZhIQBkSGbDxO02e6BdLK4FKGz2iSahdIz0YDVzklsra8BNW76HGsama2v92jAjQ=="
         },
+        "apollo-boost": {
+          "version": "0.1.23",
+          "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.1.23.tgz",
+          "integrity": "sha512-yQr1Ph3DEVvU7XeQhAh+6p2wZ++azxgGAtwXc+D5EP1CHU0HMVfVgtj1M0CDO1z14SZgQbrurQ60bgiyquoiVg==",
+          "requires": {
+            "apollo-cache": "^1.1.22",
+            "apollo-cache-inmemory": "^1.3.12",
+            "apollo-client": "^2.4.8",
+            "apollo-link": "^1.0.6",
+            "apollo-link-error": "^1.0.3",
+            "apollo-link-http": "^1.3.1",
+            "apollo-link-state": "^0.4.0",
+            "graphql-tag": "^2.4.2"
+          }
+        },
+        "apollo-cache": {
+          "version": "1.1.22",
+          "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.22.tgz",
+          "integrity": "sha512-8PoxhQLISj2oHwT7i/r4l+ly4y3RKZls+dtXzAewu3U77P9dNZKhYkRNAhx9iEfsrNoHgXBV8vMp64hb1uYh+g==",
+          "requires": {
+            "apollo-utilities": "^1.0.27"
+          }
+        },
+        "apollo-cache-inmemory": {
+          "version": "1.3.12",
+          "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.12.tgz",
+          "integrity": "sha512-jxWcW64QoYQZ09UH6v3syvCCl3MWr6bsxT3wYYL6ORi8svdJUpnNrHTcv5qXqJYVg/a+NHhfEt+eGjJUG2ytXA==",
+          "requires": {
+            "apollo-cache": "^1.1.22",
+            "apollo-utilities": "^1.0.27",
+            "optimism": "^0.6.8"
+          }
+        },
+        "apollo-client": {
+          "version": "2.4.8",
+          "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.8.tgz",
+          "integrity": "sha512-OAFbCTnGPtaIv0j+EZYzY20d+MD2JNbJ/YXZ4s0/oZlSg87bb0gjcIbccw2lnytipymZcZNr5ArFFeh0saGEwA==",
+          "requires": {
+            "@types/async": "2.0.50",
+            "@types/zen-observable": "^0.8.0",
+            "apollo-cache": "1.1.22",
+            "apollo-link": "^1.0.0",
+            "apollo-link-dedup": "^1.0.0",
+            "apollo-utilities": "1.0.27",
+            "symbol-observable": "^1.0.2",
+            "zen-observable": "^0.8.0"
+          }
+        },
+        "apollo-utilities": {
+          "version": "1.0.27",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.27.tgz",
+          "integrity": "sha512-nzrMQ89JMpNmYnVGJ4t8zN75gQbql27UDhlxNi+3OModp0Masx5g+fQmQJ5B4w2dpRuYOsdwFLmj3lQbwOKV1Q==",
+          "requires": {
+            "fast-json-stable-stringify": "^2.0.0"
+          }
+        },
+        "core-js": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+          "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz",
+          "integrity": "sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==",
+          "requires": {
+            "react-is": "^16.3.2"
+          }
+        },
         "react": {
           "version": "16.7.0",
           "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
@@ -3496,6 +3585,19 @@
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "scheduler": "^0.12.0"
+          }
+        },
+        "react-apollo": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.3.3.tgz",
+          "integrity": "sha512-y4CwwmJjp0De/An7vrvEWOJ27lxmS/SXT8z22I8aOEBC2wzdcavDPjKzeLYJKs+hv1MGS3h84PSwFtlU4Em/bA==",
+          "requires": {
+            "fbjs": "^1.0.0",
+            "hoist-non-react-statics": "^3.0.0",
+            "invariant": "^2.2.2",
+            "lodash.flowright": "^3.5.0",
+            "lodash.isequal": "^4.5.0",
+            "prop-types": "^15.6.0"
           }
         },
         "react-dom": {
@@ -20895,6 +20997,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "urijs": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@patternfly/react-charts": "1.1.0",
     "@patternfly/react-core": "1.31.0",
     "@patternfly/react-icons": "2.9.3",
-    "@red-hat-insights/insights-frontend-components": "3.29.1",
+    "@red-hat-insights/insights-frontend-components": "3.33.4",
     "actioncable": "^5.2.1",
     "apollo-boost": "^0.1.22",
     "classnames": "^2.2.5",

--- a/src/SmartComponents/CompliancePolicyCard/CompliancePolicyCard.js
+++ b/src/SmartComponents/CompliancePolicyCard/CompliancePolicyCard.js
@@ -31,7 +31,8 @@ class CompliancePolicyCard extends React.Component {
             { x: 'Compliant', y: compliantHostCount },
             { x: 'Non-compliant', y: totalHostCount - compliantHostCount }
         ];
-        const compliancePercentage = (donutValues[0].y / donutValues[1].y) || '0' + '%';
+        const compliancePercentage = 100 *
+            (donutValues[0].y / (donutValues[0].y + donutValues[1].y)) + '%';
         const label = (
             <svg
                 className="chart-label"

--- a/src/SmartComponents/InventoryDetails/InventoryDetails.js
+++ b/src/SmartComponents/InventoryDetails/InventoryDetails.js
@@ -41,7 +41,7 @@ class InventoryDetails extends React.Component {
         const { InventoryCmp } = this.state;
         return (
             <React.Fragment>
-                <InventoryCmp />
+                <InventoryCmp hideBack />
             </React.Fragment>
         );
     }

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -96,7 +96,8 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                 { name: donutValues[1].y + ' Systems Non-Compliant' }
             ];
 
-            const compliancePercentage = (donutValues[0].y / donutValues[1].y) + '%';
+            const compliancePercentage = 100 *
+                (donutValues[0].y / (donutValues[0].y + donutValues[1].y)) + '%';
 
             const label = (
                 <svg

--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -65,7 +65,7 @@ class SystemDetails extends React.Component {
                                     current={data.system.name}
                                     onNavigate={this.onNavigate}
                                 />
-                                <InventoryDetails />
+                                <InventoryDetails hideBack />
                             </PageHeader>
                             <Main>
                                 <SystemPolicyCards policies={data.system.profiles} />

--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -65,7 +65,8 @@ class SystemDetails extends React.Component {
                                     current={data.system.name}
                                     onNavigate={this.onNavigate}
                                 />
-                                <InventoryDetails hideBack />
+                                <InventoryDetails />
+                                <br/>
                             </PageHeader>
                             <Main>
                                 <SystemPolicyCards policies={data.system.profiles} />

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -18,8 +18,8 @@ export const systemsToInventoryEntities = (systems, entities) =>
             // This should compare the inventory ID instead with
             // the ID in compliance
             let matchingEntity = entities.find((entity) => {
-                return entity.facts.inventory !== undefined &&
-                    entity.facts.inventory.hostname === system.name;
+                return entity.facts !== undefined &&
+                    entity.facts.hostname === system.name;
             });
             if (matchingEntity === undefined) {
                 return;
@@ -43,9 +43,9 @@ export const systemsToInventoryEntities = (systems, entities) =>
                 updated: matchingEntity.updated,
                 facts: {
                     inventory: {
-                        hostname: matchingEntity.facts.inventory.hostname,
-                        machine_id: matchingEntity.facts.inventory.machine_id,
-                        release: matchingEntity.facts.inventory.release
+                        hostname: matchingEntity.facts.hostname,
+                        machine_id: matchingEntity.facts.machine_id,
+                        release: matchingEntity.facts.release
                     },
                     compliance: {
                         profiles: system.profile_names,

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -66,7 +66,12 @@ export const entitiesReducer = (INVENTORY_ACTION, systems, columns) => applyRedu
     {
         [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => {
             state.rows = systemsToInventoryEntities(systems, state.rows);
-            state.columns.push(...columns);
+            for (const column of columns) {
+                if (state.columns.map(column => column.key).indexOf(column.key) === -1) {
+                    state.columns.push(column);
+                }
+            }
+
             return { ...state };
         }
     },


### PR DESCRIPTION
If the inventory is rendered twice without reloading the page, the
Reducer is adding the columns to be shown more than once (e.g:
compliance score is added once again). At that point there are more
columns than there are are values to fill.