### PR TITLE
Update Remediations to new Inventory format

### DIFF
--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -66,6 +66,8 @@ export const entitiesReducer = (INVENTORY_ACTION, systems, columns) => applyRedu
     {
         [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => {
             state.rows = systemsToInventoryEntities(systems, state.rows);
+            state.count = state.rows.length;
+            state.total = state.rows.length;
             for (const column of columns) {
                 if (state.columns.map(column => column.key).indexOf(column.key) === -1) {
                     state.columns.push(column);


### PR DESCRIPTION
The newest inventory stores hosts only on 'entities.rows', instead of
'entities.entities'. We should adapt the Remediations button to that,
and also pass a 'compliance:' prefix to every rule.