### PR TITLE
RHICOMPL-384 - Papercuts on Policy list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1533,15 +1533,25 @@
       "integrity": "sha512-biz6HjWPit1Oefkvna5IQYEolQXt+VEhl/lTm3a8d9hQU4jdriIdKSuYo/CF1hjYTfsbqUHL47dnkw6Ffq7m5Q=="
     },
     "@patternfly/react-charts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-2.3.0.tgz",
-      "integrity": "sha512-tdTqugoG3wyJFpAriQlQz/Avi19peqR3Rxr8VVRcLKDcjLpQr8Im7qRCzTe4fGJMp8zT8krP7OU2MIwVkgfNTg==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-5.0.13.tgz",
+      "integrity": "sha512-uyjBUKfO9QGi7nvcE0pkAwhTTwsEoXHozQ6tgz/wT9QS4q0y+oYam5PlHBPCQ5qVwseX6v/po8Lx6ktK6xMD3A==",
       "requires": {
-        "@patternfly/react-styles": "^2.5.0",
-        "@types/victory": "^0.9.19",
-        "hoist-non-react-statics": "^3.1.0",
-        "victory": "^30.1.0",
-        "victory-core": "^31.1.0"
+        "@patternfly/patternfly": "2.33.5",
+        "@patternfly/react-styles": "^3.5.27",
+        "@patternfly/react-tokens": "^2.6.31",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.15",
+        "victory": "^33.0.5",
+        "victory-core": "^33.0.1",
+        "victory-legend": "^33.0.1"
+      },
+      "dependencies": {
+        "@patternfly/patternfly": {
+          "version": "2.33.5",
+          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-2.33.5.tgz",
+          "integrity": "sha512-/4S19Ln2BY62nUP/Ow+j4gzCKm4e3HYehW92R+iaREaBgatfq55G50QdPsXDvTvLeTp9lS6YfXJlLz7OTIHnhw=="
+        }
       }
     },
     "@patternfly/react-core": {
@@ -1683,9 +1693,9 @@
       }
     },
     "@patternfly/react-styles": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-2.5.0.tgz",
-      "integrity": "sha512-WS97UIRdLQMvu5O15WJt8xndIS99Ii9GHs9a8YsojeAwjVcZuBxV2V0o5fdMDW3SaXIQnpdfmwUotkrC6vPaRg==",
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-3.5.27.tgz",
+      "integrity": "sha512-nDhWOR+7W/oQgIw+4nwvGpoS2OgarfxlIEkFQaNdete6QyKwp2erPxDBNnj2gOGaB/+CKDWvTWD6JPhiuU56ew==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0-beta.48",
         "camel-case": "^3.0.0",
@@ -1696,15 +1706,109 @@
         "emotion-server": "^9.2.9",
         "fbjs-scripts": "^0.8.3",
         "fs-extra": "^6.0.1",
-        "jsdom": "^11.11.0",
+        "jsdom": "^15.1.0",
         "relative": "^3.0.2",
-        "resolve-from": "^4.0.0"
+        "resolve-from": "^4.0.0",
+        "typescript": "3.4.5"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+        },
+        "jsdom": {
+          "version": "15.2.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
+          "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^7.1.0",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.4.1",
+            "cssstyle": "^2.0.0",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.1.4",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.1.tgz",
+              "integrity": "sha512-6Aajq0XmukE7HdXUU6IoSWuH1H6gH9z6qmagsstTiN7cW2FNTsb+J2Chs+ufPgZCsV/yo8oaEudQLrb9dGxSVQ=="
+            },
+            "cssstyle": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.0.0.tgz",
+              "integrity": "sha512-QXSAu2WBsSRXCPjvI43Y40m6fMevvyRm8JVAuF9ksQz5jha4pWP1wpaK7Yu5oLFc6+XAY+hj8YhefyXcBB53gg==",
+              "requires": {
+                "cssom": "~0.3.6"
+              },
+              "dependencies": {
+                "cssom": {
+                  "version": "0.3.8",
+                  "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+                  "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+                }
+              }
+            }
+          }
+        },
+        "parse5": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+        },
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "ws": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
+          "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
+          "requires": {
+            "async-limiter": "^1.0.0"
+          }
         }
       }
     },
@@ -2088,22 +2192,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.8.tgz",
       "integrity": "sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A=="
     },
