### PR TITLE
Adapt pagination to newest FEC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,7 +1010,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.0.0",
         "@babel/template": "^7.1.0",
@@ -1021,7 +1020,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -2175,8 +2173,7 @@
     "@babel/parser": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
-      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
-      "dev": true
+      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.1.0",
@@ -3544,7 +3541,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
       "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.1.2",
@@ -3555,7 +3551,6 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
           "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
           }
@@ -3564,7 +3559,6 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
           "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "dev": true,
           "requires": {
             "chalk": "^2.0.0",
             "esutils": "^2.0.2",
@@ -3575,7 +3569,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -3584,7 +3577,6 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -3594,14 +3586,12 @@
         "js-tokens": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -3909,14 +3899,15 @@
       "integrity": "sha512-ni5abWOau8NwsN6oZNj+NX0QzqE1XX0WtOjBuhZSV4wtKCNwLNRlLHNLXdpVeT4nffhcMdKVV/yFxkgipUC7AA=="
     },
     "@red-hat-insights/insights-frontend-components": {
-      "version": "3.41.28",
-      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.28.tgz",
-      "integrity": "sha512-mVto8QWIkjiSVeFk4bBLWwmkTQn2/JCXA+CR1lbUtN1MoWs0w4JS/ltIoB0M2hQLC6F8LtXdh1TmaPwilnU0lA==",
+      "version": "3.41.45",
+      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.45.tgz",
+      "integrity": "sha512-PgcMEwmK4g12nB+hTdtKS8/wQuPxwIBv6PZxGOmeYguZ2nrXSId/we/1DZeKNrW5ba5szZMUn6oLsWnoXaNDsg==",
       "requires": {
-        "@patternfly/react-core": "^2.1.4",
-        "@patternfly/react-icons": "^3.7.1",
-        "@patternfly/react-table": "^1.4.11",
-        "@redhat-cloud-services/host-inventory-client": "^1.0.1",
+        "@babel/core": "^7.4.3",
+        "@patternfly/react-core": "^3.2.6",
+        "@patternfly/react-icons": "^3.7.4",
+        "@patternfly/react-table": "^2.1.6",
+        "@redhat-cloud-services/host-inventory-client": "^1.0.12",
         "abortcontroller-polyfill": "^1.2.1",
         "apollo-boost": "^0.1.23",
         "axios": "^0.18.0",
@@ -3924,7 +3915,6 @@
         "c3": "^0.6.7",
         "classnames": "^2.2.5",
         "d3": "^5.7.0",
-        "font-awesome-sass": "^4.7.0",
         "graphql": "^14.0.2",
         "graphql-tag": "^2.10.0",
         "marked": "^0.6.0",
@@ -3941,43 +3931,183 @@
         "urijs": "^1.19.1"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/core": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
+          "integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.4",
+            "@babel/helpers": "^7.4.4",
+            "@babel/parser": "^7.4.4",
+            "@babel/template": "^7.4.4",
+            "@babel/traverse": "^7.4.4",
+            "@babel/types": "^7.4.4",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.11",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+          "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+          "requires": {
+            "@babel/types": "^7.4.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+          "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+          "requires": {
+            "@babel/template": "^7.4.4",
+            "@babel/traverse": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+          "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w=="
+        },
+        "@babel/template": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+          "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+          "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "@patternfly/patternfly": {
-          "version": "1.0.244",
-          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-1.0.244.tgz",
-          "integrity": "sha512-wf6Zslj6k1b9PG94jG1lgnfz1elv0I0IifgBhXIPfnHtc697+V45PJb+Zzk+0WjuJI5oVmGO742OhIX7Mcg+tQ=="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-2.3.0.tgz",
+          "integrity": "sha512-B6JQcC9KJSeZCeKj97bQEMYhGEsSbjVSdVMg9FK6LFESD2rQWGjH73SDmmRPe5uBZ1E+S8gFsTJeyFge7Z5KPg=="
+        },
+        "@patternfly/react-core": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-3.2.6.tgz",
+          "integrity": "sha512-58GBM8SfhoggQldGArUR3LwvcMe+GaW/uTjB1/a3RTG6HXTfFfs33UXnQnN2IgWZmHOyxpjnWq2yEh5xwJs5HQ==",
+          "requires": {
+            "@patternfly/react-icons": "^3.7.4",
+            "@patternfly/react-styles": "^3.0.2",
+            "@patternfly/react-tokens": "^2.3.3",
+            "@tippy.js/react": "^1.1.1",
+            "emotion": "^9.2.9",
+            "exenv": "^1.2.2",
+            "focus-trap-react": "^4.0.1"
+          }
+        },
+        "@patternfly/react-icons": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-3.8.1.tgz",
+          "integrity": "sha512-0LCuW4qdDQdiRcnmDBhTdnJZIk1ZlP0mn9VcnnUQ5qkLlJPFtiipcgr+RoQl56ht3xt6pXDKy6Gvv7Wwz/BVkw=="
+        },
+        "@patternfly/react-styles": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-3.0.2.tgz",
+          "integrity": "sha512-JiGxDkC4JArQJ13RQOjSUE4jPmwrAq8f5E+qg0tVws1A9BQ2l3uGCRFMVbfa57qqjqk0jXNmIVdFSeCG18qwJQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0-beta.48",
+            "camel-case": "^3.0.0",
+            "css": "^2.2.3",
+            "cssom": "^0.3.4",
+            "cssstyle": "^0.3.1",
+            "emotion": "^9.2.9",
+            "emotion-server": "^9.2.9",
+            "fbjs-scripts": "^0.8.3",
+            "fs-extra": "^6.0.1",
+            "jsdom": "^11.11.0",
+            "relative": "^3.0.2",
+            "resolve-from": "^4.0.0"
+          }
         },
         "@patternfly/react-table": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-1.5.0.tgz",
