### PR TITLE
InventoryTable state needs items, not rows

### DIFF
--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -82,7 +82,7 @@ export const systemsToInventoryEntities = (systems, entities) =>
 export const entitiesReducer = (INVENTORY_ACTION, systems, columns) => applyReducerHash(
     {
         [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => {
-            state.rows = systemsToInventoryEntities(systems, state.rows);
+            state.items = systemsToInventoryEntities(systems, state.rows);
             state.count = state.rows.length;
             state.total = state.rows.length;
             state.columns = [];


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/RHICOMPL-137

This took _way_ too long to figure out.