### PR TITLE
Filter selected entities for export to CSV button properly

### DIFF
--- a/src/SmartComponents/DownloadTableButton/DownloadTableButton.js
+++ b/src/SmartComponents/DownloadTableButton/DownloadTableButton.js
@@ -65,12 +65,12 @@ DownloadTableButton.propTypes = {
 };
 
 const mapStateToProps = state => {
-    if (state.entities === undefined || state.entities.entities === undefined) {
+    if (state.entities === undefined || state.entities.rows === undefined) {
         return { selectedEntities: [] };
     }
 
     return {
-        selectedEntities: state.entities.entities.
+        selectedEntities: state.entities.rows.
         filter(entity => entity.selected).
         map(entity => entity.id)
     };


### PR DESCRIPTION
Before this, it was using the old method from the inventory
'entities.entities' to get all available entities. It's now adapted
to use .rows