### PR TITLE
Add Compliant to facts in redux store

### DIFF
--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -4,11 +4,17 @@ import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons'
 import { Link } from 'react-router-dom';
 import { FormattedRelative } from 'react-intl';
 
+const compliantIcon = (system) => (
+    <React.Fragment>
+        { system.compliant ?
+            <CheckCircleIcon style={{ color: 'var(--pf-global--success-color--100)' }}/> :
+            <ExclamationCircleIcon style={{ color: 'var(--pf-global--danger-color--100)' }}/> }
+    </React.Fragment>
+);
+
 const complianceScore = (system) => (
     <React.Fragment>
-        {system.compliant ?
-            <CheckCircleIcon style={{ color: 'var(--pf-global--success-color--100)' }}/> :
-            <ExclamationCircleIcon style={{ color: 'var(--pf-global--danger-color--100)' }}/>}
+        {compliantIcon(system)}
         { ' ' + (100 * (system.rules_passed / (system.rules_passed + system.rules_failed))).toFixed(2) + '%'}
     </React.Fragment>
 );
@@ -64,6 +70,7 @@ export const systemsToInventoryEntities = (systems, entities) =>
                             }
                         }}>{system.rules_failed}</Link>,
                         compliance_score: complianceScore(system),
+                        compliant: compliantIcon(system),
                         last_scanned: <FormattedRelative value={Date.parse(system.last_scanned)} />
                     }
                 }


### PR DESCRIPTION
![Screenshot from 2019-04-05 19-20-12](https://user-images.githubusercontent.com/598891/55645128-03370280-57d8-11e9-8e2c-f2138d033107.png)

On the systems page, the "Compliant" icon was not showing anymore as the component tries to pull it from Facts, but the Facts only contain ComplianceScore since  https://github.com/RedHatInsights/compliance-frontend/commit/a4b16a5df2c673167229ecc5003af5d3a89e3ed2