### PR TITLE
Allow to set compliance threshold on a per-profile basis

### DIFF
--- a/src/SmartComponents/CompliancePolicyCard/CompliancePolicyCard.js
+++ b/src/SmartComponents/CompliancePolicyCard/CompliancePolicyCard.js
@@ -97,7 +97,7 @@ class CompliancePolicyCard extends React.Component {
                             </GridItem>
                             <GridItem span={8}>
                                 <Text style={{ fontWeight: '500', color: '#bbb' }} component={TextVariants.small}>
-                                    Systems Compliant
+                                    Systems above compliance threshold
                                 </Text>
                             </GridItem>
                         </Grid>

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -3,6 +3,7 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import SystemsTable from '../SystemsTable/SystemsTable';
 import { onNavigate } from '../../Utilities/Breadcrumbs';
+import SetThresholdDropdown from '../SetThresholdDropdown/SetThresholdDropdown';
 import {
     Breadcrumbs,
     PageHeader,
@@ -29,11 +30,13 @@ import '../../Charts.scss';
 const QUERY = gql`
 query Profile($policyId: String!){
     profile(id: $policyId) {
+        id
         name
         ref_id
         description
         total_host_count
         compliant_host_count
+        compliance_threshold
         hosts {
             id,
             name,
@@ -144,7 +147,7 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                         />
                         <PageHeaderTitle title={policy.name} />
                         <Grid gutter='md'>
-                            <GridItem span={5}>
+                            <GridItem span={4}>
                                 <div className='chart-inline'>
                                     <div className='chart-container'>
                                         {label}
@@ -165,8 +168,9 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                                         width={200}
                                     />
                                 </div>
+
                             </GridItem>
-                            <GridItem span={7}>
+                            <GridItem span={6}>
                                 <TextContent>
                                     <Text style={{ fontWeight: 'bold' }} component={TextVariants.p}>Description</Text>
                                     <Text className="policy-description" component={TextVariants.p}>
@@ -174,6 +178,13 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                                     </Text>
                                     <br/>
                                 </TextContent>
+                                <Text component={TextVariants.small}>
+                                    Threshold for compliance: {policy.compliance_threshold}%
+                                </Text>
+                            </GridItem>
+                            <GridItem span={2}>
+                                <SetThresholdDropdown policyId={policy.id}
+                                    previousThreshold={policy.compliance_threshold} />
                             </GridItem>
                         </Grid>
                     </PageHeader>

--- a/src/SmartComponents/SetThresholdDropdown/SetThresholdDropdown.js
+++ b/src/SmartComponents/SetThresholdDropdown/SetThresholdDropdown.js
@@ -1,0 +1,112 @@
+import {
+    Dropdown,
+    DropdownToggle,
+    DropdownItem,
+    Modal,
+    Form,
+    FormGroup,
+    TextInput,
+    Button
+} from '@patternfly/react-core';
+import React, { Component } from 'react';
+import propTypes from 'prop-types';
+import UpdateProfileThreshold from './UpdateProfileThreshold';
+
+class SetThresholdDropdown extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isOpen: false,
+            isModalOpen: false,
+            validThreshold: true,
+            threshold: props.previousThreshold
+        };
+    }
+
+    handleModalToggle = () => {
+        this.setState(({ isModalOpen }) => ({
+            isModalOpen: !isModalOpen
+        }));
+    };
+
+    handleTextInputChange = threshold => {
+        if (threshold > 100 || threshold < 0) {
+            this.setState({ validThreshold: false });
+        } else {
+            this.setState({ validThreshold: true, threshold });
+        }
+    };
+
+    onToggle = isOpen => {
+        this.setState({
+            isOpen
+        });
+    };
+
+    onSelect = () => {
+        this.setState({
+            isOpen: !this.state.isOpen
+        });
+    };
+
+    render() {
+        const { isOpen, isModalOpen, threshold, validThreshold } = this.state;
+        const { policyId } = this.props;
+        const dropdownItems = [
+            <DropdownItem key="action" onClick={this.handleModalToggle} component="button">
+                Set compliance threshold
+            </DropdownItem>
+        ];
+
+        return (
+            <React.Fragment>
+                <Dropdown
+                    onSelect={this.onSelect}
+                    toggle={<DropdownToggle onToggle={this.onToggle}>Actions</DropdownToggle>}
+                    isOpen={isOpen}
+                    dropdownItems={dropdownItems}
+                />
+                <Modal
+                    isSmall
+                    title="Update compliance threshold"
+                    isOpen={isModalOpen}
+                    onClose={this.handleModalToggle}
+                    actions={[
+                        <Button key="cancel" variant="secondary" onClick={this.handleModalToggle}>
+                            Cancel
+                        </Button>,
+                        <UpdateProfileThreshold
+                            key='confirm'
+                            policyId={policyId}
+                            threshold={threshold} />
+                    ]}
+                >
+                        The compliance threshold defines what percentage of rules must be met in order for a system to
+                        be determined &quot;compliant&quot;
+                    <Form>
+                        <FormGroup field-id='policy-threshold'
+                            isValid={validThreshold}
+                            helperTextInvalid='Threshold has to be a number between 0 and 100'
+                            label="Compliance threshold (%):">
+                            <TextInput
+                                value={threshold}
+                                type='number'
+                                id='policy-threshold'
+                                onChange={this.handleTextInputChange}
+                                isValid={validThreshold}
+                                aria-label="compliance threshold"
+                            />
+                        </FormGroup>
+                    </Form>
+                </Modal>
+            </React.Fragment>
+        );
+    }
+}
+
+SetThresholdDropdown.propTypes = {
+    policyId: propTypes.string,
+    previousThreshold: propTypes.number
+};
+
+export default SetThresholdDropdown;

--- a/src/SmartComponents/SetThresholdDropdown/UpdateProfileThreshold.js
+++ b/src/SmartComponents/SetThresholdDropdown/UpdateProfileThreshold.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+import { Button } from '@patternfly/react-core';
+import propTypes from 'prop-types';
+
+class UpdateProfileButton extends React.Component {
+    onClick = () => {
+        const { mutate, policyId, threshold } = this.props;
+        mutate({
+            variables: {
+                /* eslint-disable camelcase */
+                input: {
+                    id: policyId,
+                    compliance_threshold: parseFloat(threshold)
+                }
+                /* eslint-disable camelcase */
+            }
+        })
+        .then(() => {
+            document.location.reload();
+        });
+    }
+
+    render() {
+        return (<Button type='submit' variant='primary'
+            onClick={this.onClick}>Save</Button>
+        );
+    }
+}
+
+const UPDATE_THRESHOLD = gql`
+mutation UpdateProfile($input: UpdateProfileInput!) {
+    UpdateProfile(input: $input) {
+        profile {
+            id,
+            compliance_threshold
+        }
+    }
+}
+`;
+
+UpdateProfileButton.propTypes = {
+    policyId: propTypes.string,
+    mutate: propTypes.function,
+    threshold: propTypes.number
+};
+
+const UpdateProfileThreshold = graphql(UPDATE_THRESHOLD)(UpdateProfileButton);
+export default UpdateProfileThreshold;


### PR DESCRIPTION
Demo:

![Peek 2019-03-24 11-33](https://user-images.githubusercontent.com/598891/54878156-f6ee9500-4e28-11e9-96d1-ab26ec810204.gif)


If you try to input a number above 100 or below 0, the field blocks you from doing so and shows the error, instructing you to write a number between 0 and 100. 

The page is fully reloaded after changing the threshold, I tried doing this without a page reload and it's feasible but it's a lot more of code that has to nullify the cached donut charts and compliance values everywhere. I suppose this would be something that would not be normally changed.  

cc @katierik