-    "@types/prop-types": {
-      "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "optional": true
-    },
-    "@types/react": {
-      "version": "16.9.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.9.tgz",
-      "integrity": "sha512-L+AudFJkDukk+ukInYvpoAPyJK5q1GanFOINOJnM0w6tUgITuWvJ4jyoBPFL7z4/L8hGLd+K/6xR5uUjXu0vVg==",
-      "optional": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "csstype": "^2.2.0"
-      }
-    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -2129,15 +2217,6 @@
       "requires": {
         "@types/node": "*",
         "@types/unist": "*"
-      }
-    },
-    "@types/victory": {
-      "version": "0.9.21",
-      "resolved": "https://registry.npmjs.org/@types/victory/-/victory-0.9.21.tgz",
-      "integrity": "sha512-7A2dDRhPk2O5L4nCYw55I53uNX3G/PoLb41b0XclPFi98Bf8eA7Ov/LpmUlneSQY/3o2qbpPqJ2c8TLi3R8oJg==",
-      "optional": true,
-      "requires": {
-        "@types/react": "*"
       }
     },
     "@types/zen-observable": {
@@ -2493,7 +2572,8 @@
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "dev": true
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -6775,7 +6855,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
       "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
-      "optional": true,
       "requires": {
         "d3-array": "^1.2.0",
         "d3-collection": "1",
@@ -7031,6 +7110,19 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "delaunay-find": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.4.tgz",
+      "integrity": "sha512-Dlez+Pc4Q33Y2mKe/h+p4NmQ6+W6kT6tXL+1dQfuVvp1mEDKTXRjbr6HcW5ftDKyVEY08MCCdqbR0Y6dnYYEPA==",
+      "requires": {
+        "delaunator": "^4.0.0"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -12554,6 +12646,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
       "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+      "dev": true,
       "requires": {
         "abab": "^2.0.0",
         "acorn": "^5.5.3",
@@ -12587,6 +12680,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
           "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+          "dev": true,
           "requires": {
             "cssom": "0.3.x"
           }
@@ -12846,7 +12940,8 @@
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
     },
     "leven": {
       "version": "2.1.0",
@@ -14801,7 +14896,8 @@
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -16296,8 +16392,7 @@
     "react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
-      "optional": true
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-input-autosize": {
       "version": "2.2.2",
@@ -18013,7 +18108,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "saxes": {
       "version": "3.1.11",
@@ -21154,782 +21250,309 @@
       }
     },
     "victory": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory/-/victory-30.6.1.tgz",
-      "integrity": "sha512-VJAFvZz4s6qT3KhDKLv9qMKtSwLjbRZiuK917KrfomTLYcjMgrA1FckW/8nIn1URwNdkawe4YvgAE0wdtbDO3A==",
-      "optional": true,
+      "version": "33.1.1",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-33.1.1.tgz",
+      "integrity": "sha512-V/jBG4s3ZZBgqc1D9OKXRptKlpLZroPoJ+0hIq5RvAIqYndqpy2g9xdYQOKtvL62C8LavbgDpd0iKR7ejI/I/g==",
       "requires": {
-        "victory-area": "^30.6.1",
-        "victory-axis": "^30.6.1",
-        "victory-bar": "^30.6.1",
-        "victory-box-plot": "^30.6.1",
-        "victory-brush-container": "^30.6.1",
-        "victory-brush-line": "^30.6.1",
-        "victory-candlestick": "^30.6.1",
-        "victory-chart": "^30.6.1",
-        "victory-core": "^30.6.1",
-        "victory-create-container": "^30.6.1",
-        "victory-cursor-container": "^30.6.1",
-        "victory-errorbar": "^30.6.1",
-        "victory-group": "^30.6.1",
-        "victory-legend": "^30.6.1",
-        "victory-line": "^30.6.1",
-        "victory-pie": "^30.6.1",
-        "victory-polar-axis": "^30.6.1",
-        "victory-scatter": "^30.6.1",
-        "victory-selection-container": "^30.6.1",
-        "victory-shared-events": "^30.6.1",
-        "victory-stack": "^30.6.1",
-        "victory-tooltip": "^30.6.1",
-        "victory-voronoi": "^30.6.1",
-        "victory-voronoi-container": "^30.6.1",
-        "victory-zoom-container": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-area": "^33.1.0",
+        "victory-axis": "^33.1.0",
+        "victory-bar": "^33.1.0",
+        "victory-box-plot": "^33.1.0",
+        "victory-brush-container": "^33.1.0",
+        "victory-brush-line": "^33.1.0",
+        "victory-candlestick": "^33.1.0",
+        "victory-chart": "^33.1.0",
+        "victory-core": "^33.1.0",
+        "victory-create-container": "^33.1.1",
+        "victory-cursor-container": "^33.1.0",
+        "victory-errorbar": "^33.1.0",
+        "victory-group": "^33.1.0",
+        "victory-legend": "^33.1.0",
+        "victory-line": "^33.1.0",
+        "victory-pie": "^33.1.0",
+        "victory-polar-axis": "^33.1.0",
+        "victory-scatter": "^33.1.0",
+        "victory-selection-container": "^33.1.0",
+        "victory-shared-events": "^33.1.0",
+        "victory-stack": "^33.1.0",
+        "victory-tooltip": "^33.1.0",
+        "victory-voronoi": "^33.1.0",
+        "victory-voronoi-container": "^33.1.1",
+        "victory-zoom-container": "^33.1.0"
       }
     },
     "victory-area": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-30.6.1.tgz",
-      "integrity": "sha512-Ksu0dnS2Ssiiuv/OH/1XK/a3M2D7to20JUkzVSyvm3m1HvKyvRCK4fDuBI2mXFWaX5iT2gJmqtVj6R22b+NOtg==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-33.1.0.tgz",
+      "integrity": "sha512-l4wKcO5RvWbBWqR8Xj9AjtfjfSAVBc7VmEthqUZBeYi3cpDHXRp2vN+HjiYmcXR/cKtmuZBJD3FFobstdoKfFw==",
       "requires": {
         "d3-shape": "^1.2.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-axis": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-30.6.1.tgz",
-      "integrity": "sha512-SJFdMDYOLG9EfPovskomeXvb4VOJnTF//DvXCIcw6Ysy6sMpkwvWfpJVKgh9JAzELirW8OSU775f5BcwZ+z1xg==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-33.1.0.tgz",
+      "integrity": "sha512-V46wBQitoOgYQQzM4BKOfNhTXoSmPPdLSqY4Zv5FK1dQnGR6AeMPHeVIiHb1G0NbavfLLenXzBBlOkBS9HJzQA==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-bar": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-30.6.1.tgz",
-      "integrity": "sha512-P9v6OAz9w71+cTvRuRm43jtXV9Ag41bGn2RXf7nUgp1M0GFvaFQGujSILdSVsE8zEdyQLmwUxJRSz+s5b6CeSQ==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-33.1.0.tgz",
+      "integrity": "sha512-8cSthTsg/v/6CCB5AgG7pMRtO7+q3u195jGsmm0uM2/4vUDFzDdiF19orPiFooDSvBvVdNeIBssz/Z8kEyXR4A==",
       "requires": {
         "d3-shape": "^1.2.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-box-plot": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-30.6.1.tgz",
-      "integrity": "sha512-2UVGOG+E4Nm0LLQyj3q13oAaE8vChAkrOZryTFFtDLZHVw5pUxDzZtWlgysna82tkJQA4vjlcq2h2lbZw9G1Rw==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-33.1.0.tgz",
+      "integrity": "sha512-p1TIc5YaUXDc1aJPZJq/ExHRkLazh5VH7HpA0ImnoqVriPKg4FES1XqqNxV/TsXzItAPXj+WXStOrjMBbBxGLw==",
       "requires": {
         "d3-array": "^1.2.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-brush-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-30.6.1.tgz",
-      "integrity": "sha512-V76eHU0Mn92DgOjnYJVHT+4skHkACBn2wQROd0E9ZFNqqyTa76U/ISD+4ihjNSqy0HfGdaHTjxcjL83E/EfONw==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-33.1.0.tgz",
+      "integrity": "sha512-ud7iPqCIrKOSn4wffve6I2dTj+OovdWFDgeBNgNtw0jc/mErrsd4vSXNHKzD2lPhjcTwNImtop5e1aWA9Liwdw==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-brush-line": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-30.6.1.tgz",
-      "integrity": "sha512-wOeIIPm8BDNqqDJQFfHe6txJ8JPWNKzHeQ6WTiwntw/IN8oLk4cwnbbW5yhQQC6rOniRFZH5iqb5V+zdCLUCWg==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-33.1.0.tgz",
+      "integrity": "sha512-ZQaaPL3eJ+YCa4c+3Is1AXJBiuhNt+dSGB/wCDRtwFTmDp4Ce5eLGSyvyuj0QYb5wxvfGChs1pnG1TfDinUNaw==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-candlestick": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-30.6.1.tgz",
-      "integrity": "sha512-cF0/jRU8LY14vBWHugU/5Ei1a+Lcc6u1k4o03m7ujKSsBffvVDnj4CN+nR9jwMMEMUeViBiVpY8HfhzFXVQ5KQ==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-33.1.0.tgz",
+      "integrity": "sha512-onmr+smsc2ORU81f5YHNLLHqCzwBJY2aUuS2w8qDDnTzuHmbjH5Jyb6877spTyWggNjs5YcNv/zvkXW2THK4CQ==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-chart": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-30.6.1.tgz",
-      "integrity": "sha512-JHP51QSJweuOQqMMqVim5u/vLKnvD3hjANpJdPPzthTrrmm1IPHAMLkUQ0m0tPiKsAf/5E49jDx4mDz7r6IK7w==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-33.1.0.tgz",
+      "integrity": "sha512-S+sy5xMkLWvBdS3KH5OJnDBOOOCC07tb1/KWEv1S/6K/y7BMSVyzgYCHsGJauj/ir07nPjiwCbfEEZyKCXjIyQ==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-axis": "^30.6.1",
-        "victory-core": "^30.6.1",
-        "victory-polar-axis": "^30.6.1",
-        "victory-shared-events": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-axis": "^33.1.0",
+        "victory-core": "^33.1.0",
+        "victory-polar-axis": "^33.1.0",
+        "victory-shared-events": "^33.1.0"
       }
     },
     "victory-core": {
-      "version": "31.2.0",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-31.2.0.tgz",
-      "integrity": "sha512-fKSJ2vKkvk6jc6ofBQ7/MbC2+r3Do7zeKfUnT7l4Z163kPDOWicA+wUdgMPlRtRv4J70z9tIENq8xMI22FMCpA==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-33.1.0.tgz",
+      "integrity": "sha512-JiNbxuBBQUazOHVG9T+fUtVQygmPubzQ3UlC9QGX+rLIk4c3ISIQu6edApMbSmuaV16zSbcXwHcxdYuEvmyvow==",
       "requires": {
         "d3-ease": "^1.0.0",
         "d3-interpolate": "^1.1.1",
         "d3-scale": "^1.0.0",
         "d3-shape": "^1.2.0",
         "d3-timer": "^1.0.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0"
       }
     },
     "victory-create-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-30.6.1.tgz",
-      "integrity": "sha512-Bm23Yk9xzdO8uCK99G+IFFclWx/vpDLea2vcW2MyHlTT2Iwa1HHW8UAYFfwr6858LYMaOa/Y9UV/YvP+twctoA==",
-      "optional": true,
+      "version": "33.1.1",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-33.1.1.tgz",
+      "integrity": "sha512-M4cRC5rjtRcWqUCegc6CkPKL0CNM0SJwlp/kFG5qOv736P+u5wm883C6BevW7a+aOy6lbYgKRUH19Yboxcuydw==",
       "requires": {
-        "lodash": "^4.17.5",
-        "victory-brush-container": "^30.6.1",
-        "victory-core": "^30.6.1",
-        "victory-cursor-container": "^30.6.1",
-        "victory-selection-container": "^30.6.1",
-        "victory-voronoi-container": "^30.6.1",
-        "victory-zoom-container": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "lodash": "^4.17.15",
+        "victory-brush-container": "^33.1.0",
+        "victory-core": "^33.1.0",
+        "victory-cursor-container": "^33.1.0",
+        "victory-selection-container": "^33.1.0",
+        "victory-voronoi-container": "^33.1.1",
+        "victory-zoom-container": "^33.1.0"
       }
     },
     "victory-cursor-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-30.6.1.tgz",
-      "integrity": "sha512-XjmLUdQWEiv8F+AwfpVvi3kETJz7OCWlpkypbiIJjLvYM8lUeT84boOftMfyw+HRjUAxPQFh1D7yBUvAqrwKiA==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-33.1.0.tgz",
+      "integrity": "sha512-PIOKteQLOC5/GJPtYCN4YufPKt0L/c8ajXc3SPRo0h4kv+eWU1v3l3mbf5vSYxtZsUefAh3jST18FBLwZrskow==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-errorbar": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-30.6.1.tgz",
-      "integrity": "sha512-SBowNqH5MBh1GoqA3UF5YVsFB0h0o60IkR5Yjhe/uaGhwyZVAu5X9+BE0CXRq0uDLhOX9GDvqDs59hAe0D3xiw==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-33.1.0.tgz",
+      "integrity": "sha512-6o64FXsXrczQQEoan6woIFm/EyJxgfOd8uxdYQ7m5pCH65U6rSefMKFUB/dLjyz6vMV5rwt7Q0chnAtt3Zg82A==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-group": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-30.6.1.tgz",
-      "integrity": "sha512-fGt6/+GgsBqFiuzVdzQHRc2joYEDL9Bo2wE8rCH5HAUnj/oI6drKi8euooUpBOIhbOQeycCj7r6BXJvp8H9CfQ==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-33.1.0.tgz",
+      "integrity": "sha512-lI/Lv6AsyK3Dn6kjjLSt3N6ywiVnkqlyLZRMo6weW+qdkcTbSSVigQqzYrfoEnx2ZTM0jVxqARuu8iA5H0ONJQ==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^33.1.0"
       }
     },
     "victory-legend": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-30.6.1.tgz",
