### PR TITLE
Disable Ansible button when not available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3357,9 +3357,9 @@
       "dev": true
     },
     "@patternfly/patternfly-next": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly-next/-/patternfly-next-1.0.41.tgz",
-      "integrity": "sha512-DgzY/K9Ihl3qEz6nMrZfSwqj27uncbLsYwGt1myWRHoA+c4VVzFvMCgV5Oz1VFR+9jmALrKI8aSXFrgC8eoThA=="
+      "version": "1.0.168",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly-next/-/patternfly-next-1.0.168.tgz",
+      "integrity": "sha512-eXVnIDibKbAmdel0R8iVO8pWjdZfYfPKaPAeUoMrId/9pGq/yChuoM0rbdaKOimY6GYM0PkbqgSSJdxVYwJmyQ=="
     },
     "@patternfly/react-charts": {
       "version": "1.4.1",
@@ -14920,7 +14920,7 @@
     },
     "moment-timezone": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
+      "resolved": "http://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
       "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "appname": "compliance"
   },
   "dependencies": {
-    "@patternfly/patternfly-next": "^1.0.41",
+    "@patternfly/patternfly-next": "^1.0.80",
     "@patternfly/react-charts": "1.4.1",
     "@patternfly/react-core": "1.49.4",
     "@patternfly/react-icons": "2.9.3",

--- a/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
+++ b/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
@@ -52,9 +52,11 @@ class ComplianceRemediationButton extends React.Component {
     }
 
     render() {
+        const { disableRemediations } = this.props;
         return (
             <div id='remediation-button' style={{ marginRight: '20px' }}>
                 <RemediationButton
+                    isDisabled={disableRemediations || this.dataProvider().issues.length === 0}
                     dataProvider={this.dataProvider}
                 />
             </div>
@@ -65,7 +67,12 @@ class ComplianceRemediationButton extends React.Component {
 ComplianceRemediationButton.propTypes = {
     selectedEntities: propTypes.array,
     selectedRules: propTypes.array,
-    allSystems: propTypes.array // Prop coming from data.allSystems GraphQL query
+    allSystems: propTypes.array, // Prop coming from data.allSystems GraphQL query
+    disableRemediations: propTypes.bool
+};
+
+ComplianceRemediationButton.defaultProps = {
+    disableRemediations: false
 };
 
 const mapStateToProps = state => {

--- a/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
+++ b/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
@@ -39,7 +39,7 @@ const ComplianceSystemsTable = () => (
 
             return (
                 <div className="systems-table">
-                    <SystemsTable items={systems} columns={columns} />
+                    <SystemsTable disableRemediations={true} items={systems} columns={columns} />
                 </div>
             );
         }}

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -170,7 +170,7 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                     <Main>
                         <Grid gutter='md'>
                             <GridItem span={12}>
-                                <SystemsTable items={systems} columns={columns} />
+                                <SystemsTable disableRemediations={true} items={systems} columns={columns} />
                             </GridItem>
                         </Grid>
                     </Main>

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -48,13 +48,13 @@ class SystemsTable extends React.Component {
 
     render() {
         const { InventoryCmp } = this.state;
-        const { items } = this.props;
+        const { items, disableRemediations } = this.props;
         const tableHeaderButtons = <reactCore.Level gutter="md">
             <reactCore.LevelItem>
                 <DownloadTableButton />
             </reactCore.LevelItem>
             <reactCore.LevelItem>
-                <ComplianceRemediationButton />
+                <ComplianceRemediationButton disableRemediations={disableRemediations} />
             </reactCore.LevelItem>
         </reactCore.Level>;
 
@@ -74,7 +74,12 @@ class SystemsTable extends React.Component {
 
 SystemsTable.propTypes = {
     items: propTypes.array,
-    columns: propTypes.array
+    columns: propTypes.array,
+    disableRemediations: propTypes.bool
+};
+
+SystemsTable.defaultProps = {
+    disableRemediations: false
 };
 
 export default SystemsTable;


### PR DESCRIPTION
This commit disables the button in the places where we can potentially
request N fixes for M hosts, which is something not supported by the
Remediations modal yet. It also enables the button only when you check a
few rules in the rules page.