-          "integrity": "sha512-TklyXP3ynFblor6ZK5DSCxoTMKgjgKayZHqI72V86B5MYyYaPJn+txzreWqPZkoTpghUVjSWcVM2FiTOelRllw==",
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-2.1.6.tgz",
+          "integrity": "sha512-NF8p4slEpfLbFVVk0w3NEskJj+QPEU8WnGB8xW6Vl15c/WrlLGILArdaGtbCyv7hSEplG9AHUabU+DZ8htDnDA==",
           "requires": {
-            "@patternfly/patternfly": "1.0.244",
-            "@patternfly/react-core": "^2.11.0",
-            "@patternfly/react-icons": "^3.8.0",
-            "@patternfly/react-styles": "^2.5.0",
+            "@patternfly/patternfly": "2.3.0",
+            "@patternfly/react-core": "^3.2.6",
+            "@patternfly/react-icons": "^3.7.4",
+            "@patternfly/react-styles": "^3.0.2",
             "exenv": "^1.2.2",
             "reactabular-table": "^8.14.0"
-          },
-          "dependencies": {
-            "@patternfly/react-core": {
-              "version": "2.11.1",
-              "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-2.11.1.tgz",
-              "integrity": "sha512-nJSwQwbavwnKlt8WEqJFE+VUjoUaUTYV4LBRh+EJT1NDi4fvR43F1jD5K4N70iSzpmwfLD16azUj8Y8KdqKdBw==",
-              "requires": {
-                "@patternfly/react-icons": "^3.7.1",
-                "@patternfly/react-styles": "^2.4.0",
-                "@patternfly/react-tokens": "^2.3.0",
-                "@tippy.js/react": "^1.1.1",
-                "emotion": "^9.2.9",
-                "exenv": "^1.2.2",
-                "focus-trap-react": "^4.0.1"
-              }
-            },
-            "@patternfly/react-icons": {
-              "version": "3.8.0",
-              "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-3.8.0.tgz",
-              "integrity": "sha512-qj9JyJUR4YZ5wYNdD5EiaZtn7rOBP658jp44wWIPLb7ufKQpt1pTf638NoIzD5nJKYa4yE5ZUtEwoTIF820ayw=="
-            }
+          }
+        },
+        "@patternfly/react-tokens": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-2.3.3.tgz",
+          "integrity": "sha512-+2SSGvOV1rZr1l6+p2QzORVJhpOKjrHqCBfkp10La7O93+mVLYU0vugTp1elhxeh32IuLCJAPDLrCJPBAfmYKw=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
           }
         },
         "apollo-boost": {
@@ -4043,6 +4173,34 @@
             "tslib": "^1.9.3"
           }
         },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cssom": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+          "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        },
         "hoist-non-react-statics": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
