### PR TITLE
RHICOMPL-189 - Do not clear filter after clicking outside

### DIFF
--- a/src/SmartComponents/SystemsComplianceFilter/SystemsComplianceFilter.js
+++ b/src/SmartComponents/SystemsComplianceFilter/SystemsComplianceFilter.js
@@ -66,6 +66,7 @@ class SystemsComplianceFilter extends React.Component {
     render() {
         return (
             <FilterDropdown
+                filters={ this.state }
                 addFilter={ this.addFilter }
                 removeFilter={ this.removeFilter }
                 filterCategories={ FILTER_CATEGORIES }


### PR DESCRIPTION
![Peek 2019-05-29 16-49](https://user-images.githubusercontent.com/598891/58567216-3d4ddf00-8232-11e9-9c7a-99bf89b97176.gif)

Without the filter prop, the behavior in the gif is the current one: the filters are cleared after clicking outside of the filter and hiding the dropdown. This PR fixes that so filters persist after a click.