### PR TITLE
Add docker compose setup for development

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,16 @@
+# Comment out to enable
+# DEFAULT_HOST=ci.foo.redhat.com
+
+# LOCAL_API='true'
+# API_PORT=''
+# API_HOST=''
+
+# LOCAL_INGRESS='true'
+# INGRESS_HOST=''
+# INGRESS_PORT='8080'
+
+# LOCAL_INVENTORY='true'
+# INVENTORY_HOST=''
+# INVENTORY_PORT='8888'
+
+

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+LOCAL_CHROME_PATH=`echo $PWD`/../insights-chrome/build

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-LOCAL_CHROME_PATH=`echo $PWD`/../insights-chrome/build

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Comment out to enable
-# DEFAULT_HOST=ci.foo.redhat.com
+DEFAULT_HOST=ci.foo.redhat.com
+HOT_RELOAD='false'
 
-# LOCAL_API='true'
+LOCAL_API='true'
 # API_PORT=''
 # API_HOST=''
 

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 src/__fixtures__/*
+config/spandx.*
+config/dev.webpack*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
+.env
+
 # vscode config
 .vscode/
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ yarn.lock
 
 .DS_Store
 coverage
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn.lock
 
 .DS_Store
 coverage
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM fedora:29
 RUN dnf install -y npm git
 
-COPY . /frontend
+RUN mkdir /frontend
 WORKDIR /frontend
 
 COPY package*.json /frontend/
 RUN npm install
 
-CMD ["/usr/bin/npm", "run", "start"]
+COPY ./entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["npm", "run", "start"]
 
 EXPOSE 8002

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM fedora:29
+RUN dnf install -y npm git
+
+COPY . /frontend
+WORKDIR /frontend
+
+RUN rm -rf node_modules/*
+
+RUN npm install
+
+CMD ["/usr/bin/npm", "run", "start"]
+
+EXPOSE 8002

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ RUN dnf install -y npm git
 COPY . /frontend
 WORKDIR /frontend
 
-RUN rm -rf node_modules/*
-
+COPY package*.json /frontend/
 RUN npm install
 
 CMD ["/usr/bin/npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Both will require to have hostnames like `ci.foo.redhat.com` resolve to the loca
 To run the container setup either Podman or Docker and their compose commands can be used to
 
 ```shell
+  $ touch .env  # Can be used to enable a local backend and other services (see .env.example)
   $ podman-compose up
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,28 +21,60 @@ You should also run [Insights Compliance Backend](https://github.com/RedHatInsig
 Have [insights-proxy](https://github.com/RedHatInsights/insights-proxy) installed under PROXY_PATH
 
 ```shell
-SPANDX_CONFIG="./config/spandx.config.js" bash $PROXY_PATH/scripts/run.sh
+  $ SPANDX_CONFIG="./config/spandx.config.js" bash $PROXY_PATH/scripts/run.sh
 ```
 
+## Build & run the application
 
-## Build app
+There are two ways to start the frontend, either locally or in a container.
+Both will make the compiled JavaScript available on [http://localhost:8002](http://localhost:8002) (or `http://DOCKER_HOST`)
 
-1. ```npm install```
+### Local Environment
 
-2. ```npm run start```
-    - starts webpack bundler and serves the files with webpack dev server
+You can run the webpack-dev-server locally with:
 
-### Testing
+```shell
+  $ npm install   # installs all packages
+  $ npm run start # starts webpack bundler and serves the files with webpack dev server
+```
 
-- Travis is used to test the build for this code.
-  - `npm run test` will run linters and tests
+### Docker Environment
+
+You can also start a containerized environment via:
+
+```shell
+  $ docker-compose up
+```
+
+This will build the image if it is not yet available locally and run the container.
+
+#### Opening a shell
+
+To run tests or lint your code you might want to run a shell container, this can be done via:
+
+```shell
+  $ docker-compose up # Only required if no frontend container is running yet
+  $ docker-compose exec frontend bash # # Opens bash within the container
+```
+
+## Testing
+
+Tests are run using `jest`[1] and are located in a components `_COMPONENT_NAME_.test.js` file.
+They run on Travis and can locally be executed via `npm run test`.
+
+[1] https://jestjs.io/
+
+## Code standards
+
+Travis also lints the code, this can also be done locally with `npm run lint`.
+The rules to follow are found in `eslintrc.yml`.
 
 ## Deploying
 
 - Pushing to 'master' will deploy the app in qa-beta, ci-beta, and prod-beta.
 - Pushing to 'stable' will deploy the app in qa-stable, ci-stable, and prod-stable.
 
-# Patternfly
+## Patternfly
 
 - This project imports Patternfly components:
   - [Patternfly React](https://github.com/patternfly/patternfly-react)

--- a/README.md
+++ b/README.md
@@ -6,79 +6,70 @@ React.js app for Red Hat Insights Compliance.
 
 ## Getting Started
 
-There is a [comprehensive quick start guide in the Storybook Documentation](https://github.com/RedHatInsights/insights-frontend-storybook/blob/master/src/docs/welcome/quickStart/DOC.md) to setting up an Insights environment complete with:
+This application requires the use of [Insights Proxy](https://github.com/RedHatInsights/insights-proxy), which is configured with default routes that proxy a staging environment for services that are not available locally.
+The frontend itself will run via the `webpack-dev-server`. Both can be run either manually and separately or in a container setup.
 
-- Insights Frontend Starter App
+Both will require to have hostnames like `ci.foo.redhat.com` resolve to the local host.
+[Insights Proxy](https://github.com/RedHatInsights/insights-proxy/blob/master/scripts/patch-etc-hosts.sh) provides a script to patch the `/etc/hosts` file for this purpose.
 
-- [Insights Chroming](https://github.com/RedHatInsights/insights-chrome)
-- [Insights Proxy](https://github.com/RedHatInsights/insights-proxy)
+## Running in containers
 
-Note: You will need to set up the Insights environment if you want to develop with the starter app due to the consumption of the chroming service as well as setting up your global/app navigation through the API.
+To run the container setup either Podman or Docker and their compose commands can be used to
 
-You should also run [Insights Compliance Backend](https://github.com/RedHatInsights/compliance-backend) so that the frontend can consume its data from somewhere.
+```shell
+  $ podman-compose up
+```
 
-## Running locally
-Have [insights-proxy](https://github.com/RedHatInsights/insights-proxy) installed under PROXY_PATH
+This will build the image if it is not yet available locally and run the containers to make the frontend available at [https://ci.foo.redhat.com:1337/insights/compliance/](https://ci.foo.redhat.com:1337/insights/compliance/)
+
+### Opening a shell
+
+To run tests or lint your code you might want to run a shell container, this can be done via:
+
+```shell
+  $ podman-compose up # Only required if no frontend container is running yet
+  $ podman-compose run frontend bash # # Opens bash within the container
+```
+
+### Running other dependent services locally
+
+To configure the proxy to use local services the `.env` contains a few `LOCAL_` variables that can be uncommented and adjusted.
+
+## Running on localhost
+
+To run a [insights-proxy](https://github.com/RedHatInsights/insights-proxy) follow the preparation steps, to then be able and run the following **within** this repositories directory.
 
 ```shell
   $ SPANDX_CONFIG="./config/spandx.config.js" bash $PROXY_PATH/scripts/run.sh
 ```
 
-## Build & run the application
+This will start a proxy with proper configuration for this frontend.
 
-There are two ways to start the frontend, either locally or in a container.
-Both will make the compiled JavaScript available on [http://localhost:8002](http://localhost:8002) (or `http://DOCKER_HOST`)
-
-### Local Environment
-
-You can run the webpack-dev-server locally with:
+The frontend itself can be started with `npm run start` once all dependencies are install.
 
 ```shell
   $ npm install   # installs all packages
   $ npm run start # starts webpack bundler and serves the files with webpack dev server
 ```
 
-### Docker Environment
-
-You can also start a containerized environment via:
-
-```shell
-  $ docker-compose up
-```
-
-This will build the image if it is not yet available locally and run the container.
-
-#### Opening a shell
-
-To run tests or lint your code you might want to run a shell container, this can be done via:
-
-```shell
-  $ docker-compose up # Only required if no frontend container is running yet
-  $ docker-compose exec frontend bash # # Opens bash within the container
-```
-
-## Testing
-
-Tests are run using `jest`[1] and are located in a components `_COMPONENT_NAME_.test.js` file.
-They run on Travis and can locally be executed via `npm run test`.
-
-[1] https://jestjs.io/
-
 ## Code standards
 
 Travis also lints the code, this can also be done locally with `npm run lint`.
 The rules to follow are found in `eslintrc.yml`.
 
+## Testing
+
+Tests are run using [jest](https://jestjs.io/) and are located in a components `_COMPONENT_NAME_.test.js` file.
+They run on Travis and can locally be executed via `npm run test`.
+
+## Code Notes
+
+* This project uses [Patternfly](https://github.com/patternfly/patternfly-react) components and should be preferred.
+* The [insights-frontend-components](https://www.npmjs.com/package/@red-hat-insights/insights-frontend-components) package is included to provide components shared across the Insights Platform.
+* Header and sidebar are provided by  [insights-proxy](https://github.com/RedHatInsights/insights-chrome)
+* "Inventory Components" (like the SystemsTable) are loaded **via** the chrome.
+
 ## Deploying
 
 - Pushing to 'master' will deploy the app in qa-beta, ci-beta, and prod-beta.
 - Pushing to 'stable' will deploy the app in qa-stable, ci-stable, and prod-stable.
-
-## Patternfly
-
-- This project imports Patternfly components:
-  - [Patternfly React](https://github.com/patternfly/patternfly-react)
-
-## Insights Components
-
-Insights Platform will deliver components and static assets through [npm](https://www.npmjs.com/package/@red-hat-insights/insights-frontend-components). ESI tags are used to import the [chroming](https://github.com/RedHatInsights/insights-chrome) which takes care of the header, sidebar, and footer.

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -4,20 +4,34 @@ const _ = require('lodash');
 const webpackConfig = require('./base.webpack.config');
 const config = require('./webpack.common.js');
 
+if (process.env.DEFAULT_HOST) {
+    default_host = process.env.DEFAULT_HOST;
+} else {
+    default_host = 'host.docker.internal';
+}
+
+// Hot reloading will not work at the moment within a container because of CORS issues.
+const hotReload = function () {
+    process.env.HOT_RELOAD && process.env.HOT_RELOAD === 'true' ? true : false
+}
+
 webpackConfig.devServer = {
     contentBase: config.paths.public,
     historyApiFallback: true,
     serveIndex: false,
-    hot: process.env.HOT === 'false' ? false : true,
+    liveReload: hotReload(),
+    hot: hotReload(),
+    injectClient: hotReload(),
+    inline: hotReload(),
     allowedHosts: [
-        'frontend',
         'ci.foo.redhat.com',
         'qa.foo.redhat.com',
         'stage.foo.redhat.com',
-        'prod.foo.redhat.com'
+        'prod.foo.redhat.com',
+        default_host
     ],
-    port: process.env.PORT ? process.env.PORT  : '8002',
-    host: process.env.HOST ? process.env.HOST  : 'localhost'
+    port: process.env.FRONTEND_PORT ? process.env.FRONTEND_PORT  : '8002',
+    host: process.env.FRONTEND_HOST ? process.env.FRONTEND_HOST  : '0.0.0.0'
 };
 
 module.exports = _.merge({

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,6 +10,7 @@ webpackConfig.devServer = {
     serveIndex: false,
     hot: process.env.HOT === 'false' ? false : true,
     allowedHosts: [
+        'frontend',
         'ci.foo.redhat.com',
         'qa.foo.redhat.com',
         'stage.foo.redhat.com',

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -12,7 +12,7 @@ if (process.env.DEFAULT_HOST) {
 
 // Hot reloading will not work at the moment within a container because of CORS issues.
 const hotReload = function () {
-    process.env.HOT_RELOAD && process.env.HOT_RELOAD === 'true' ? true : false
+    return process.env.HOT_RELOAD && process.env.HOT_RELOAD === 'true' ? true : false
 }
 
 webpackConfig.devServer = {

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -6,14 +6,16 @@ const APP_ID = 'compliance';
 const FRONTEND_PORT = 8002;
 const API_PORT = 3000;
 const routes = {};
-const frontentHost = process.env.UI_HOST ? process.env.UI_HOST : 'frontend'
+const frontendHost = process.env.UI_HOST ? process.env.UI_HOST : 'frontend';
 
-routes[`/beta/${BETA_SECTION}/${APP_ID}`] = { host: `http://${frontentHost}:${FRONTEND_PORT}` };
-routes[`/${SECTION}/${APP_ID}`]      = { host: `http://${frontentHost}:${FRONTEND_PORT}` };
-routes[`/beta/apps/${APP_ID}`]       = { host: `http://${frontentHost}:${FRONTEND_PORT}` };
-routes[`/apps/${APP_ID}`]            = { host: `http://${frontentHost}:${FRONTEND_PORT}` };
+routes[`/beta/${BETA_SECTION}/${APP_ID}`] = { host: `http://${frontendHost}:${FRONTEND_PORT}` };
+routes[`/${SECTION}/${APP_ID}`]      = { host: `http://${frontendHost}:${FRONTEND_PORT}` };
+routes[`/beta/apps/${APP_ID}`]       = { host: `http://${frontendHost}:${FRONTEND_PORT}` };
+routes[`/apps/${APP_ID}`]            = { host: `http://${frontendHost}:${FRONTEND_PORT}` };
 
-routes[`/api/${APP_ID}`] = { host: `http://localhost:${API_PORT}` };
-routes[`/r/insights/platform/${APP_ID}`] = { host: `http://localhost:${API_PORT}` };
+if (process.env.LOCAL_API) {
+    routes[`/api/${APP_ID}`] = { host: `http://localhost:${API_PORT}` };
+    routes[`/r/insights/platform/${APP_ID}`] = { host: `http://localhost:${API_PORT}` };
+}
 
 module.exports = { routes };

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -49,11 +49,4 @@ if (LOCAL_INVENTORY) {
     routes[`/api/inventory/v1`] = { host: `http://${INVENTORY_HOST}:${INVENTORY_PORT}` };
 }
 
-module.exports = {
-    routes,
-    esi: {
-        allowedHosts: [
-            /^https:\/\/.*redhat.com/
-        ]
-    },
-};
+module.exports = { routes };

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -6,11 +6,12 @@ const APP_ID = 'compliance';
 const FRONTEND_PORT = 8002;
 const API_PORT = 3000;
 const routes = {};
+const frontentHost = process.env.UI_HOST ? process.env.UI_HOST : 'frontend'
 
-routes[`/beta/${BETA_SECTION}/${APP_ID}`] = { host: `http://localhost:${FRONTEND_PORT}` };
-routes[`/${SECTION}/${APP_ID}`]      = { host: `http://localhost:${FRONTEND_PORT}` };
-routes[`/beta/apps/${APP_ID}`]       = { host: `http://localhost:${FRONTEND_PORT}` };
-routes[`/apps/${APP_ID}`]            = { host: `http://localhost:${FRONTEND_PORT}` };
+routes[`/beta/${BETA_SECTION}/${APP_ID}`] = { host: `http://${frontentHost}:${FRONTEND_PORT}` };
+routes[`/${SECTION}/${APP_ID}`]      = { host: `http://${frontentHost}:${FRONTEND_PORT}` };
+routes[`/beta/apps/${APP_ID}`]       = { host: `http://${frontentHost}:${FRONTEND_PORT}` };
+routes[`/apps/${APP_ID}`]            = { host: `http://${frontentHost}:${FRONTEND_PORT}` };
 
 routes[`/api/${APP_ID}`] = { host: `http://localhost:${API_PORT}` };
 routes[`/r/insights/platform/${APP_ID}`] = { host: `http://localhost:${API_PORT}` };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
           - PLATFORM=linux
           - PORT=8002
           # Comment out to use a local backend
-          - LOCAL_API=false
+          # - LOCAL_API=false
           # - LOCAL_API_SCHEME=http
           # - LOCAL_API_PORT=3000
           - UI_HOST=frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,18 @@
 version: '3'
 services:
     frontend:
+        env_file: .env
         build: .
         ports:
             - 8002:8002
-        environment:
-            - HOST=0.0.0.0
         volumes:
             - .:/frontend:z
-            - node_modules:/frontend/node_modules
+            - /frontend/node_modules
 
     proxy:
+        env_file: .env
         image: docker.io/redhatinsights/insights-proxy
         ports:
-          - "1337:1337"
-        depends_on:
-          - frontend
-        links:
-          - frontend
-        environment:
-          - PLATFORM=linux
-          - PORT=8002
-          # Comment out to use a local backend
-          # - LOCAL_API=false
-          # - LOCAL_API_SCHEME=http
-          # - LOCAL_API_PORT=3000
-          - UI_HOST=frontend
+          - 1337:1337
         volumes:
           - ./config/spandx.config.js:/config/spandx.config.js:z
-
-networks:
-    default:
-        external:
-            name: docker_default # should match insights-upload's network name
-
-volumes:
-    node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,34 +2,8 @@ version: '3'
 services:
   frontend:
     build: .
-    network_mode: "host"
     ports:
       - "8002:8002"
     volumes:
       - .:/frontend/:z
       - /frontend/node_modules/
-    extra_hosts:
-      - prod.foo.redhat.com:127.0.0.1
-      - stage.foo.redhat.com:127.0.0.1
-      - qa.foo.redhat.com:127.0.0.1
-      - ci.foo.redhat.com:127.0.0.1
-  proxy:
-    image: docker.io/redhatinsights/insights-proxy
-    network_mode: "host"
-    ports:
-      - "1337:1337"
-    extra_hosts:
-      - prod.foo.redhat.com:127.0.0.1
-      - stage.foo.redhat.com:127.0.0.1
-      - qa.foo.redhat.com:127.0.0.1
-      - ci.foo.redhat.com:127.0.0.1
-    environment:
-      - PLATFORM=linux
-      - PORT=8002
-      - LOCAL_CHROME=true
-      - LOCAL_API=true
-      - LOCAL_API_SCHEME=http
-      - LOCAL_API_PORT=3000
-    volumes:
-      - ${LOCAL_CHROME_PATH}:/chrome:z
-      - ./config/spandx.config.js:/config/spandx.config.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,12 @@ services:
   frontend:
     build: .
     ports:
-      - "8002:8002"
+      - 8002:8002
     volumes:
       - .:/frontend/:z
       - /frontend/node_modules/
+
+networks:
+  default:
+    external:
+      name: docker_default # should match insights-upload's network name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,38 @@
 version: '3'
 services:
-  frontend:
-    build: .
-    ports:
-      - 8002:8002
-    volumes:
-      - .:/frontend
-      - node_modules:/frontend/node_modules
+    frontend:
+        build: .
+        ports:
+            - 8002:8002
+        environment:
+            - HOST=0.0.0.0
+        volumes:
+            - .:/frontend:z
+            - node_modules:/frontend/node_modules
+
+    proxy:
+        image: docker.io/redhatinsights/insights-proxy
+        ports:
+          - "1337:1337"
+        depends_on:
+          - frontend
+        links:
+          - frontend
+        environment:
+          - PLATFORM=linux
+          - PORT=8002
+          # Comment out to use a local backend
+          - LOCAL_API=false
+          # - LOCAL_API_SCHEME=http
+          # - LOCAL_API_PORT=3000
+          - UI_HOST=frontend
+        volumes:
+          - ./config/spandx.config.js:/config/spandx.config.js:z
 
 networks:
-  default:
-    external:
-      name: docker_default # should match insights-upload's network name
+    default:
+        external:
+            name: docker_default # should match insights-upload's network name
 
 volumes:
-  node_modules:
+    node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+services:
+  frontend:
+    build: .
+    network_mode: "host"
+    ports:
+      - "8002:8002"
+    volumes:
+      - .:/frontend:Z
+      - /frontend/node_modules/
+    extra_hosts:
+      - prod.foo.redhat.com:127.0.0.1
+      - stage.foo.redhat.com:127.0.0.1
+      - qa.foo.redhat.com:127.0.0.1
+      - ci.foo.redhat.com:127.0.0.1
+  proxy:
+    image: docker.io/redhatinsights/insights-proxy
+    network_mode: "host"
+    ports:
+      - "1337:1337"
+    extra_hosts:
+      - prod.foo.redhat.com:127.0.0.1
+      - stage.foo.redhat.com:127.0.0.1
+      - qa.foo.redhat.com:127.0.0.1
+      - ci.foo.redhat.com:127.0.0.1
+    environment:
+      - PLATFORM=linux
+      - PORT=8002
+      - LOCAL_CHROME=true
+      - LOCAL_API=true
+      - LOCAL_API_SCHEME=http
+      - LOCAL_API_PORT=3000
+    volumes:
+      - ${LOCAL_CHROME_PATH}:/chrome:Z
+      - ./config/spandx.config.js:/config/spandx.config.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,13 @@ services:
     ports:
       - 8002:8002
     volumes:
-      - .:/frontend/:z
-      - /frontend/node_modules/
+      - .:/frontend
+      - node_modules:/frontend/node_modules
 
 networks:
   default:
     external:
       name: docker_default # should match insights-upload's network name
+
+volumes:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8002:8002"
     volumes:
-      - .:/frontend:Z
+      - .:/frontend/:z
       - /frontend/node_modules/
     extra_hosts:
       - prod.foo.redhat.com:127.0.0.1
@@ -31,5 +31,5 @@ services:
       - LOCAL_API_SCHEME=http
       - LOCAL_API_PORT=3000
     volumes:
-      - ${LOCAL_CHROME_PATH}:/chrome:Z
+      - ${LOCAL_CHROME_PATH}:/chrome:z
       - ./config/spandx.config.js:/config/spandx.config.js

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 set -e
+
+if [[ ! -d "/frontend/node_modules/@redhat-cloud-services" ]]; then
+    echo "No modules installed! Installing..."
+    cd /frontend; /usr/bin/npm install;
+fi
+
 exec "$@"


### PR DESCRIPTION
This adds a Docker image and docker compose setup to eventually only have to use `docker-compose build` & `docker-compose up` to get the frontend and insights-proxy up and running for development.

This is based on the setup used for https://github.com/RedHatInsights/notifications-frontend/.