### PR TITLE
Add dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+      - match:
+          dependency_name: "@redhat-cloud-services/frontend*"
+      - match:
+          dependency_name: "@patternfly/*"
+          dependency_type: "direct"


### PR DESCRIPTION
Once #209 is merged and we enable dependabot, we can configure it with this to give us automatic updates for new package versions of `@redhat-cloud-services/frontend*` & `@patternfly/*` packages.