### PR TITLE
Remove invalid DOM nesting inside a <p>

### DIFF
--- a/src/SmartComponents/CompliancePoliciesCards/CompliancePoliciesCards.js
+++ b/src/SmartComponents/CompliancePoliciesCards/CompliancePoliciesCards.js
@@ -9,9 +9,9 @@ import {
     Button,
     Bullseye,
     EmptyState,
-    EmptyStateIcon,
-    EmptyStateBody
+    EmptyStateIcon
 } from '@patternfly/react-core';
+import emptyStateStyles from '@patternfly/patternfly/components/EmptyState/empty-state.css';
 import { ClipboardCheckIcon } from '@patternfly/react-icons';
 import { routerParams } from '@red-hat-insights/insights-frontend-components';
 import CompliancePolicyCard from '../CompliancePolicyCard/CompliancePolicyCard';
@@ -57,7 +57,7 @@ const CompliancePoliciesCards = () => (
                         <EmptyStateIcon size="xl" title="Compliance" icon={ClipboardCheckIcon} />
                         <br/>
                         <Title size="lg">Welcome to Compliance</Title>
-                        <EmptyStateBody>
+                        <span className={emptyStateStyles.emptyStateBody}>
                             <TextContent>
                                 You have not uploaded any reports yet. Please generate a report using
                                 OpenSCAP:
@@ -71,7 +71,7 @@ const CompliancePoliciesCards = () => (
                                     --content-type application/vnd.redhat.compliance.something+tgz
                                 </Text>
                             </TextContent>
-                        </EmptyStateBody>
+                        </span>
 
                         <Button
                             variant="primary"


### PR DESCRIPTION
If we want to use `TextVariant.blockquote` or `<div>`, we cannot put it inside an `<EmptyStateBody>`, as it generates the following warning because [it's essentially a `<p>` tag](https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateBody.js#L7):

```
Warning: validateDOMNesting(...): <blockquote> cannot appear as a descendant of <p>.
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
```

This does not change how the empty state page looks. It merely replaces the `<p>` with a `<span>`