### PR TITLE
RHICOMPL-272 - Make sure all percentages displayed are rounded

### DIFF
--- a/src/SmartComponents/CompliancePolicyCard/CompliancePolicyCard.js
+++ b/src/SmartComponents/CompliancePolicyCard/CompliancePolicyCard.js
@@ -19,6 +19,7 @@ import {
     ChartTheme
 } from '@patternfly/react-charts';
 import '../../Charts.scss';
+import { fixedPercentage } from '../../Utilities/TextHelper';
 
 class CompliancePolicyCard extends React.Component {
     constructor(policy) {
@@ -42,8 +43,8 @@ class CompliancePolicyCard extends React.Component {
             { x: 'Compliant', y: compliantHostCount },
             { x: 'Non-compliant', y: totalHostCount - compliantHostCount }
         ];
-        const compliancePercentage = Math.floor(100 *
-            (donutValues[0].y / (donutValues[0].y + donutValues[1].y))) + '%';
+        const compliancePercentage = fixedPercentage(Math.floor(100 *
+            (donutValues[0].y / (donutValues[0].y + donutValues[1].y))));
         const label = (
             <svg
                 className="chart-label"

--- a/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
+++ b/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
@@ -24,7 +24,7 @@ class BusinessObjectiveField extends React.Component {
         this.state = {
             policyId: props.policyId,
             isExpanded: false,
-            originalValue: props.businessObjective ? props.businessObjective.title : 'e.g: Project Gemini',
+            originalValue: props.businessObjective ? props.businessObjective.title : 'e.g.: Project Gemini',
             selected: props.businessObjective ? props.businessObjective.id : '',
             options: [],
             originalOptions: [],

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -4,6 +4,7 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import SystemsTable from '../SystemsTable/SystemsTable';
 import { onNavigate } from '../../Utilities/Breadcrumbs';
+import { fixedPercentage } from '../../Utilities/TextHelper';
 import EditPolicy from '../EditPolicy/EditPolicy';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
@@ -142,8 +143,8 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
         { name: donutValues[1].y + ' Systems Non-Compliant' }
     ];
 
-    const compliancePercentage = Math.floor(100 *
-        (donutValues[0].y / (donutValues[0].y + donutValues[1].y))) + '%';
+    const compliancePercentage = fixedPercentage(Math.floor(100 *
+        (donutValues[0].y / (donutValues[0].y + donutValues[1].y))));
 
     const label = (
         <svg
@@ -238,7 +239,7 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
                                       Minimum threshold for compliance <OutlinedQuestionCircleIcon className='grey-icon'/>
                                     </Text>
                                     <Text className='threshold-tooltip' component={TextVariants.p}>
-                                        { policy.complianceThreshold }%
+                                        { fixedPercentage(policy.complianceThreshold) }
                                     </Text>
                                 </span>
                             </Tooltip>

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -306,8 +306,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1
-              %
+              1%
             </p>
           </span>
         </div>
@@ -643,8 +642,7 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1
-              %
+              1%
             </p>
           </span>
         </div>
@@ -980,8 +978,7 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1
-              %
+              1%
             </p>
           </span>
         </div>
@@ -2110,8 +2107,7 @@ exports[`PolicyDetailsQuery passes loading on to SystemTable 1`] = `
                 className="threshold-tooltip"
                 component="p"
               >
-                1
-                %
+                1%
               </Text>
             </span>
           </Tooltip>
@@ -2470,8 +2466,7 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1
-              %
+              1%
             </p>
           </span>
         </div>
@@ -2807,8 +2802,7 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1
-              %
+              1%
             </p>
           </span>
         </div>

--- a/src/Utilities/TextHelper.js
+++ b/src/Utilities/TextHelper.js
@@ -1,0 +1,3 @@
+export const fixedPercentage = (value, fixed = 0, withPercent = true) => {
+    return (value).toFixed(fixed) + (withPercent ? '%' : '');
+};

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { FormattedRelative } from 'react-intl';
 import { EXPORT_TO_CSV } from '../ActionTypes';
 import { downloadCsv } from '../../Utilities/CsvExport';
+import { fixedPercentage } from '../../Utilities/TextHelper';
 
 const compliantIcon = (system) => (
     <React.Fragment>
@@ -23,7 +24,7 @@ const complianceScoreString = (system) => {
         return ' N/A';
     }
 
-    return ' ' + (100 * (system.rulesPassed / (system.rulesPassed + system.rulesFailed))).toFixed(2) + '%';
+    return ' ' + fixedPercentage(100 * (system.rulesPassed / (system.rulesPassed + system.rulesFailed)));
 };
 
 const complianceScore = (system) => (


### PR DESCRIPTION
This adds a helper and wraps all percentages displayed to make sure they are displayed consistantly throughout the UI.

It also sneaks in a minor fix: adding a dot to 'e.g'