### PR TITLE
Update Breadcrumbs to use patternfly component

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -9,7 +9,6 @@ import EditPolicy from '../EditPolicy/EditPolicy';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import {
-    Breadcrumbs,
     PageHeader,
     PageHeaderTitle,
     Main,
@@ -25,7 +24,9 @@ import {
     Text,
     TextContent,
     Tooltip,
-    TextVariants
+    TextVariants,
+    Breadcrumb,
+    BreadcrumbItem
 } from '@patternfly/react-core';
 import gql from 'graphql-tag';
 import '../../Charts.scss';
@@ -164,12 +165,12 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
     return (
         <React.Fragment>
             <PageHeader>
-                <Breadcrumbs
-                    style={{ padding: '0px' }}
-                    items={[{ title: 'Policies', navigate: '/policies' }]}
-                    current={policy.name}
-                    onNavigate={onNavigateWithProps}
-                />
+                <Breadcrumb>
+                    <BreadcrumbItem to='/rhel/compliance/policies' onClick={ (event) => onNavigateWithProps(event) }>
+                      Policies
+                    </BreadcrumbItem>
+                    <BreadcrumbItem isActive>{policy.name}</BreadcrumbItem>
+                </Breadcrumb>
                 <PageHeaderTitle title={policy.name} />
                 <EditPolicy policyId={policy.id}
                     previousThreshold={policy.complianceThreshold}

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -8,18 +8,17 @@ exports[`PolicyDetails expect to render without error 1`] = `
   >
     <nav
       aria-label="Breadcrumb"
-      class="pf-c-breadcrumb ins-c-breadcrumbs"
-      style="padding: 0px;"
+      class="pf-c-breadcrumb"
     >
       <ol
         class="pf-c-breadcrumb__list"
       >
         <li
           class="pf-c-breadcrumb__item"
-          data-key="0"
         >
           <a
-            aria-label="/policies"
+            class="pf-c-breadcrumb__link"
+            href="/rhel/compliance/policies"
           >
             Policies
           </a>
@@ -45,9 +44,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
         <li
           class="pf-c-breadcrumb__item"
         >
-           
           profile1
-           
         </li>
       </ol>
     </nav>
@@ -303,18 +300,17 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
   >
     <nav
       aria-label="Breadcrumb"
-      class="pf-c-breadcrumb ins-c-breadcrumbs"
-      style="padding: 0px;"
+      class="pf-c-breadcrumb"
     >
       <ol
         class="pf-c-breadcrumb__list"
       >
         <li
           class="pf-c-breadcrumb__item"
-          data-key="0"
         >
           <a
-            aria-label="/policies"
+            class="pf-c-breadcrumb__link"
+            href="/rhel/compliance/policies"
           >
             Policies
           </a>
@@ -340,9 +336,7 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
         <li
           class="pf-c-breadcrumb__item"
         >
-           
           profile1
-           
         </li>
       </ol>
     </nav>
@@ -598,18 +592,17 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
   >
     <nav
       aria-label="Breadcrumb"
-      class="pf-c-breadcrumb ins-c-breadcrumbs"
-      style="padding: 0px;"
+      class="pf-c-breadcrumb"
     >
       <ol
         class="pf-c-breadcrumb__list"
       >
         <li
           class="pf-c-breadcrumb__item"
-          data-key="0"
         >
           <a
-            aria-label="/policies"
+            class="pf-c-breadcrumb__link"
+            href="/rhel/compliance/policies"
           >
             Policies
           </a>
@@ -635,9 +628,7 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
         <li
           class="pf-c-breadcrumb__item"
         >
-           
           profile1
-           
         </li>
       </ol>
     </nav>
@@ -888,24 +879,19 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
 exports[`PolicyDetailsQuery passes loading on to SystemTable 1`] = `
 <Fragment>
   <PageHeader>
-    <Breadcrumbs
-      className=""
-      current="profile1"
-      items={
-        Array [
-          Object {
-            "navigate": "/policies",
-            "title": "Policies",
-          },
-        ]
-      }
-      onNavigate={[MockFunction]}
-      style={
-        Object {
-          "padding": "0px",
-        }
-      }
-    />
+    <Component>
+      <BreadcrumbItem
+        onClick={[Function]}
+        to="/rhel/compliance/policies"
+      >
+        Policies
+      </BreadcrumbItem>
+      <BreadcrumbItem
+        isActive={true}
+      >
+        profile1
+      </BreadcrumbItem>
+    </Component>
     <PageHeaderTitle
       title="profile1"
     />
@@ -1149,18 +1135,17 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
   >
     <nav
       aria-label="Breadcrumb"
-      class="pf-c-breadcrumb ins-c-breadcrumbs"
-      style="padding: 0px;"
+      class="pf-c-breadcrumb"
     >
       <ol
         class="pf-c-breadcrumb__list"
       >
         <li
           class="pf-c-breadcrumb__item"
-          data-key="0"
         >
           <a
-            aria-label="/policies"
+            class="pf-c-breadcrumb__link"
+            href="/rhel/compliance/policies"
           >
             Policies
           </a>
@@ -1186,9 +1171,7 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
         <li
           class="pf-c-breadcrumb__item"
         >
-           
           profile1
-           
         </li>
       </ol>
     </nav>
@@ -1444,18 +1427,17 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
   >
     <nav
       aria-label="Breadcrumb"
-      class="pf-c-breadcrumb ins-c-breadcrumbs"
-      style="padding: 0px;"
+      class="pf-c-breadcrumb"
     >
       <ol
         class="pf-c-breadcrumb__list"
       >
         <li
           class="pf-c-breadcrumb__item"
-          data-key="0"
         >
           <a
-            aria-label="/policies"
+            class="pf-c-breadcrumb__link"
+            href="/rhel/compliance/policies"
           >
             Policies
           </a>
@@ -1481,9 +1463,7 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
         <li
           class="pf-c-breadcrumb__item"
         >
-           
           profile1
-           
         </li>
       </ol>
     </nav>

--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import {
-    Breadcrumbs,
     PageHeader,
     Main,
     Skeleton,
@@ -9,6 +8,10 @@ import {
 } from '@redhat-cloud-services/frontend-components';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import { onNavigate } from '../../Utilities/Breadcrumbs';
+import {
+    Breadcrumb,
+    BreadcrumbItem
+} from '@patternfly/react-core';
 import InventoryDetails from '../InventoryDetails/InventoryDetails';
 import ComplianceSystemDetails from '@redhat-cloud-services/frontend-components-inventory-compliance';
 import { Query } from 'react-apollo';
@@ -51,12 +54,12 @@ class SystemDetails extends React.Component {
                     return (
                         <React.Fragment>
                             <PageHeader>
-                                <Breadcrumbs
-                                    style={{ padding: '0px' }}
-                                    items={[{ title: 'Systems', navigate: '/systems' }]}
-                                    current={data.system.name}
-                                    onNavigate={this.onNavigate}
-                                />
+                                <Breadcrumb>
+                                    <BreadcrumbItem to='/rhel/compliance/systems' onClick={ (event) => this.onNavigate(event) }>
+                                        Systems
+                                    </BreadcrumbItem>
+                                    <BreadcrumbItem isActive>{data.system.name}</BreadcrumbItem>
+                                </Breadcrumb>
                                 <InventoryDetails sendData={this.getData} />
                                 <br/>
                             </PageHeader>

--- a/src/Utilities/Breadcrumbs.js
+++ b/src/Utilities/Breadcrumbs.js
@@ -1,3 +1,4 @@
-export function onNavigate(event, item) {
-    this.props.history.push(item);
+export function onNavigate(event) {
+    event.preventDefault();
+    this.props.history.push(event.target.pathname);
 }


### PR DESCRIPTION
This replaces the `Breadcrumbs` component from `frontend-components` with the Patternfly 4 component. As the Patternfly component had no equivilant to `onNavigate`, it is using `onClick` instead and required a minor fix.

Visibly nothing changes, they are identical.
