### PR TITLE
Display only profiles with at least 1 host

### DIFF
--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -95,7 +95,8 @@ const CompliancePolicies = () => {
         );
     }
 
-    const policies = data.allProfiles;
+    const policies = data.allProfiles.filter((profile) => profile.totalHostCount > 0);
+
     let policyCards = [];
     let pageHeader;
     if (policies.length) {


### PR DESCRIPTION
Simple workaround for all of the N/A profiles. In addition to that, if https://github.com/RedHatInsights/compliance-backend/pull/257 we will need to merge something like this.