### PR TITLE
Fix all systems pagination to show all systems instead of limited amount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11003,12 +11003,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11023,17 +11025,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11150,7 +11155,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11162,6 +11168,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11176,6 +11183,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11183,12 +11191,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11207,6 +11217,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11287,7 +11298,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11299,6 +11311,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11420,6 +11433,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
+++ b/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
@@ -13,6 +13,9 @@ const QUERY = gql`
         profile_names
         compliant
     }
+    allProfiles {
+        total_host_count
+    }
 }
 `;
 
@@ -24,6 +27,7 @@ const ComplianceSystemsTable = () => (
             if (loading) { return <EmptyTable><Spinner/></EmptyTable>; }
 
             const systems = data.allSystems;
+            const systemsCount = data.allProfiles.reduce((acc, curr) => acc + curr.total_host_count, 0);
             const columns = [{
                 composed: ['facts.os_release', 'display_name'],
                 key: 'display_name',
@@ -45,7 +49,7 @@ const ComplianceSystemsTable = () => (
                 }
             }];
 
-            return <SystemsTable items={systems} columns={columns} />;
+            return <SystemsTable items={systems} columns={columns} systemsCount={systemsCount}/>;
         }}
     </Query>
 );

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -118,6 +118,7 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
             }
 
             const systems = data.profile.hosts;
+            const systemsCount = data.profile.total_host_count;
             const columns = [{
                 composed: ['facts.os_release', 'display_name'],
                 key: 'display_name',
@@ -238,7 +239,7 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                     <Main>
                         <Grid gutter='md'>
                             <GridItem span={12}>
-                                <SystemsTable items={systems} columns={columns} />
+                                <SystemsTable items={systems} columns={columns} systemsCount={systemsCount} />
                             </GridItem>
                         </Grid>
                     </Main>

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -14,7 +14,12 @@ import gql from 'graphql-tag';
 
 const GET_SYSTEMS = gql`
 query getSystems($filter: String!, $perPage: Int, $page: Int) {
-    allSystems(search: $filter, per_page: $perPage, page: $page) { id }
+    allSystems(search: $filter, per_page: $perPage, page: $page) {
+        id
+        name
+        profile_names
+        compliant
+    }
 }
 `;
 
@@ -24,12 +29,12 @@ class SystemsTable extends React.Component {
         super(props);
         this.state = {
             InventoryCmp: () => <EmptyTable><Spinner/></EmptyTable>,
-            items: this.props.items.slice(0, 50),
+            items: this.props.items,
             filterEnabled: false,
             filter: '',
             page: 1,
             perPage: 50,
-            totalItems: this.props.items.length
+            totalItems: this.props.systemsCount
         };
 
         this.fetchInventory = this.fetchInventory.bind(this);
@@ -59,7 +64,6 @@ class SystemsTable extends React.Component {
     }
 
     async fetchInventory() {
-        const { items } = this.state;
         const { columns } = this.props ;
 
         const {
@@ -77,7 +81,7 @@ class SystemsTable extends React.Component {
         this.getRegistry().register({
             ...mergeWithEntities(
                 entitiesReducer(
-                    INVENTORY_ACTION_TYPES, items, columns
+                    INVENTORY_ACTION_TYPES, () => this.state.items, columns
                 ))
         });
 
@@ -116,7 +120,8 @@ class SystemsTable extends React.Component {
 SystemsTable.propTypes = {
     client: propTypes.object,
     items: propTypes.array,
-    columns: propTypes.array
+    columns: propTypes.array,
+    systemsCount: propTypes.number
 };
 
 export default withApollo(SystemsTable);

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -92,7 +92,7 @@ export const systemsToInventoryEntities = (systems, entities) =>
 export const entitiesReducer = (INVENTORY_ACTION, systems, columns) => applyReducerHash(
     {
         [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => {
-            state.rows = systemsToInventoryEntities(systems, state.rows);
+            state.rows = systemsToInventoryEntities(systems(), state.rows);
             state.count = state.rows.length;
             state.total = state.rows.length;
             state.columns = [];


### PR DESCRIPTION
### Description
When fetching all systems we have to get amount of systems in DB by getting host count in all profiles. Laer we have to fetch current page from graphql and once that is done call host fetch to get inventory info. Once inventory fetches these data we have to map our specific information to it as well.

### Changes
* Call graphql with `allProfiles` query and take `total_host_count`. Once that is fullfilled pass number of systems to Systems table as total
* Fetch `name`, `profile_names` and `compliant` values for each page in systems
* Pass callback to systems to reducer so we can access previously fetched systems (from compliance DB)