### PR TITLE
Show N/A if compliance cannot be computed

### DIFF
--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
-import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { QuestionCircleIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { FormattedRelative } from 'react-intl';
 import { EXPORT_TO_CSV } from '../ActionTypes';
@@ -8,13 +8,21 @@ import { downloadCsv } from '../../Utilities/CsvExport';
 
 const compliantIcon = (system) => (
     <React.Fragment>
-        { system.compliant ?
-            <CheckCircleIcon style={{ color: 'var(--pf-global--success-color--100)' }}/> :
-            <ExclamationCircleIcon style={{ color: 'var(--pf-global--danger-color--100)' }}/> }
+        {
+            ((system.rulesPassed + system.rulesFailed) === 0) ?
+                <QuestionCircleIcon style={{ color: 'var(--pf-global--disabled-color--100)' }}/> :
+                system.compliant ?
+                    <CheckCircleIcon style={{ color: 'var(--pf-global--success-color--100)' }}/> :
+                    <ExclamationCircleIcon style={{ color: 'var(--pf-global--danger-color--100)' }}/>
+        }
     </React.Fragment>
 );
 
 const complianceScoreString = (system) => {
+    if ((system.rulesPassed + system.rulesFailed) === 0) {
+        return ' N/A';
+    }
+
     return ' ' + (100 * (system.rulesPassed / (system.rulesPassed + system.rulesFailed))).toFixed(2) + '%';
 };
 


### PR DESCRIPTION
If a host has no info to compute its compliance, we are currently showing `NaN` and :heavy_check_mark:  - which is wrong. This should be a very rare and unexpected case, but still I would rather show this than the current misleading :heavy_check_mark:  

![Screenshot from 2019-07-16 10-04-17](https://user-images.githubusercontent.com/598891/61279044-aaeba580-a7b5-11e9-85ca-d0032160325b.png)
