### PR TITLE
Request for all host remediations at once

### DIFF
--- a/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
+++ b/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
@@ -34,12 +34,10 @@ class ComplianceRemediationButton extends React.Component {
     }
 
     /* eslint-disable camelcase */
-    formatRule = ({ title, ref_id }, profile, system) => ({
+    formatRule = ({ title, ref_id }, profile, systems) => ({
         id: `ssg:rhel7|${profile}|${ref_id}`,
         description: title,
-        systems: [
-            system
-        ]
+        systems
     })
 
     findRule = (rules, ref_id) => {
@@ -59,7 +57,7 @@ class ComplianceRemediationButton extends React.Component {
         return ref_id.split('xccdf_org.ssgproject.content_profile_')[1];
     }
 
-    rulesWithRemediations = (rules, system_id) => {
+    fetchRules = (rules) => {
         return window.insights.chrome.auth.getUser()
         .then(() => {
             return fetch('/api/remediations/v1/resolutions', {
@@ -77,23 +75,38 @@ class ComplianceRemediationButton extends React.Component {
                 }
 
                 return response.json();
-            }).then(response => Object.keys(response).filter(rule => response[rule]).map(
-                rule_ref_id => this.formatRule(this.findRule(rules, rule_ref_id), rule_ref_id.split('|')[1], system_id)
-            ));
+            });
         });
+    }
+
+    rulesWithRemediations = (rules, rulesPerSystem) => {
+        return this.fetchRules(rules).then(response => Object.keys(response).filter(rule => response[rule]).reduce(
+            (acc, rule_ref_id) => {
+                const rule = this.findRule(rules, rule_ref_id);
+                acc.push(this.formatRule(rule, rule_ref_id.split('|')[1], rulesPerSystem[rule.ref_id]));
+                return acc;
+            }, []
+        ));
     }
 
     dataProvider = () => {
         const { allSystems, selectedRules } = this.props;
         const result = { systems: [], issues: [] };
-        allSystems.forEach(async (system) => {
-            result.systems.push(system.id);
-            if (selectedRules) {
-                result.issues.push(selectedRules.map(rule => this.formatRule(rule, system.id)));
-            } else {
-                result.issues.push(this.rulesWithRemediations(system.rule_objects_failed, system.id));
-            }
-        });
+
+        allSystems.forEach(system => { result.systems.push(system.id); });
+
+        if (selectedRules) {
+            result.issues.push(selectedRules.map(rule => this.formatRule(rule, [allSystems[0].id])));
+        } else {
+            const rules = flatten(allSystems.map(system => system.rule_objects_failed));
+            const rulesPerSystem = rules.reduce((acc, rule) => {
+                acc[rule.ref_id] = allSystems.filter(
+                    system => system.rule_objects_failed.map(rule => rule.ref_id).includes(rule.ref_id)
+                ).map(system => system.id);
+                return acc;
+            }, {});
+            result.issues.push(this.rulesWithRemediations(rules, rulesPerSystem));
+        }
 
         return Promise.all(result.issues).then(issues => {
             result.issues = this.uniqIssuesBySystem(flatten(issues));


### PR DESCRIPTION
Before this change, to display the remediations modal we had
to fetch all remediations available per system. Now we request
all remediations using only one request.