@@ -4050,6 +4208,39 @@
           "requires": {
             "react-is": "^16.7.0"
           }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "optimism": {
           "version": "0.6.9",
@@ -4071,15 +4262,15 @@
           }
         },
         "react-apollo": {
-          "version": "2.5.4",
-          "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.5.4.tgz",
-          "integrity": "sha512-olH9zYijOXVfj14hD7bQlZ0POBJchxg2e+mfnxEiEdqZra4+58SfIY0KPhmM9jqbeeusc6J/P4zzWIHt5DdNDg==",
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.5.5.tgz",
+          "integrity": "sha512-zoJYlkI3i7+f1ejCbFtWU2GLCxjrmB3Es6RANyEZcbl0yetf5TI6ofMjBzILTvwoqp6tiQHH/8q66vQF0KcLmQ==",
           "requires": {
             "apollo-utilities": "^1.2.1",
             "hoist-non-react-statics": "^3.3.0",
             "lodash.isequal": "^4.5.0",
             "prop-types": "^15.7.2",
-            "ts-invariant": "^0.3.2",
+            "ts-invariant": "^0.4.0",
             "tslib": "^1.9.3"
           },
           "dependencies": {
@@ -4102,9 +4293,9 @@
               }
             },
             "ts-invariant": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
-              "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.1.tgz",
+              "integrity": "sha512-fdL8AZinDiVKMsOI0cOWHLprS85LWy2p/eVSctVe6fpZF9BAvO59sQYMEWQ37yybBtlKU2zkmILYmy1jrOf6+g==",
               "requires": {
                 "tslib": "^1.9.3"
               }
@@ -4126,13 +4317,31 @@
           "version": "16.8.6",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
           "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         }
       }
     },
     "@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.11.tgz",
-      "integrity": "sha512-dwKmB/hP52xqR8y303+uXOQxYpPgxh1bJxGHFqzQNsocVIkCrQhwotHiWmkchOKpUkkVD6gIuA9Q5DocvshAnw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.12.tgz",
+      "integrity": "sha512-+JBqLXT++xA4UCOZET/+GpB5B0wWR0pMj/RZ+V8qPUmYUAhKB8MGibGvPchA0RyAqTVxlPPj7KOiMKRebuLugg==",
       "requires": {
         "axios": "^0.18.0"
       }
@@ -7977,7 +8186,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.1"
       }
@@ -7985,8 +8193,7 @@
     "color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
-      "dev": true
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "color-string": {
       "version": "0.3.0",
@@ -10652,7 +10859,8 @@
     "font-awesome-sass": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome-sass/-/font-awesome-sass-4.7.0.tgz",
-      "integrity": "sha1-TtppPpFQCc4Asijglk3F7Km8NOE="
+      "integrity": "sha1-TtppPpFQCc4Asijglk3F7Km8NOE=",
+      "optional": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -11810,8 +12018,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -16815,8 +17022,7 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -19372,7 +19578,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-core": "2.10.6",
     "@patternfly/react-icons": "3.7.1",
     "@patternfly/react-table": "1.4.6",
-    "@red-hat-insights/insights-frontend-components": "3.41.28",
+    "@red-hat-insights/insights-frontend-components": "3.41.45",
     "actioncable": "^5.2.1",
     "apollo-boost": "^0.1.22",
     "classnames": "^2.2.5",

--- a/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
+++ b/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
@@ -7,7 +7,7 @@ import ErrorPage from '../ErrorPage/ErrorPage';
 
 const QUERY = gql`
 {
-    allSystems {
+    allSystems(per_page: 50, page: 1) {
         id
         name
         profile_names


### PR DESCRIPTION
This seems to allow pagination to work well using the new FEC version, it fetches 50 items by default as expected by that table. Updating patternfly and react-patternfly to the FEC breaks some things like breadcrumbs and tabs, so we're holding off those for now.  