### PR TITLE
RHICOMPL-245 - Fix pagination in systems list

### DIFF
--- a/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
+++ b/src/SmartComponents/ComplianceSystemsTable/ComplianceSystemsTable.js
@@ -31,7 +31,7 @@ const ComplianceSystemsTable = () => (
             if (loading) { return <EmptyTable><Spinner/></EmptyTable>; }
 
             const systems = data.allSystems;
-            const systemsCount = data.allProfiles.reduce((acc, curr) => acc + curr.total_host_count, 0);
+            const systemsCount = data.allProfiles.reduce((acc, curr) => acc + curr.totalHostCount, 0);
             const columns = [{
                 composed: ['facts.os_release', 'display_name'],
                 key: 'display_name',


### PR DESCRIPTION
Currently pagination is broken because the system count is not done appropriately due to a capitalization error after the GraphQL refactor. It works OK with this change.