### PR TITLE
Support C2S remediations

### DIFF
--- a/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
+++ b/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
@@ -54,7 +54,7 @@ class ComplianceRemediationButton extends React.Component {
     }
 
     removeRefIdPrefix = (refId) => {
-        const splitRefId = refId.split('xccdf_org.ssgproject.content_profile_')[1];
+        const splitRefId = refId.toLowerCase().split('xccdf_org.ssgproject.content_profile_')[1];
         if (splitRefId) {
             return splitRefId;
         } else {


### PR DESCRIPTION
Without turning the profile into lowercase, the C2S profile does not
work. Remediations expects the profile to be lowercase so it returns a
400 when we check whether there is an available remediation or not