### PR TITLE
RHICOMPL-145 - Commands to copy should have white background

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -10,3 +10,7 @@ section.pf-l-page-header.pf-l-page__main-section, section.pf-c-page-header.pf-c-
 .pf-l-tabs, .pf-c-tabs {
     padding-top: 22px;
 }
+
+.upload-instructions {
+    background: white
+}

--- a/src/SmartComponents/CompliancePoliciesCards/CompliancePoliciesCards.js
+++ b/src/SmartComponents/CompliancePoliciesCards/CompliancePoliciesCards.js
@@ -101,12 +101,14 @@ const CompliancePoliciesCards = () => (
                                 about your system&#39;s compliance to policies.
                                 <br/>
                                 Generate a report with OpenSCAP with the following command:
-                                <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
+                                <ClipboardCopy className='upload-instructions'
+                                    variant={ClipboardCopyVariant.expansion}>
                                     oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_standard
                                     --results scan.xml /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
                                 </ClipboardCopy>
                                 And upload it using the following command:
-                                <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
+                                <ClipboardCopy className='upload-instructions'
+                                    variant={ClipboardCopyVariant.expansion}>
                                     sudo insights-client --verbose --payload scan.xml
                                     --content-type application/vnd.redhat.compliance.something+tgz
                                 </ClipboardCopy>


### PR DESCRIPTION
![Screenshot from 2019-07-02 18-37-36](https://user-images.githubusercontent.com/598891/60530169-7cbb8f80-9cf8-11e9-8f2a-87da89eb3e16.png)

The reason why the TextInput was grey is that disabled text inputs are grey by default, the color comes from the system, not from Patternfly. If we set the `isReadOnly` option, the text input to copy becomes grey instead of white.