### PR TITLE
Set inline for Truncate

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -218,9 +218,9 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
                     </GridItem>
                     <GridItem sm={12} md={12} lg={12} xl={6}>
                         <TextContent>
-                            <Text style={{ fontWeight: 'bold' }} component={TextVariants.span}>Description</Text>
-                            <Text component={TextVariants.span}>
-                                <Truncate text={linkifyHtml(policy.description)} length={380} />
+                            <Text style={{ fontWeight: 'bold' }} component={TextVariants.p}>Description</Text>
+                            <Text component={TextVariants.p}>
+                                <Truncate text={linkifyHtml(policy.description)} length={380} inline={true} />
                             </Text>
                             <Tooltip
                                 position='left'

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -263,19 +263,12 @@ exports[`PolicyDetails expect to render without error 1`] = `
             class=""
             data-pf-content="true"
           >
-            <div
-              class="pf-l-stack ins-c-truncate is-block"
+            <span
+              class="ins-c-truncate is-inline"
+              widget-type="InsightsTruncateInline"
             >
-              <div
-                class="pf-l-stack__item"
-              >
-                <span
-                  widget-type="InsightsTruncateBlock"
-                >
-                  profile description
-                </span>
-              </div>
-            </div>
+              profile description
+            </span>
           </p>
           <span
             tabindex="0"
@@ -600,19 +593,12 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
             class=""
             data-pf-content="true"
           >
-            <div
-              class="pf-l-stack ins-c-truncate is-block"
+            <span
+              class="ins-c-truncate is-inline"
+              widget-type="InsightsTruncateInline"
             >
-              <div
-                class="pf-l-stack__item"
-              >
-                <span
-                  widget-type="InsightsTruncateBlock"
-                >
-                  profile description
-                </span>
-              </div>
-            </div>
+              profile description
+            </span>
           </p>
           <span
             tabindex="0"
@@ -937,19 +923,12 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
             class=""
             data-pf-content="true"
           >
-            <div
-              class="pf-l-stack ins-c-truncate is-block"
+            <span
+              class="ins-c-truncate is-inline"
+              widget-type="InsightsTruncateInline"
             >
-              <div
-                class="pf-l-stack__item"
-              >
-                <span
-                  widget-type="InsightsTruncateBlock"
-                >
-                  profile description
-                </span>
-              </div>
-            </div>
+              profile description
+            </span>
           </p>
           <span
             tabindex="0"
@@ -2040,6 +2019,7 @@ exports[`PolicyDetailsQuery passes loading on to SystemTable 1`] = `
       >
         <TextContent>
           <Text
+            component="p"
             style={
               Object {
                 "fontWeight": "bold",
@@ -2048,10 +2028,13 @@ exports[`PolicyDetailsQuery passes loading on to SystemTable 1`] = `
           >
             Description
           </Text>
-          <Text>
+          <Text
+            component="p"
+          >
             <Truncate
               collapseText="Collapse"
               expandText="Read more"
+              inline={true}
               length={380}
               text="profile description"
             />
@@ -2427,19 +2410,12 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
             class=""
             data-pf-content="true"
           >
-            <div
-              class="pf-l-stack ins-c-truncate is-block"
+            <span
+              class="ins-c-truncate is-inline"
+              widget-type="InsightsTruncateInline"
             >
-              <div
-                class="pf-l-stack__item"
-              >
-                <span
-                  widget-type="InsightsTruncateBlock"
-                >
-                  profile description
-                </span>
-              </div>
-            </div>
+              profile description
+            </span>
           </p>
           <span
             tabindex="0"
@@ -2764,19 +2740,12 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
             class=""
             data-pf-content="true"
           >
-            <div
-              class="pf-l-stack ins-c-truncate is-block"
+            <span
+              class="ins-c-truncate is-inline"
+              widget-type="InsightsTruncateInline"
             >
-              <div
-                class="pf-l-stack__item"
-              >
-                <span
-                  widget-type="InsightsTruncateBlock"
-                >
-                  profile description
-                </span>
-              </div>
-            </div>
+              profile description
+            </span>
           </p>
           <span
             tabindex="0"


### PR DESCRIPTION
Fix for a minor issue with truncate rendering a div within a p element if it's not set to inline, which makes the DOM invalid and show an error in the console.

The error is also shown when running tests (locally and CI):

```console.error node_modules/react-dom/cjs/react-dom.development.js:558
      Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
          in div (created by StackItem)
          in StackItem (created by Truncate)
          in div (created by Stack)
          in Stack (created by Truncate)
          in Truncate (created by PolicyDetailsQuery)
          in p (created by Text)
          in Text (created by PolicyDetailsQuery)
          in div (created by TextContent)
          in TextContent (created by PolicyDetailsQuery)
          in div (created by GridItem)
          in GridItem (created by PolicyDetailsQuery)
          in div (created by Grid)
          in Grid (created by PolicyDetailsQuery)
          in section (created by Context.Consumer)
          in PageHeader (created by PolicyDetailsQuery)
          in PolicyDetailsQuery
          in Provider
```