### PR TITLE
Adapt to ssg: remediations API format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3899,9 +3899,9 @@
       "integrity": "sha512-ni5abWOau8NwsN6oZNj+NX0QzqE1XX0WtOjBuhZSV4wtKCNwLNRlLHNLXdpVeT4nffhcMdKVV/yFxkgipUC7AA=="
     },
     "@red-hat-insights/insights-frontend-components": {
-      "version": "3.41.45",
-      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.45.tgz",
-      "integrity": "sha512-PgcMEwmK4g12nB+hTdtKS8/wQuPxwIBv6PZxGOmeYguZ2nrXSId/we/1DZeKNrW5ba5szZMUn6oLsWnoXaNDsg==",
+      "version": "3.41.50",
+      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.50.tgz",
+      "integrity": "sha512-jyYBtARzMV5vFsay2tEvTvxFXP8bdn3BCH+NHwSG2T6kTYWnM22FSHnv4eyDPNYO80p7ai7twYpHH/CyuDfJBA==",
       "requires": {
         "@babel/core": "^7.4.3",
         "@patternfly/react-core": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-core": "2.10.6",
     "@patternfly/react-icons": "3.7.1",
     "@patternfly/react-table": "1.4.6",
-    "@red-hat-insights/insights-frontend-components": "3.41.45",
+    "@red-hat-insights/insights-frontend-components": "3.41.50",
     "actioncable": "^5.2.1",
     "apollo-boost": "^0.1.22",
     "classnames": "^2.2.5",


### PR DESCRIPTION
This should be completed with a similar PR in insights-frontend-components. This button is only used in the SystemsTable, but the `insights-frontend-components` one is used in the rules table.