### PR TITLE
RHICOMPL-208 - Policy detail header responsiveness

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -14,3 +14,7 @@ section.pf-l-page-header.pf-l-page__main-section, section.pf-c-page-header.pf-c-
 .upload-instructions {
     background: white
 }
+
+.policy-details-dropdown {
+    float: right
+}

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -1,5 +1,6 @@
 import {
     Dropdown,
+    DropdownPosition,
     DropdownToggle,
     DropdownItem,
     Modal,
@@ -56,6 +57,8 @@ class EditPolicy extends Component {
             <React.Fragment>
                 <Dropdown
                     onSelect={this.onSelect}
+                    className='policy-details-dropdown'
+                    position={DropdownPosition.right}
                     toggle={<DropdownToggle onToggle={this.onToggle}>Actions</DropdownToggle>}
                     isOpen={isOpen}
                     dropdownItems={dropdownItems}

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -172,13 +172,17 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                             onNavigate={onNavigateWithProps}
                         />
                         <PageHeaderTitle title={policy.name} />
+                        <EditPolicy policyId={policy.id}
+                            previousThreshold={policy.complianceThreshold}
+                            businessObjective={policy.businessObjective}
+                        />
                         { policy.businessObjective &&
                         <Text style={{ color: 'var(--pf-global--Color--200)' }}>
                             Business objective: { policy.businessObjective.title }
                         </Text>
                         }
                         <Grid gutter='md'>
-                            <GridItem span={4}>
+                            <GridItem sm={12} md={12} lg={12} xl={6}>
                                 <div className='chart-inline'>
                                     <div className='chart-container'>
                                         {label}
@@ -201,7 +205,7 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                                 </div>
 
                             </GridItem>
-                            <GridItem span={6}>
+                            <GridItem sm={12} md={12} lg={12} xl={6}>
                                 <TextContent>
                                     <Text style={{ fontWeight: 'bold' }} component={TextVariants.p}>Description</Text>
                                     <Text component={TextVariants.p}>
@@ -226,12 +230,6 @@ const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => (
                                         </Text>
                                     </Tooltip>
                                 </TextContent>
-                            </GridItem>
-                            <GridItem span={2}>
-                                <EditPolicy policyId={policy.id}
-                                    previousThreshold={policy.complianceThreshold}
-                                    businessObjective={policy.businessObjective}
-                                />
                             </GridItem>
                         </Grid>
                     </PageHeader>


### PR DESCRIPTION
I wanted to use the newer version of the charts in https://www.patternfly.org/v4/documentation/react/charts/chartdonututilization/ - but in the end it's a bit difficult because the `VictoryContainer` in which the charts are rendered has some props already baked in by Patternfly.

Quick demo (>10MB, cannot upload to GitHub directly): 
https://gfycat.com/unconsciousanydikkops