### PR TITLE
Update imagestreams empty state with valid DOM

### DIFF
--- a/src/SmartComponents/ImageStreamsWizard/ImageStreamEmptyState.js
+++ b/src/SmartComponents/ImageStreamsWizard/ImageStreamEmptyState.js
@@ -5,11 +5,11 @@ import {
     Bullseye,
     EmptyState,
     EmptyStateIcon,
-    EmptyStateBody,
     Button
 } from '@patternfly/react-core';
 import { ClipboardCheckIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
+import emptyStateStyles from '@patternfly/patternfly/components/EmptyState/empty-state.css';
 
 const ImageStreamEmptyState = ({ openWizard }) => (
     <Bullseye>
@@ -17,13 +17,13 @@ const ImageStreamEmptyState = ({ openWizard }) => (
             <EmptyStateIcon size="xl" title="Compliance" icon={ClipboardCheckIcon} />
             <br/>
             <Title size="lg">No Image Streams</Title>
-            <EmptyStateBody>
+            <span className={emptyStateStyles.emptyStateBody}>
                 <TextContent>
                     You have not added any Image Streams to scan yet.<br/>
 
                     Add an Image Stream to scan and view compliance reports.
                 </TextContent>
-            </EmptyStateBody>
+            </span>
             <Button variant='primary' onClick={openWizard}> Scan an Image Stream </Button>
         </EmptyState>
     </Bullseye>


### PR DESCRIPTION
Same as https://github.com/RedHatInsights/compliance-frontend/pull/115

If we want to use `<div>`, we cannot put it inside an `<EmptyStateBody>`, as it generates the following warning because [it's essentially a `<p>` tag](https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateBody.js#L7):

```
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
```

This does not change how the empty state page looks. It merely replaces the `<p>` with a `<span>`