-      "integrity": "sha512-iadVJSaj+mhT9Crx2eYMF39qTyvn03B5p44OjeLqKcvb0MDElVDsXyYHTwsUgnE4i+YPOFz9+buMaw2UWXU0NA==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-33.1.0.tgz",
+      "integrity": "sha512-FZwl9o/DZVvmBAvpNQxpr9EwdRqFGICBXdTtsfQlPPYnXHRUhGbiwpYFOmuSGixnmu4imAtCKE+0svokxs8dVg==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-line": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-30.6.1.tgz",
-      "integrity": "sha512-JmL17SK4bLkhQEelDoj6QK9KLF8o5uW0aNNxdhSqluFxROLtuixUzvffEYlN0weHCkIR6f/o2PqbujLVtoxOOg==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-33.1.0.tgz",
+      "integrity": "sha512-ld1VUJPMrJ04PbvviwPoXYyoYgA2HkqloLYS99iSX0+O8lmw6HfAz4dHqboSTYSrMqo8OaW3pTy8CltcqGzIZw==",
       "requires": {
         "d3-shape": "^1.2.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-pie": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-30.6.1.tgz",
-      "integrity": "sha512-03jIWh/+17j7FX21KSNWSglhb50DqJQ9Jy5+nVAEcTlhIiI3bffuDd9IvoCfXMMwDmoRvaRq1xtXSElq4jZYpw==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-33.1.0.tgz",
+      "integrity": "sha512-h+qd23myAF3CVOczGBqM+rBf+cXF7pibXUSy4tJDltdaLindnHY/70Y4WIrtCiCw5nM3aR9yn16TnlSd/nqMpQ==",
       "requires": {
         "d3-shape": "^1.0.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-polar-axis": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-30.6.1.tgz",
-      "integrity": "sha512-OQIAKURdTdmOk/rXr+DNeE9xoROEOqmAdanTYXdpeazbYiClSbhcbIypK0Z7qyGziIV8D8W4r4at/mAMA9AkXQ==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-33.1.0.tgz",
+      "integrity": "sha512-mDYBvghGdHJni58uRarR3A09wZOogcs2EYmEUKCi1CrDQ3c7ZmXZl3j3R02CdKtnHLiJPZmZi+KHy9fEskRItA==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-scatter": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-30.6.1.tgz",
-      "integrity": "sha512-UsIne7V/LruhkA5r+BqUa4MNuMGSgOgPyklOOyKur1jrYm83kE3t0T7ObiTrFBLsL7SqVnmxARXW66Lv2GWE+g==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-33.1.0.tgz",
+      "integrity": "sha512-xUzIPlTgSrd96vCTklAdAmR1gx9aZ+cywmF2wX9r4Mz5p1u7JFqNy0V767zZ+6A49i3Iy4L7QWfDBI2i3YugLQ==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-selection-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-30.6.1.tgz",
-      "integrity": "sha512-ihv1aGOwu3IX/v94IRawMAlWRMlt/BogrU28FXhhVMdqXemPFkq3J9COq0khGhh+wuqtC1tu9Ni7uw4YA3fdZg==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-33.1.0.tgz",
+      "integrity": "sha512-iNtEdRPl1wEeUfcxxLRpU0UwgT7cES09dkBmZESdNXydFwhhLUuFBYw2lEIO+bZj7P9j4HFGoqJjH9+q7rE04A==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-shared-events": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-30.6.1.tgz",
-      "integrity": "sha512-4zQ6gfkrQVNtx+bUv+kgNNtVX5Mr6T68Hs2xV4H0f3FrToyFrsXtANGFhAzgmi+00Mk06FVIAIY94tZW3Cej1Q==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-33.1.0.tgz",
+      "integrity": "sha512-mI80VA9pUlpW4wzdBHPQd6bzlbDK3+7aom9iQuwQq/5XKAAmcYINyL6921Ml+suNo2VC0vg9nC4IYcLjrYBkFQ==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^33.1.0"
       }
     },
     "victory-stack": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-30.6.1.tgz",
-      "integrity": "sha512-WJk9FIe/GuqXaZsB+vZSTbgIyg53I6cwCtyMvh4Jj3iFWHuRmpVaT7vwJ46/I2WOKLvQWyd0EY380kby5PNUVg==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-33.1.0.tgz",
+      "integrity": "sha512-kD78gMpuRqqA1K63Myvoj2qrhYSnGAUV4Vv1RMJhnlFmyBri3Eww9KokVUfxCbAxWeuK4ykvTAeM4AD+byEmcw==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^33.1.0"
       }
     },
     "victory-tooltip": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-30.6.1.tgz",
-      "integrity": "sha512-Mezqycvoxms6ON6ftBKU8TpB8Ggsiy+1gJREeOt83TfvrIp8DKher33kj83ofD853rPcmRJeMNAz57I1mpXtHA==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-33.1.0.tgz",
+      "integrity": "sha512-bWrBvkd4NTmJzt+H5GCAkRguhvIvAfwms2yPFZVygXIEJR324k45G+m54ATTVjnPzN4JZzmyzqq9XUreYXMB4A==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-voronoi": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-30.6.1.tgz",
-      "integrity": "sha512-bxzYmGROFYtpP3EmmcKwHMDAvpIVNYK+7LNOuYwu0z/IHBT//K2EplWAV90IYIvTdKVT75lgqiYsFOWY78L2yw==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-33.1.0.tgz",
+      "integrity": "sha512-mDx8ylDpk786pccVzEplJkSsSOvBM0E8mFypfx/yGYDeIRvHdDTuGVHN3YmPl+mZM8mZ3sGzMx4IJPRkS6pdtg==",
       "requires": {
         "d3-voronoi": "^1.1.2",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "victory-voronoi-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-30.6.1.tgz",
-      "integrity": "sha512-rHT7rgYLuetgi67CFyM8N3AgomzNi1/tjjUKC2SmD2qq8bBysVXlyzTh2Zx4aTLVX59XNNGAaLxPjUjkZWYY2g==",
-      "optional": true,
+      "version": "33.1.1",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-33.1.1.tgz",
+      "integrity": "sha512-oZtOmF1ODQWmkXgOU3XnR1frEB8ZJaEwIWc1fQVpnmAXhXD4k6a2/B0w9DanHWk2KgcMkmP2c0zriGeSgmNj4Q==",
       "requires": {
-        "d3-voronoi": "^1.1.2",
-        "lodash": "^4.17.5",
+        "delaunay-find": "0.0.4",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1",
-        "victory-tooltip": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0",
+        "victory-tooltip": "^33.1.0"
       }
     },
     "victory-zoom-container": {
-      "version": "30.6.1",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-30.6.1.tgz",
-      "integrity": "sha512-F/b2l6LJjkR1OF+ioU49yGDW0rJJusKqrOFtcSDbnyeSwKkQGkgJ0T+Nv/TN5jSBdC3Wb/kKtwqHRYCrxtt3Zg==",
-      "optional": true,
+      "version": "33.1.0",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-33.1.0.tgz",
+      "integrity": "sha512-CPAxLHnuC4FzmIwA24mNK+VfwWjK8tYwFf+TnKWxV70zoL6lho2eAmbF88QPJGAsav+xCl0bT8/uZNTn7PU7lw==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^30.6.1"
-      },
-      "dependencies": {
-        "victory-core": {
-          "version": "30.6.1",
-          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-30.6.1.tgz",
-          "integrity": "sha512-oP5gHIVnpcp6I8oHPLDlIHqaEJ3lWMQHjwOTKr/ICsbabdtWBd0D8AByrV0qaXm8vgUmvyBhQqH2UCXb1Zh+jA==",
-          "optional": true,
-          "requires": {
-            "d3-ease": "^1.0.0",
-            "d3-interpolate": "^1.1.1",
-            "d3-scale": "^1.0.0",
-            "d3-shape": "^1.2.0",
-            "d3-timer": "^1.0.0",
-            "lodash": "^4.17.5",
-            "prop-types": "^15.5.8",
-            "react-fast-compare": "^2.0.0"
-          }
-        }
+        "victory-core": "^33.1.0"
       }
     },
     "vm-browserify": {
@@ -23180,6 +22803,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -23360,6 +22984,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@data-driven-forms/pf4-component-mapper": "^1.13.4",
     "@patternfly/patternfly-next": "^1.0.175",
-    "@patternfly/react-charts": "2.3.0",
+    "@patternfly/react-charts": "5.0.13",
     "@patternfly/react-tokens": "2.6.31",
     "@patternfly/react-core": "3.104.1",
     "@patternfly/react-icons": "3.14.12",

--- a/src/Charts.scss
+++ b/src/Charts.scss
@@ -4,13 +4,8 @@
     display: inline-flex;
 }
 
