### PR TITLE
Update FEC to show rules in FF <= 60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3766,6 +3766,19 @@
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz",
+      "integrity": "sha512-834DrzO2Ne3upCW+mJJPC/E6BsFcj+2Z1HmPIhbpbj8UaKmXWum4NClqLpUiMetugRlHuG4jbIHNdv2/lc3c1Q=="
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.8.2.tgz",
+      "integrity": "sha512-nhEWctDOP6f+Ka10LXAFoF+6mtWidC2iQgTBGRGgydmhBtcIEwyxWVx5wQHa86A1zAMi5TnipDAYQs2qn7DD6A==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.18"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -3899,9 +3912,9 @@
       "integrity": "sha512-ni5abWOau8NwsN6oZNj+NX0QzqE1XX0WtOjBuhZSV4wtKCNwLNRlLHNLXdpVeT4nffhcMdKVV/yFxkgipUC7AA=="
     },
     "@red-hat-insights/insights-frontend-components": {
-      "version": "3.41.50",
-      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.50.tgz",
-      "integrity": "sha512-jyYBtARzMV5vFsay2tEvTvxFXP8bdn3BCH+NHwSG2T6kTYWnM22FSHnv4eyDPNYO80p7ai7twYpHH/CyuDfJBA==",
+      "version": "3.41.57",
+      "resolved": "https://registry.npmjs.org/@red-hat-insights/insights-frontend-components/-/insights-frontend-components-3.41.57.tgz",
+      "integrity": "sha512-ierjf0DGoJibKN/CiNRE4iS3lHREj8vG+gV+W4+8cPFH4ewNByVT2wLD/MfHqWAMmtYCOUA71xmdKdpRM6Oh+g==",
       "requires": {
         "@babel/core": "^7.4.3",
         "@patternfly/react-core": "^3.2.6",
@@ -4042,18 +4055,18 @@
           }
         },
         "@patternfly/patternfly": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-2.3.0.tgz",
-          "integrity": "sha512-B6JQcC9KJSeZCeKj97bQEMYhGEsSbjVSdVMg9FK6LFESD2rQWGjH73SDmmRPe5uBZ1E+S8gFsTJeyFge7Z5KPg=="
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-2.6.5.tgz",
+          "integrity": "sha512-L0k+ea2N679ytQwTqYJ7RewVDx6FDpm9burtHgD8fhcIN0UJJo7v2IkhLya2WzH2/O7L7TiF45lb/ZVoFVckDA=="
         },
         "@patternfly/react-core": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-3.2.6.tgz",
-          "integrity": "sha512-58GBM8SfhoggQldGArUR3LwvcMe+GaW/uTjB1/a3RTG6HXTfFfs33UXnQnN2IgWZmHOyxpjnWq2yEh5xwJs5HQ==",
+          "version": "3.16.10",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-3.16.10.tgz",
+          "integrity": "sha512-ASoNNuC+S2UjUeT2aR7LsAuDJpvXzMHYCjRc9WmXD9S52nvqA5p4SS9cXV60RCTvRpUbXJ7/55gnxi4Dt9u6/A==",
           "requires": {
-            "@patternfly/react-icons": "^3.7.4",
-            "@patternfly/react-styles": "^3.0.2",
-            "@patternfly/react-tokens": "^2.3.3",
+            "@patternfly/react-icons": "^3.8.1",
+            "@patternfly/react-styles": "^3.2.0",
+            "@patternfly/react-tokens": "^2.5.1",
             "@tippy.js/react": "^1.1.1",
             "emotion": "^9.2.9",
             "exenv": "^1.2.2",
@@ -4061,14 +4074,17 @@
           }
         },
         "@patternfly/react-icons": {
-          "version": "3.8.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-3.8.1.tgz",
-          "integrity": "sha512-0LCuW4qdDQdiRcnmDBhTdnJZIk1ZlP0mn9VcnnUQ5qkLlJPFtiipcgr+RoQl56ht3xt6pXDKy6Gvv7Wwz/BVkw=="
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-3.9.2.tgz",
+          "integrity": "sha512-EwPB+Nodd7zwiFh7R3Qq6Dif+xUR3WOwaJ+SRbP5NsxEAJf3CyYyrd7rbN8yFrFLTMKzknT2ez9XrP/5Lgr5LQ==",
+          "requires": {
+            "@fortawesome/free-brands-svg-icons": "^5.8.1"
+          }
         },
         "@patternfly/react-styles": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-3.0.2.tgz",
