### PR TITLE
Remove translate prop to reduce warnings

### DIFF
--- a/src/SmartComponents/DownloadTableButton/DownloadTableButton.js
+++ b/src/SmartComponents/DownloadTableButton/DownloadTableButton.js
@@ -52,7 +52,7 @@ class DownloadTableButton extends React.Component {
                 <Tooltip
                     enableFlip={ true }
                     content={
-                        <div translate>
+                        <div>
                             More actions
                         </div>
                     }


### PR DESCRIPTION
I added this as a premature start to i18n, but it generates a warning in the JS console:

```
Warning: Received `true` for a non-boolean attribute `translate`.
```