-.chart-label{
-    position: relative;
-}
-
 .chart-container{
-    width: 200px;
-    height: 200px;
+    width: 462px;
 }
 
 .card-chart-container{

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -87,7 +87,7 @@ const CompliancePolicies = () => {
                 <Main>
                     <div className="policies-donuts">
                         <Grid gutter='md'>
-                            <LoadingComplianceCards/>;
+                            <LoadingComplianceCards/>
                         </Grid>
                     </div>
                 </Main>

--- a/src/SmartComponents/CompliancePolicyCard/CompliancePolicyCard.js
+++ b/src/SmartComponents/CompliancePolicyCard/CompliancePolicyCard.js
@@ -15,8 +15,8 @@ import {
 } from '@patternfly/react-core';
 import {
     ChartDonut,
-    ChartLabel,
-    ChartTheme
+    ChartThemeColor,
+    ChartThemeVariant
 } from '@patternfly/react-charts';
 import '../../Charts.scss';
 import { fixedPercentage } from '../../Utilities/TextHelper';
@@ -45,30 +45,6 @@ class CompliancePolicyCard extends React.Component {
         ];
         const compliancePercentage = fixedPercentage(Math.floor(100 *
             (donutValues[0].y / (donutValues[0].y + donutValues[1].y))));
-        const label = (
-            <svg
-                className="chart-label"
-                height={300}
-                width={300}
-            >
-                <ChartLabel
-                    style={{ fontSize: 26 }}
-                    text={compliancePercentage}
-                    textAnchor="middle"
-                    verticalAnchor="middle"
-                    x={150}
-                    y={135}
-                />
-                <ChartLabel
-                    style={{ fill: 'var(--pf-global--Color--200)' }}
-                    text="Systems above threshold"
-                    textAnchor="middle"
-                    verticalAnchor="middle"
-                    x={150}
-                    y={165}
-                />
-            </svg>
-        );
 
         return (
             <Card widget-id={this.policy.refId}>
@@ -97,7 +73,7 @@ class CompliancePolicyCard extends React.Component {
                                     </span>
                                 </TextContent>
                             </GridItem>
-                            <GridItem span={8}>
+                            <GridItem span={12}>
                                 <Text
                                     style={{ fontWeight: '500', color: 'var(--pf-global--Color--200)' }}
                                     component={TextVariants.small}
@@ -130,12 +106,15 @@ class CompliancePolicyCard extends React.Component {
                         <GridItem style={{ textAlign: 'center' }} span={12}>
                             <div className='chart-inline'>
                                 <div className='card-chart-container'>
-                                    {label}
                                     <ChartDonut data={donutValues}
                                         identifier={this.policy.name.replace(/ /g, '')}
-                                        theme={ChartTheme.light.blue}
-                                        height={205}
-                                        width={205}
+                                        innerRadius={122}
+                                        themeColor={ChartThemeColor.blue}
+                                        themeVariant={ChartThemeVariant.light}
+                                        title={compliancePercentage}
+                                        subTitle="Systems above threshold"
+                                        height={300}
+                                        width={300}
                                     />
                                 </div>
                             </div>

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -18,9 +18,8 @@ import {
 } from '@redhat-cloud-services/frontend-components';
 import {
     ChartDonut,
-    ChartLegend,
-    ChartLabel,
-    ChartTheme
+    ChartThemeColor,
+    ChartThemeVariant
 } from '@patternfly/react-charts';
 import {
     Text,
@@ -161,31 +160,6 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
     const compliancePercentage = fixedPercentage(Math.floor(100 *
         (donutValues[0].y / (donutValues[0].y + donutValues[1].y))));
 
-    const label = (
-        <svg
-            className="chart-label"
-            height={200}
-            width={200}
-        >
-            <ChartLabel
-                style={{ fontSize: 20 }}
-                text={compliancePercentage}
-                textAnchor="middle"
-                verticalAnchor="middle"
-                x={100}
-                y={90}
-            />
-            <ChartLabel
-                style={{ fill: '#bbb' }}
-                text="Compliant"
-                textAnchor="middle"
-                verticalAnchor="middle"
-                x={100}
-                y={110}
-            />
-        </svg>
-    );
-
     return (
         <React.Fragment>
             <PageHeader>
@@ -212,23 +186,26 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
                     <GridItem sm={12} md={12} lg={12} xl={6}>
                         <div className='chart-inline'>
                             <div className='chart-container'>
-                                {label}
                                 <ChartDonut data={donutValues}
                                     identifier={donutId}
-                                    theme={ChartTheme.light.blue}
+                                    title={compliancePercentage}
+                                    subTitle="Compliant"
+                                    themeColor={ChartThemeColor.blue}
+                                    themeVariant={ChartThemeVariant.light}
+                                    style={{ fontSize: 20 }}
+                                    innerRadius={88}
+                                    width={462}
                                     legendPosition='right'
-                                    height={200}
-                                    width={200}
+                                    legendData={legendData}
+                                    legendOrientation='vertical'
+                                    padding={{
+                                        bottom: 20,
+                                        left: 0,
+                                        right: 250,
+                                        top: 20
+                                    }}
                                 />
                             </div>
-                            <ChartLegend
-                                data={legendData}
-                                orientation={'vertical'}
-                                theme={ChartTheme.light.blue}
-                                y={55}
-                                height={200}
-                                width={200}
-                            />
                         </div>
 
                     </GridItem>

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -81,167 +81,131 @@ exports[`PolicyDetails expect to render without error 1`] = `
           <div
             class="chart-container"
           >
-            <svg
-              class="chart-label"
-              height="200"
-              width="200"
-            >
-              <text
-                direction="inherit"
-                dx="0"
-                dy="7.1"
-                x="100"
-                y="90"
-              >
-                <tspan
-                  dx="0"
-                  style="font-size: 20px; fill: #252525; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  100%
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="100"
-                y="110"
-              >
-                <tspan
-                  dx="0"
-                  style="fill: #bbb; font-size: 14px; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  Compliant
-                </tspan>
-              </text>
-            </svg>
             <div
-              class="VictoryContainer"
-              style="height: 100%; width: 100%; pointer-events: none; position: relative;"
+              class="pf-c-chart"
+              style="pointer-events: none; position: relative; width: 100%; height: auto;"
             >
               <svg
-                aria-labelledby="victory-container-19-title victory-container-19-desc"
-                height="200"
+                height="230"
                 role="img"
-                style="pointer-events: all; width: 100%; height: 100%;"
-                viewBox="0 0 200 200"
-                width="200"
+                style="pointer-events: all; width: 100%; height: auto;"
+                viewBox="0 0 462 230"
+                width="462"
               >
                 <g>
                   <path
-                    d="M1.0378342131579386,-87.99387990164998A88,88,0,1,1,-2.5733811020175525,-87.96236530303047L-2.4337511686168343,-79.96297177599926A80,80,0,1,0,1.0378342131579519,-79.99326784265035Z"
+                    d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
                     role="presentation"
                     shape-rendering="auto"
                     style="fill: #06c; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    transform="translate(106, 115)"
                   />
                   <path
-                    d="M-0.7679351238568747,-87.99664922964708L-0.698122839869886,-79.9969538451337Z"
+                    d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
                     role="presentation"
                     shape-rendering="auto"
-                    style="fill: #bee1f4; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    style="fill: #8bc1f7; padding: 8px; stroke: transparent; stroke-width: 1;"
+                    transform="translate(106, 115)"
                   />
                 </g>
+                <g>
+                  <rect
+                    height="61.809999999999995"
+                    role="presentation"
+                    shape-rendering="auto"
+                    style="fill: none;"
+                    vector-effect="non-scaling-stroke"
+                    width="225.29780853517875"
+                    x="209"
+                    y="86.095"
+                  />
+                  <path
+                    d="M 218.128, 104.967
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #06c;"
+                  />
+                  <path
+                    d="M 218.128, 135.872
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #8bc1f7;"
+                  />
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-0"
+                    x="239.8"
+                    y="100.095"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      1 System compliant
+                    </tspan>
+                  </text>
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-1"
+                    x="239.8"
+                    y="131"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      0 Systems non-compliant
+                    </tspan>
+                  </text>
+                </g>
+                <text
+                  direction="inherit"
+                  dx="0"
+                  dy="1.200000000000001"
+                  x="106"
+                  y="115"
+                >
+                  <tspan
+                    dx="0"
+                    style="font-size: 24px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); fill: #252525; stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    100%
+                  </tspan>
+                  <tspan
+                    dx="0"
+                    dy="19"
+                    style="fill: #b8bbbe; font-size: 14px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    Compliant
+                  </tspan>
+                </text>
               </svg>
               <div
-                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: 100%;"
+                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: auto;"
               >
                 <svg
-                  height="200"
-                  style="overflow: visible; width: 100%; height: 100%;"
-                  viewBox="0 0 200 200"
-                  width="200"
+                  height="230"
+                  style="overflow: visible; width: 100%; height: auto;"
+                  viewBox="0 0 462 230"
+                  width="462"
                 />
               </div>
-            </div>
-          </div>
-          <div
-            class="VictoryContainer"
-            style="pointer-events: none; position: relative; width: 200px; height: 200px;"
-          >
-            <svg
-              aria-labelledby="victory-container-20-title victory-container-20-desc"
-              height="200"
-              role="img"
-              style="pointer-events: all; width: 200px; height: 200px;"
-              width="200"
-            >
-              <rect
-                height="61.809999999999995"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: none;"
-                vector-effect="non-scaling-stroke"
-                width="202.5554655870445"
-                x="0"
-                y="55"
-              />
-              <path
-                d="M 9.128, 73.872
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #06c;"
-              />
-              <path
-                d="M 9.128, 104.777
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #bee1f4;"
-              />
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="69"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  1 System compliant
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="99.905"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  0 Systems non-compliant
-                </tspan>
-              </text>
-            </svg>
-            <div
-              style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 200px; height: 200px;"
-            >
-              <svg
-                height="200"
-                style="overflow: visible; width: 200px; height: 200px;"
-                width="200"
-              />
             </div>
           </div>
         </div>
@@ -412,167 +376,131 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
           <div
             class="chart-container"
           >
-            <svg
-              class="chart-label"
-              height="200"
-              width="200"
-            >
-              <text
-                direction="inherit"
-                dx="0"
-                dy="7.1"
-                x="100"
-                y="90"
-              >
-                <tspan
-                  dx="0"
-                  style="font-size: 20px; fill: #252525; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  100%
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="100"
-                y="110"
-              >
-                <tspan
-                  dx="0"
-                  style="fill: #bbb; font-size: 14px; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  Compliant
-                </tspan>
-              </text>
-            </svg>
             <div
-              class="VictoryContainer"
-              style="height: 100%; width: 100%; pointer-events: none; position: relative;"
+              class="pf-c-chart"
+              style="pointer-events: none; position: relative; width: 100%; height: auto;"
             >
               <svg
-                aria-labelledby="victory-container-3-title victory-container-3-desc"
-                height="200"
+                height="230"
                 role="img"
-                style="pointer-events: all; width: 100%; height: 100%;"
-                viewBox="0 0 200 200"
-                width="200"
+                style="pointer-events: all; width: 100%; height: auto;"
+                viewBox="0 0 462 230"
+                width="462"
               >
                 <g>
                   <path
-                    d="M1.0378342131579386,-87.99387990164998A88,88,0,1,1,-2.5733811020175525,-87.96236530303047L-2.4337511686168343,-79.96297177599926A80,80,0,1,0,1.0378342131579519,-79.99326784265035Z"
+                    d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
                     role="presentation"
                     shape-rendering="auto"
                     style="fill: #06c; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    transform="translate(106, 115)"
                   />
                   <path
-                    d="M-0.7679351238568747,-87.99664922964708L-0.698122839869886,-79.9969538451337Z"
+                    d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
                     role="presentation"
                     shape-rendering="auto"
-                    style="fill: #bee1f4; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    style="fill: #8bc1f7; padding: 8px; stroke: transparent; stroke-width: 1;"
+                    transform="translate(106, 115)"
                   />
                 </g>
+                <g>
+                  <rect
+                    height="61.809999999999995"
+                    role="presentation"
+                    shape-rendering="auto"
+                    style="fill: none;"
+                    vector-effect="non-scaling-stroke"
+                    width="225.29780853517875"
+                    x="209"
+                    y="86.095"
+                  />
+                  <path
+                    d="M 218.128, 104.967
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #06c;"
+                  />
+                  <path
+                    d="M 218.128, 135.872
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #8bc1f7;"
+                  />
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-0"
+                    x="239.8"
+                    y="100.095"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      1 System compliant
+                    </tspan>
+                  </text>
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-1"
+                    x="239.8"
+                    y="131"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      0 Systems non-compliant
+                    </tspan>
+                  </text>
+                </g>
+                <text
+                  direction="inherit"
+                  dx="0"
+                  dy="1.200000000000001"
+                  x="106"
+                  y="115"
+                >
+                  <tspan
+                    dx="0"
+                    style="font-size: 24px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); fill: #252525; stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    100%
+                  </tspan>
+                  <tspan
+                    dx="0"
+                    dy="19"
+                    style="fill: #b8bbbe; font-size: 14px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    Compliant
+                  </tspan>
+                </text>
               </svg>
               <div
-                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: 100%;"
+                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: auto;"
               >
                 <svg
-                  height="200"
-                  style="overflow: visible; width: 100%; height: 100%;"
-                  viewBox="0 0 200 200"
-                  width="200"
+                  height="230"
+                  style="overflow: visible; width: 100%; height: auto;"
+                  viewBox="0 0 462 230"
+                  width="462"
                 />
               </div>
-            </div>
-          </div>
-          <div
-            class="VictoryContainer"
-            style="pointer-events: none; position: relative; width: 200px; height: 200px;"
-          >
-            <svg
-              aria-labelledby="victory-container-4-title victory-container-4-desc"
-              height="200"
-              role="img"
-              style="pointer-events: all; width: 200px; height: 200px;"
-              width="200"
-            >
-              <rect
-                height="61.809999999999995"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: none;"
-                vector-effect="non-scaling-stroke"
-                width="202.5554655870445"
-                x="0"
-                y="55"
-              />
-              <path
-                d="M 9.128, 73.872
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #06c;"
-              />
-              <path
-                d="M 9.128, 104.777
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #bee1f4;"
-              />
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="69"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  1 System compliant
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="99.905"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  0 Systems non-compliant
-                </tspan>
-              </text>
-            </svg>
-            <div
-              style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 200px; height: 200px;"
-            >
-              <svg
-                height="200"
-                style="overflow: visible; width: 200px; height: 200px;"
-                width="200"
-              />
             </div>
           </div>
         </div>
@@ -743,167 +671,131 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
           <div
             class="chart-container"
           >
-            <svg
-              class="chart-label"
-              height="200"
-              width="200"
-            >
-              <text
-                direction="inherit"
-                dx="0"
-                dy="7.1"
-                x="100"
-                y="90"
-              >
-                <tspan
-                  dx="0"
-                  style="font-size: 20px; fill: #252525; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  100%
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="100"
-                y="110"
-              >
-                <tspan
-                  dx="0"
-                  style="fill: #bbb; font-size: 14px; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  Compliant
-                </tspan>
-              </text>
-            </svg>
             <div
-              class="VictoryContainer"
-              style="height: 100%; width: 100%; pointer-events: none; position: relative;"
+              class="pf-c-chart"
+              style="pointer-events: none; position: relative; width: 100%; height: auto;"
             >
               <svg
-                aria-labelledby="victory-container-15-title victory-container-15-desc"
-                height="200"
+                height="230"
                 role="img"
-                style="pointer-events: all; width: 100%; height: 100%;"
-                viewBox="0 0 200 200"
-                width="200"
+                style="pointer-events: all; width: 100%; height: auto;"
+                viewBox="0 0 462 230"
+                width="462"
               >
                 <g>
                   <path
-                    d="M1.0378342131579386,-87.99387990164998A88,88,0,1,1,-2.5733811020175525,-87.96236530303047L-2.4337511686168343,-79.96297177599926A80,80,0,1,0,1.0378342131579519,-79.99326784265035Z"
+                    d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
                     role="presentation"
                     shape-rendering="auto"
                     style="fill: #06c; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    transform="translate(106, 115)"
                   />
                   <path
-                    d="M-0.7679351238568747,-87.99664922964708L-0.698122839869886,-79.9969538451337Z"
+                    d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
                     role="presentation"
                     shape-rendering="auto"
-                    style="fill: #bee1f4; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    style="fill: #8bc1f7; padding: 8px; stroke: transparent; stroke-width: 1;"
+                    transform="translate(106, 115)"
                   />
                 </g>
+                <g>
+                  <rect
+                    height="61.809999999999995"
+                    role="presentation"
+                    shape-rendering="auto"
+                    style="fill: none;"
+                    vector-effect="non-scaling-stroke"
+                    width="225.29780853517875"
+                    x="209"
+                    y="86.095"
+                  />
+                  <path
+                    d="M 218.128, 104.967
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #06c;"
+                  />
+                  <path
+                    d="M 218.128, 135.872
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #8bc1f7;"
+                  />
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-0"
+                    x="239.8"
+                    y="100.095"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      1 System compliant
+                    </tspan>
+                  </text>
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-1"
+                    x="239.8"
+                    y="131"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      0 Systems non-compliant
+                    </tspan>
+                  </text>
+                </g>
+                <text
+                  direction="inherit"
+                  dx="0"
+                  dy="1.200000000000001"
+                  x="106"
+                  y="115"
+                >
+                  <tspan
+                    dx="0"
+                    style="font-size: 24px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); fill: #252525; stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    100%
+                  </tspan>
+                  <tspan
+                    dx="0"
+                    dy="19"
+                    style="fill: #b8bbbe; font-size: 14px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    Compliant
+                  </tspan>
+                </text>
               </svg>
               <div
-                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: 100%;"
+                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: auto;"
               >
                 <svg
-                  height="200"
-                  style="overflow: visible; width: 100%; height: 100%;"
-                  viewBox="0 0 200 200"
-                  width="200"
+                  height="230"
+                  style="overflow: visible; width: 100%; height: auto;"
+                  viewBox="0 0 462 230"
+                  width="462"
                 />
               </div>
-            </div>
-          </div>
-          <div
-            class="VictoryContainer"
-            style="pointer-events: none; position: relative; width: 200px; height: 200px;"
-          >
-            <svg
-              aria-labelledby="victory-container-16-title victory-container-16-desc"
-              height="200"
-              role="img"
-              style="pointer-events: all; width: 200px; height: 200px;"
-              width="200"
-            >
-              <rect
-                height="61.809999999999995"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: none;"
-                vector-effect="non-scaling-stroke"
-                width="202.5554655870445"
-                x="0"
-                y="55"
-              />
-              <path
-                d="M 9.128, 73.872
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #06c;"
-              />
-              <path
-                d="M 9.128, 104.777
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #bee1f4;"
-              />
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="69"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  1 System compliant
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="99.905"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  0 Systems non-compliant
-                </tspan>
-              </text>
-            </svg>
-            <div
-              style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 200px; height: 200px;"
-            >
-              <svg
-                height="200"
-                style="overflow: visible; width: 200px; height: 200px;"
-                width="200"
-              />
             </div>
           </div>
         </div>
@@ -1053,36 +945,6 @@ exports[`PolicyDetailsQuery passes loading on to SystemTable 1`] = `
           <div
             className="chart-container"
           >
-            <svg
-              className="chart-label"
-              height={200}
-              width={200}
-            >
-              <ChartLabel
-                style={
-                  Object {
-                    "fontSize": 20,
-                  }
-                }
-                text="100%"
-                textAnchor="middle"
-                verticalAnchor="middle"
-                x={100}
-                y={90}
-              />
-              <ChartLabel
-                style={
-                  Object {
-                    "fill": "#bbb",
-                  }
-                }
-                text="Compliant"
-                textAnchor="middle"
-                verticalAnchor="middle"
-                x={100}
-                y={110}
-              />
-            </svg>
             <ChartDonut
               data={
                 Array [
@@ -1096,922 +958,40 @@ exports[`PolicyDetailsQuery passes loading on to SystemTable 1`] = `
                   },
                 ]
               }
-              height={200}
               identifier="profile1"
+              innerRadius={88}
+              legendData={
+                Array [
+                  Object {
+                    "name": "1 System compliant",
+                  },
+                  Object {
+                    "name": "0 Systems non-compliant",
+                  },
+                ]
+              }
+              legendOrientation="vertical"
               legendPosition="right"
-              theme={
+              padding={
                 Object {
-                  "area": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "data": Object {
-                        "fill": "#bee1f4",
-                        "fillOpacity": 0.4,
-                        "stroke": "#73bcf7",
-                        "strokeWidth": 2,
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                        "textAnchor": "middle",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "axis": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "axis": Object {
-                        "fill": "transparent",
-                        "stroke": "#737679",
-                        "strokeLinecap": "round",
-                        "strokeLinejoin": "round",
-                        "strokeWidth": 1,
-                      },
-                      "axisLabel": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 100,
-                        "stroke": "transparent",
-                        "textAnchor": "middle",
-                      },
-                      "grid": Object {
-                        "fill": "none",
-                        "pointerEvents": "painted",
-                        "stroke": "none",
-                      },
-                      "tickLabels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                      },
-                      "ticks": Object {
-                        "fill": "transparent",
-                        "size": 1,
-                        "stroke": "transparent",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "bar": Object {
-                    "barWidth": 10,
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "data": Object {
-                        "stroke": "none",
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "boxplot": Object {
-                    "boxWidth": 20,
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "max": Object {
-                        "padding": 8,
-                        "stroke": "#73bcf7",
-                        "strokeWidth": 1,
-                      },
-                      "maxLabels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                      },
-                      "median": Object {
-                        "padding": 8,
-                        "stroke": "#73bcf7",
-                        "strokeWidth": 1,
-                      },
-                      "medianLabels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                      },
-                      "min": Object {
-                        "padding": 8,
-                        "stroke": "#73bcf7",
-                        "strokeWidth": 1,
-                      },
-                      "minLabels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                      },
-                      "q1": Object {
-                        "fill": "#bee1f4",
-                        "padding": 8,
-                      },
-                      "q1Labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                      },
-                      "q3": Object {
-                        "fill": "#bee1f4",
-                        "padding": 8,
-                      },
-                      "q3Labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "candlestick": Object {
-                    "candleColors": Object {
-                      "negative": "#73bcf7",
-                      "positive": "#bee1f4",
-                    },
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "data": Object {
-                        "stroke": "#73bcf7",
-                        "strokeWidth": 1,
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                        "textAnchor": "middle",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "chart": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "parent": Object {
-                        "border": "1px solid #bee1f4",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "errorbar": Object {
-                    "borderWidth": 8,
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "data": Object {
-                        "fill": "transparent",
-                        "stroke": "#73bcf7",
-                        "strokeWidth": 2,
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                        "textAnchor": "middle",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "group": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "width": 451,
-                  },
-                  "legend": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "gutter": 20,
-                    "orientation": "horizontal",
-                    "style": Object {
-                      "data": Object {
-                        "type": "square",
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                      },
-                      "title": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 2,
-                        "stroke": "transparent",
-                      },
-                    },
-                    "titleOrientation": "top",
-                  },
-                  "line": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "data": Object {
-                        "fill": "transparent",
-                        "stroke": "#73bcf7",
-                        "strokeWidth": 2,
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                        "textAnchor": "middle",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "pie": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "padding": 20,
-                    "style": Object {
-                      "data": Object {
-                        "padding": 8,
-                        "stroke": "transparent",
-                        "strokeWidth": 1,
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 8,
-                        "stroke": "transparent",
-                      },
-                    },
-                  },
-                  "scatter": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "data": Object {
-                        "fill": "#bee1f4",
-                        "stroke": "transparent",
-                        "strokeWidth": 0,
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 10,
-                        "stroke": "transparent",
-                        "textAnchor": "middle",
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "stack": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "data": Object {
-                        "stroke": "#fff",
-                        "strokeWidth": 1,
-                      },
-                    },
-                    "width": 451,
-                  },
-                  "tooltip": Object {
-                    "cornerRadius": 0,
-                    "flyoutStyle": Object {
-                      "cornerRadius": 0,
-                      "fill": "#fff",
-                      "pointerEvents": "none",
-                      "stroke": "#151515",
-                      "strokeWidth": 1,
-                    },
-                    "pointerLength": 10,
-                    "style": Object {
-                      "fill": "#fff",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 8,
-                      "pointerEvents": "none",
-                      "stroke": "#151515",
-                      "textAnchor": "middle",
-                    },
-                  },
-                  "voronoi": Object {
-                    "colorScale": Array [
-                      "#06c",
-                      "#bee1f4",
-                      "#73bcf7",
-                      "#0066ff",
-                    ],
-                    "height": 301,
-                    "padding": 8,
-                    "style": Object {
-                      "data": Object {
-                        "fill": "transparent",
-                        "stroke": "transparent",
-                        "strokeWidth": 0,
-                      },
-                      "flyout": Object {
-                        "fill": "#fff",
-                        "pointerEvents": "none",
-                        "strokeWidth": 1,
-                      },
-                      "labels": Object {
-                        "fill": "#151515",
-                        "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                        "fontSize": 14,
-                        "letterSpacing": "normal",
-                        "padding": 8,
-                        "pointerEvents": "none",
-                        "stroke": "transparent",
-                        "textAnchor": "middle",
-                      },
-                    },
-                    "width": 451,
-                  },
+                  "bottom": 20,
+                  "left": 0,
+                  "right": 250,
+                  "top": 20,
                 }
               }
-              width={200}
+              style={
+                Object {
+                  "fontSize": 20,
+                }
+              }
+              subTitle="Compliant"
+              themeColor="blue"
+              themeVariant="light"
+              title="100%"
+              width={462}
             />
           </div>
-          <ChartLegend
-            data={
-              Array [
-                Object {
-                  "name": "1 System compliant",
-                },
-                Object {
-                  "name": "0 Systems non-compliant",
-                },
-              ]
-            }
-            height={200}
-            orientation="vertical"
-            theme={
-              Object {
-                "area": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "data": Object {
-                      "fill": "#bee1f4",
-                      "fillOpacity": 0.4,
-                      "stroke": "#73bcf7",
-                      "strokeWidth": 2,
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                      "textAnchor": "middle",
-                    },
-                  },
-                  "width": 451,
-                },
-                "axis": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "axis": Object {
-                      "fill": "transparent",
-                      "stroke": "#737679",
-                      "strokeLinecap": "round",
-                      "strokeLinejoin": "round",
-                      "strokeWidth": 1,
-                    },
-                    "axisLabel": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 100,
-                      "stroke": "transparent",
-                      "textAnchor": "middle",
-                    },
-                    "grid": Object {
-                      "fill": "none",
-                      "pointerEvents": "painted",
-                      "stroke": "none",
-                    },
-                    "tickLabels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                    },
-                    "ticks": Object {
-                      "fill": "transparent",
-                      "size": 1,
-                      "stroke": "transparent",
-                    },
-                  },
-                  "width": 451,
-                },
-                "bar": Object {
-                  "barWidth": 10,
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "data": Object {
-                      "stroke": "none",
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                    },
-                  },
-                  "width": 451,
-                },
-                "boxplot": Object {
-                  "boxWidth": 20,
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "max": Object {
-                      "padding": 8,
-                      "stroke": "#73bcf7",
-                      "strokeWidth": 1,
-                    },
-                    "maxLabels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                    },
-                    "median": Object {
-                      "padding": 8,
-                      "stroke": "#73bcf7",
-                      "strokeWidth": 1,
-                    },
-                    "medianLabels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                    },
-                    "min": Object {
-                      "padding": 8,
-                      "stroke": "#73bcf7",
-                      "strokeWidth": 1,
-                    },
-                    "minLabels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                    },
-                    "q1": Object {
-                      "fill": "#bee1f4",
-                      "padding": 8,
-                    },
-                    "q1Labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                    },
-                    "q3": Object {
-                      "fill": "#bee1f4",
-                      "padding": 8,
-                    },
-                    "q3Labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                    },
-                  },
-                  "width": 451,
-                },
-                "candlestick": Object {
-                  "candleColors": Object {
-                    "negative": "#73bcf7",
-                    "positive": "#bee1f4",
-                  },
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "data": Object {
-                      "stroke": "#73bcf7",
-                      "strokeWidth": 1,
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                      "textAnchor": "middle",
-                    },
-                  },
-                  "width": 451,
-                },
-                "chart": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "parent": Object {
-                      "border": "1px solid #bee1f4",
-                    },
-                  },
-                  "width": 451,
-                },
-                "errorbar": Object {
-                  "borderWidth": 8,
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "data": Object {
-                      "fill": "transparent",
-                      "stroke": "#73bcf7",
-                      "strokeWidth": 2,
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                      "textAnchor": "middle",
-                    },
-                  },
-                  "width": 451,
-                },
-                "group": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "width": 451,
-                },
-                "legend": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "gutter": 20,
-                  "orientation": "horizontal",
-                  "style": Object {
-                    "data": Object {
-                      "type": "square",
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                    },
-                    "title": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 2,
-                      "stroke": "transparent",
-                    },
-                  },
-                  "titleOrientation": "top",
-                },
-                "line": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "data": Object {
-                      "fill": "transparent",
-                      "stroke": "#73bcf7",
-                      "strokeWidth": 2,
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                      "textAnchor": "middle",
-                    },
-                  },
-                  "width": 451,
-                },
-                "pie": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "padding": 20,
-                  "style": Object {
-                    "data": Object {
-                      "padding": 8,
-                      "stroke": "transparent",
-                      "strokeWidth": 1,
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 8,
-                      "stroke": "transparent",
-                    },
-                  },
-                },
-                "scatter": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "data": Object {
-                      "fill": "#bee1f4",
-                      "stroke": "transparent",
-                      "strokeWidth": 0,
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 10,
-                      "stroke": "transparent",
-                      "textAnchor": "middle",
-                    },
-                  },
-                  "width": 451,
-                },
-                "stack": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "data": Object {
-                      "stroke": "#fff",
-                      "strokeWidth": 1,
-                    },
-                  },
-                  "width": 451,
-                },
-                "tooltip": Object {
-                  "cornerRadius": 0,
-                  "flyoutStyle": Object {
-                    "cornerRadius": 0,
-                    "fill": "#fff",
-                    "pointerEvents": "none",
-                    "stroke": "#151515",
-                    "strokeWidth": 1,
-                  },
-                  "pointerLength": 10,
-                  "style": Object {
-                    "fill": "#fff",
-                    "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                    "fontSize": 14,
-                    "letterSpacing": "normal",
-                    "padding": 8,
-                    "pointerEvents": "none",
-                    "stroke": "#151515",
-                    "textAnchor": "middle",
-                  },
-                },
-                "voronoi": Object {
-                  "colorScale": Array [
-                    "#06c",
-                    "#bee1f4",
-                    "#73bcf7",
-                    "#0066ff",
-                  ],
-                  "height": 301,
-                  "padding": 8,
-                  "style": Object {
-                    "data": Object {
-                      "fill": "transparent",
-                      "stroke": "transparent",
-                      "strokeWidth": 0,
-                    },
-                    "flyout": Object {
-                      "fill": "#fff",
-                      "pointerEvents": "none",
-                      "strokeWidth": 1,
-                    },
-                    "labels": Object {
-                      "fill": "#151515",
-                      "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
-                      "fontSize": 14,
-                      "letterSpacing": "normal",
-                      "padding": 8,
-                      "pointerEvents": "none",
-                      "stroke": "transparent",
-                      "textAnchor": "middle",
-                    },
-                  },
-                  "width": 451,
-                },
-              }
-            }
-            width={200}
-            y={55}
-          />
         </div>
       </GridItem>
       <GridItem
@@ -2242,167 +1222,131 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
           <div
             class="chart-container"
           >
-            <svg
-              class="chart-label"
-              height="200"
-              width="200"
-            >
-              <text
-                direction="inherit"
-                dx="0"
-                dy="7.1"
-                x="100"
-                y="90"
-              >
-                <tspan
-                  dx="0"
-                  style="font-size: 20px; fill: #252525; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  100%
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="100"
-                y="110"
-              >
-                <tspan
-                  dx="0"
-                  style="fill: #bbb; font-size: 14px; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  Compliant
-                </tspan>
-              </text>
-            </svg>
             <div
-              class="VictoryContainer"
-              style="height: 100%; width: 100%; pointer-events: none; position: relative;"
+              class="pf-c-chart"
+              style="pointer-events: none; position: relative; width: 100%; height: auto;"
             >
               <svg
-                aria-labelledby="victory-container-7-title victory-container-7-desc"
-                height="200"
+                height="230"
                 role="img"
-                style="pointer-events: all; width: 100%; height: 100%;"
-                viewBox="0 0 200 200"
-                width="200"
+                style="pointer-events: all; width: 100%; height: auto;"
+                viewBox="0 0 462 230"
+                width="462"
               >
                 <g>
                   <path
-                    d="M1.0378342131579386,-87.99387990164998A88,88,0,1,1,-2.5733811020175525,-87.96236530303047L-2.4337511686168343,-79.96297177599926A80,80,0,1,0,1.0378342131579519,-79.99326784265035Z"
+                    d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
                     role="presentation"
                     shape-rendering="auto"
                     style="fill: #06c; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    transform="translate(106, 115)"
                   />
                   <path
-                    d="M-0.7679351238568747,-87.99664922964708L-0.698122839869886,-79.9969538451337Z"
+                    d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
                     role="presentation"
                     shape-rendering="auto"
-                    style="fill: #bee1f4; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    style="fill: #8bc1f7; padding: 8px; stroke: transparent; stroke-width: 1;"
+                    transform="translate(106, 115)"
                   />
                 </g>
+                <g>
+                  <rect
+                    height="61.809999999999995"
+                    role="presentation"
+                    shape-rendering="auto"
+                    style="fill: none;"
+                    vector-effect="non-scaling-stroke"
+                    width="225.29780853517875"
+                    x="209"
+                    y="86.095"
+                  />
+                  <path
+                    d="M 218.128, 104.967
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #06c;"
+                  />
+                  <path
+                    d="M 218.128, 135.872
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #8bc1f7;"
+                  />
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-0"
+                    x="239.8"
+                    y="100.095"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      1 System compliant
+                    </tspan>
+                  </text>
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-1"
+                    x="239.8"
+                    y="131"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      0 Systems non-compliant
+                    </tspan>
+                  </text>
+                </g>
+                <text
+                  direction="inherit"
+                  dx="0"
+                  dy="1.200000000000001"
+                  x="106"
+                  y="115"
+                >
+                  <tspan
+                    dx="0"
+                    style="font-size: 24px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); fill: #252525; stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    100%
+                  </tspan>
+                  <tspan
+                    dx="0"
+                    dy="19"
+                    style="fill: #b8bbbe; font-size: 14px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    Compliant
+                  </tspan>
+                </text>
               </svg>
               <div
-                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: 100%;"
+                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: auto;"
               >
                 <svg
-                  height="200"
-                  style="overflow: visible; width: 100%; height: 100%;"
-                  viewBox="0 0 200 200"
-                  width="200"
+                  height="230"
+                  style="overflow: visible; width: 100%; height: auto;"
+                  viewBox="0 0 462 230"
+                  width="462"
                 />
               </div>
-            </div>
-          </div>
-          <div
-            class="VictoryContainer"
-            style="pointer-events: none; position: relative; width: 200px; height: 200px;"
-          >
-            <svg
-              aria-labelledby="victory-container-8-title victory-container-8-desc"
-              height="200"
-              role="img"
-              style="pointer-events: all; width: 200px; height: 200px;"
-              width="200"
-            >
-              <rect
-                height="61.809999999999995"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: none;"
-                vector-effect="non-scaling-stroke"
-                width="202.5554655870445"
-                x="0"
-                y="55"
-              />
-              <path
-                d="M 9.128, 73.872
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #06c;"
-              />
-              <path
-                d="M 9.128, 104.777
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #bee1f4;"
-              />
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="69"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  1 System compliant
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="99.905"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  0 Systems non-compliant
-                </tspan>
-              </text>
-            </svg>
-            <div
-              style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 200px; height: 200px;"
-            >
-              <svg
-                height="200"
-                style="overflow: visible; width: 200px; height: 200px;"
-                width="200"
-              />
             </div>
           </div>
         </div>
@@ -2573,167 +1517,131 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
           <div
             class="chart-container"
           >
-            <svg
-              class="chart-label"
-              height="200"
-              width="200"
-            >
-              <text
-                direction="inherit"
-                dx="0"
-                dy="7.1"
-                x="100"
-                y="90"
-              >
-                <tspan
-                  dx="0"
-                  style="font-size: 20px; fill: #252525; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  100%
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="100"
-                y="110"
-              >
-                <tspan
-                  dx="0"
-                  style="fill: #bbb; font-size: 14px; font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; stroke: transparent;"
-                  text-anchor="middle"
-                  x="100"
-                >
-                  Compliant
-                </tspan>
-              </text>
-            </svg>
             <div
-              class="VictoryContainer"
-              style="height: 100%; width: 100%; pointer-events: none; position: relative;"
+              class="pf-c-chart"
+              style="pointer-events: none; position: relative; width: 100%; height: auto;"
             >
               <svg
-                aria-labelledby="victory-container-11-title victory-container-11-desc"
-                height="200"
+                height="230"
                 role="img"
-                style="pointer-events: all; width: 100%; height: 100%;"
-                viewBox="0 0 200 200"
-                width="200"
+                style="pointer-events: all; width: 100%; height: auto;"
+                viewBox="0 0 462 230"
+                width="462"
               >
                 <g>
                   <path
-                    d="M1.0378342131579386,-87.99387990164998A88,88,0,1,1,-2.5733811020175525,-87.96236530303047L-2.4337511686168343,-79.96297177599926A80,80,0,1,0,1.0378342131579519,-79.99326784265035Z"
+                    d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
                     role="presentation"
                     shape-rendering="auto"
                     style="fill: #06c; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    transform="translate(106, 115)"
                   />
                   <path
-                    d="M-0.7679351238568747,-87.99664922964708L-0.698122839869886,-79.9969538451337Z"
+                    d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
                     role="presentation"
                     shape-rendering="auto"
-                    style="fill: #bee1f4; padding: 8px; stroke: transparent; stroke-width: 1;"
-                    transform="translate(100, 100)"
+                    style="fill: #8bc1f7; padding: 8px; stroke: transparent; stroke-width: 1;"
+                    transform="translate(106, 115)"
                   />
                 </g>
+                <g>
+                  <rect
+                    height="61.809999999999995"
+                    role="presentation"
+                    shape-rendering="auto"
+                    style="fill: none;"
+                    vector-effect="non-scaling-stroke"
+                    width="225.29780853517875"
+                    x="209"
+                    y="86.095"
+                  />
+                  <path
+                    d="M 218.128, 104.967
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #06c;"
+                  />
+                  <path
+                    d="M 218.128, 135.872
+      h9.744000000000028
+      v-9.744000000000028
+      h-9.744000000000028
+      z"
+                    style="fill: #8bc1f7;"
+                  />
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-0"
+                    x="239.8"
+                    y="100.095"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      1 System compliant
+                    </tspan>
+                  </text>
+                  <text
+                    direction="inherit"
+                    dx="0"
+                    dy="4.97"
+                    id="legend-labels-1"
+                    x="239.8"
+                    y="131"
+                  >
+                    <tspan
+                      dx="0"
+                      style="font-family: var(--pf-chart-global--FontFamily); font-size: 14px; letter-spacing: var(--pf-chart-global--letter-spacing); padding: 10px; stroke: transparent; fill: #252525;"
+                      text-anchor="start"
+                      x="239.8"
+                    >
+                      0 Systems non-compliant
+                    </tspan>
+                  </text>
+                </g>
+                <text
+                  direction="inherit"
+                  dx="0"
+                  dy="1.200000000000001"
+                  x="106"
+                  y="115"
+                >
+                  <tspan
+                    dx="0"
+                    style="font-size: 24px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); fill: #252525; stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    100%
+                  </tspan>
+                  <tspan
+                    dx="0"
+                    dy="19"
+                    style="fill: #b8bbbe; font-size: 14px; font-family: var(--pf-chart-global--FontFamily); letter-spacing: var(--pf-chart-global--letter-spacing); stroke: transparent;"
+                    text-anchor="middle"
+                    x="106"
+                  >
+                    Compliant
+                  </tspan>
+                </text>
               </svg>
               <div
-                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: 100%;"
+                style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 100%; height: auto;"
               >
                 <svg
-                  height="200"
-                  style="overflow: visible; width: 100%; height: 100%;"
-                  viewBox="0 0 200 200"
-                  width="200"
+                  height="230"
+                  style="overflow: visible; width: 100%; height: auto;"
+                  viewBox="0 0 462 230"
+                  width="462"
                 />
               </div>
-            </div>
-          </div>
-          <div
-            class="VictoryContainer"
-            style="pointer-events: none; position: relative; width: 200px; height: 200px;"
-          >
-            <svg
-              aria-labelledby="victory-container-12-title victory-container-12-desc"
-              height="200"
-              role="img"
-              style="pointer-events: all; width: 200px; height: 200px;"
-              width="200"
-            >
-              <rect
-                height="61.809999999999995"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: none;"
-                vector-effect="non-scaling-stroke"
-                width="202.5554655870445"
-                x="0"
-                y="55"
-              />
-              <path
-                d="M 9.128, 73.872
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #06c;"
-              />
-              <path
-                d="M 9.128, 104.777
-      h9.744
-      v-9.744
-      h-9.744
-      z"
-                role="presentation"
-                shape-rendering="auto"
-                style="fill: #bee1f4;"
-              />
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="69"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  1 System compliant
-                </tspan>
-              </text>
-              <text
-                direction="inherit"
-                dx="0"
-                dy="4.97"
-                x="30.8"
-                y="99.905"
-              >
-                <tspan
-                  dx="0"
-                  style="font-family: 'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; fill: #151515; stroke: transparent;"
-                  text-anchor="start"
-                  x="30.8"
-                >
-                  0 Systems non-compliant
-                </tspan>
-              </text>
-            </svg>
-            <div
-              style="z-index: 99; position: absolute; top: 0px; left: 0px; width: 200px; height: 200px;"
-            >
-              <svg
-                height="200"
-                style="overflow: visible; width: 200px; height: 200px;"
-                width="200"
-              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
 "Systems meet compliance threshold" doesn't need to wrap
Tooltips on charts should be the black ones
  - I needed to update Patternfly-charts to the latest version, which actually allows us to remove a lot of code. 
 - Removed a semicolon in the loading state

![Screenshot from 2019-10-21 13-00-02](https://user-images.githubusercontent.com/598891/67199943-b5e05280-f402-11e9-8861-32677d063b0b.png)

![Screenshot from 2019-10-21 12-59-49](https://user-images.githubusercontent.com/598891/67199944-b678e900-f402-11e9-9dfc-32283ddd561c.png)

cc @katierik