-          "integrity": "sha512-JiGxDkC4JArQJ13RQOjSUE4jPmwrAq8f5E+qg0tVws1A9BQ2l3uGCRFMVbfa57qqjqk0jXNmIVdFSeCG18qwJQ==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-3.2.0.tgz",
+          "integrity": "sha512-8M7bo4kPvypHlbzuynV53xjk5176EktfEgZ283sfHmvUlU3Yvq2+m8hS9ERHE9gd91Ip4HiyucAVVACd2gtHNQ==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0-beta.48",
             "camel-case": "^3.0.0",
@@ -4085,22 +4101,22 @@
           }
         },
         "@patternfly/react-table": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-2.1.6.tgz",
-          "integrity": "sha512-NF8p4slEpfLbFVVk0w3NEskJj+QPEU8WnGB8xW6Vl15c/WrlLGILArdaGtbCyv7hSEplG9AHUabU+DZ8htDnDA==",
+          "version": "2.5.11",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-2.5.11.tgz",
+          "integrity": "sha512-5iaF4RE52vXvko0mgdjS60gCfqR06bZ8E7ALdnsf32mzDuLHjZ2/PqX9uy6Kvz3BaVUQIC1mT1Jow2R2p/VFew==",
           "requires": {
-            "@patternfly/patternfly": "2.3.0",
-            "@patternfly/react-core": "^3.2.6",
-            "@patternfly/react-icons": "^3.7.4",
-            "@patternfly/react-styles": "^3.0.2",
+            "@patternfly/patternfly": "2.6.5",
+            "@patternfly/react-core": "^3.16.10",
+            "@patternfly/react-icons": "^3.8.1",
+            "@patternfly/react-styles": "^3.2.0",
             "exenv": "^1.2.2",
             "reactabular-table": "^8.14.0"
           }
         },
         "@patternfly/react-tokens": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-2.3.3.tgz",
-          "integrity": "sha512-+2SSGvOV1rZr1l6+p2QzORVJhpOKjrHqCBfkp10La7O93+mVLYU0vugTp1elhxeh32IuLCJAPDLrCJPBAfmYKw=="
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-2.5.1.tgz",
+          "integrity": "sha512-ZykUfWT4yCELXhGGwQxcNqnXwe3sqfSuoL6IlQRV6wtUKk+/et7NkVvrRwvci926+Usemr4IQVc8V9gbHqRN/A=="
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -4339,9 +4355,9 @@
       }
     },
     "@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.12.tgz",
-      "integrity": "sha512-+JBqLXT++xA4UCOZET/+GpB5B0wWR0pMj/RZ+V8qPUmYUAhKB8MGibGvPchA0RyAqTVxlPPj7KOiMKRebuLugg==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.13.tgz",
+      "integrity": "sha512-Al1lTouQYF5Jel2hXuyi6RswzoMfny/B2vAozKrVsOVs30fxrkEJHoG2NsDsh2c8MHOhpDaWpj3R8TLux2FO5A==",
       "requires": {
         "axios": "^0.18.0"
       }
@@ -11003,14 +11019,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11025,20 +11039,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11155,8 +11166,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11168,7 +11178,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11183,7 +11192,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11191,14 +11199,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11217,7 +11223,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11298,8 +11303,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11311,7 +11315,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11433,7 +11436,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-core": "2.10.6",
     "@patternfly/react-icons": "3.7.1",
     "@patternfly/react-table": "1.4.6",
-    "@red-hat-insights/insights-frontend-components": "3.41.50",
+    "@red-hat-insights/insights-frontend-components": "3.41.57",
     "actioncable": "^5.2.1",
     "apollo-boost": "^0.1.22",
     "classnames": "^2.2.5",


### PR DESCRIPTION
If you go to the System Details view, the rules won't load as they are coming from FEC and versions of FEC before this one don't have the fix to work with the API on FF<= 60