### PR TITLE
RHICOMPL-401 - Enable remediations button only if remediation available

### DIFF
--- a/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
+++ b/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
@@ -112,13 +112,17 @@ class ComplianceRemediationButton extends React.Component {
         dispatchAction(addNotification(result.getNotification()));
     }
 
-    render() {
+    noRemediationAvailable = () => {
         const { allSystems } = this.props;
+        return !allSystems.some((system) => system.ruleObjectsFailed.some((rule) => rule.remediationAvailable));
+    }
+
+    render() {
 
         return (
             <React.Fragment>
                 <RemediationButton
-                    isDisabled={ allSystems.length === 0 || allSystems[0].ruleObjectsFailed.length === 0 }
+                    isDisabled={ this.noRemediationAvailable() }
                     dataProvider={ this.dataProvider }
                     onRemediationCreated={ this.onCreated }
                 >


### PR DESCRIPTION
Here's a system with remediations available:
![Screenshot from 2019-10-29 11-12-28](https://user-images.githubusercontent.com/598891/67758183-7c7c9800-fa3d-11e9-9256-b68168de41c9.png)

And here's another system *with rules failing* but NO remediations available, the button should remain disabled like this:
![Screenshot from 2019-10-29 11-14-09](https://user-images.githubusercontent.com/598891/67758184-7d152e80-fa3d-11e9-8a18-ecbf9feb035e.png)

