### PR TITLE
Fixes RHICOMPL-34: Redirect to login on 401's

### DIFF
--- a/src/SmartComponents/CompliancePoliciesCards/CompliancePoliciesCards.js
+++ b/src/SmartComponents/CompliancePoliciesCards/CompliancePoliciesCards.js
@@ -34,7 +34,13 @@ const QUERY = gql`
 const CompliancePoliciesCards = () => (
     <Query query={QUERY}>
         {({ data, error, loading }) => {
-            if (error) { return 'Oops! Error loading Policy data: ' + error; }
+            if (error) {
+                if (error.networkError.statusCode === 401) {
+                    window.insights.chrome.auth.logout();
+                }
+
+                return 'Oops! Error loading Policy data: ' + error;
+            }
 
             if (loading) { return 'Loading Policies...'; }
 

--- a/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
+++ b/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
@@ -18,7 +18,13 @@ const QUERY = gql`
 const ComplianceSystemsTable = () => (
     <Query query={QUERY}>
         {({ data, error, loading }) => {
-            if (error) { return 'Oops! Error loading Systems data: ' + error; }
+            if (error) {
+                if (error.networkError.statusCode === 401) {
+                    window.insights.chrome.auth.logout();
+                }
+
+                return 'Oops! Error loading Systems data: ' + error;
+            }
 
             if (loading) { return 'Loading Systems...'; }
 

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -54,7 +54,13 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
             let donutId = 'loading-donut';
             let policy = {};
 
-            if (error) { return 'Oops! Error loading Policy data: ' + error; }
+            if (error) {
+                if (error.networkError.statusCode === 401) {
+                    window.insights.chrome.auth.logout();
+                }
+
+                return 'Oops! Error loading Policy data: ' + error;
+            }
 
             if (loading) {
                 return (<PageHeader>Loading Policy details...</PageHeader>);

--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -45,7 +45,13 @@ class SystemDetails extends React.Component {
             <Query query={QUERY} variables={{ systemId }}>
                 {({ data, error, loading }) => {
                     let rules = {};
-                    if (error) { return 'Oops! Error loading System data: ' + error; }
+                    if (error) {
+                        if (error.networkError.statusCode === 401) {
+                            window.insights.chrome.auth.logout();
+                        }
+
+                        return 'Oops! Error loading Systems data: ' + error;
+                    }
 
                     if (loading) {
                         return (<PageHeader>Loading System details...</PageHeader>);


### PR DESCRIPTION
IMO if a user is denied access to a given resource for RBAC reasons, we should be returning 403 rather than 401, as discussed [here](http://www.dirv.me/blog/2011/07/18/understanding-403-forbidden/index.html).