### PR TITLE
Simplify BusinessObjectiveField and fix behaviour

### DIFF
--- a/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
+++ b/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
@@ -24,10 +24,12 @@ class BusinessObjectiveField extends React.Component {
         };
     }
 
-    loadOptions = () => {
+    loadOptions = (title) => {
+        const variables = title ? { title } : {};
         this.props.client.cache.reset();
         return this.props.client.query({
-            query: GET_BUSINESS_OBJECTIVES
+            query: GET_BUSINESS_OBJECTIVES,
+            variables
         }).then((items) => {
             return items.data.businessObjectives.map(businessObjective => (
                 this.createOption(businessObjective)

--- a/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
+++ b/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
@@ -25,6 +25,7 @@ class BusinessObjectiveField extends React.Component {
     }
 
     loadOptions = () => {
+        this.props.client.cache.reset();
         return this.props.client.query({
             query: GET_BUSINESS_OBJECTIVES
         }).then((items) => {

--- a/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
+++ b/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
@@ -25,7 +25,6 @@ class BusinessObjectiveField extends React.Component {
     }
 
     loadOptions = () => {
-        this.props.client.cache.reset();
         return this.props.client.query({
             query: GET_BUSINESS_OBJECTIVES
         }).then((items) => {

--- a/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
+++ b/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
@@ -6,8 +6,6 @@ import propTypes from 'prop-types';
 import { ReduxFormCreatableSelectInput } from '../ReduxFormWrappers/ReduxFormWrappers';
 import gql from 'graphql-tag';
 import { withApollo } from 'react-apollo';
-import { connect } from 'react-redux';
-import debounce from 'lodash/debounce';
 
 const GET_BUSINESS_OBJECTIVES = gql`
 query businessObjectives {
@@ -22,30 +20,18 @@ class BusinessObjectiveField extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            policyId: props.policyId,
-            isExpanded: false,
-            selected: props.businessObjective ? this.createOption(props.businessObjective) : '',
-            options: [],
-            originalOptions: [],
-            client: props.client,
-            isLoading: true
+            selected: props.businessObjective ? this.createOption(props.businessObjective) : null
         };
+    }
 
-        // Resetting the cache is necessary to reload the list of Business Objectives
-        // after removing or adding any.
-        props.client.cache.reset();
-        props.client.query({
+    loadOptions = () => {
+        this.props.client.cache.reset();
+        return this.props.client.query({
             query: GET_BUSINESS_OBJECTIVES
         }).then((items) => {
-            const options = items.data.businessObjectives.map(businessObjective => (
+            return items.data.businessObjectives.map(businessObjective => (
                 this.createOption(businessObjective)
             ));
-
-            this.setState({
-                isLoading: false,
-                options,
-                originalOptions: options
-            });
         });
     }
 
@@ -54,26 +40,9 @@ class BusinessObjectiveField extends React.Component {
         value: businessObjective.id
     });
 
-    handleInputChange = debounce(value => {
-        this.handleCreate(value);
-    }, 500)
-
     handleChange = (newValue) => {
-        this.setState({ selected: newValue });
-    };
-
-    handleCreate = (inputValue) => {
-        const { originalOptions } = this.state;
-
-        if (inputValue.length === 0 || originalOptions.map(option => option.label).indexOf(inputValue) !== -1) {
-            return;
-        }
-
         const { dispatch } = this.props;
-        this.setState({ isLoading: true });
-
-        let newOption = this.createOption({ title: inputValue, value: inputValue });
-        newOption.create = true;
+        this.setState({ selected: newValue });
 
         // Manually dispatch the action to ensure the newly created label is set
         dispatch({
@@ -82,17 +51,18 @@ class BusinessObjectiveField extends React.Component {
                 field: 'businessObjective',
                 form: 'editPolicy'
             },
-            payload: newOption
-        });
-        this.setState({
-            isLoading: false,
-            options: [newOption, ...originalOptions],
-            selected: newOption
+            payload: newValue
         });
     };
 
+    handleCreate = (inputValue) => {
+        let newOption = this.createOption({ title: inputValue, value: inputValue });
+        newOption.create = true;
+        this.handleChange(newOption);
+    };
+
     render() {
-        const { isLoading, selected, options } = this.state;
+        const { selected } = this.state;
         const titleId = 'business-objective-typeahead';
 
         return (
@@ -109,14 +79,11 @@ class BusinessObjectiveField extends React.Component {
                         aria-label="Select a business objective"
                         component={ReduxFormCreatableSelectInput}
                         isClearable
-                        selected={selected}
                         placeholder='Type to select and create'
-                        isDisabled={isLoading}
-                        isLoading={isLoading}
                         onChange={this.handleChange}
                         onCreateOption={this.handleCreate}
-                        onInputChange={this.handleInputChange}
-                        options={options}
+                        loadOptions={this.loadOptions}
+                        selected={selected}
                     />
                 </FormGroup>
             </React.Fragment>
@@ -125,14 +92,12 @@ class BusinessObjectiveField extends React.Component {
 }
 
 BusinessObjectiveField.propTypes = {
-    policyId: propTypes.string,
     businessObjective: propTypes.object,
     client: propTypes.object,
-    dispatch: propTypes.function
+    dispatch: propTypes.func
 };
 
 export default compose(
-    connect(),
     withApollo,
     reduxForm({
         form: 'editPolicy'

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -48,7 +48,7 @@ class EditPolicy extends Component {
 
     render() {
         const { policyId, isOpen, isModalOpen, businessObjective } = this.state;
-        const { previousThreshold, editPolicyBusinessObjective, complianceThreshold } = this.props;
+        const { previousThreshold, editPolicyBusinessObjective, complianceThreshold, dispatch } = this.props;
         const dropdownItems = [
             <DropdownItem key="action" onClick={this.handleModalToggle} component="button">
                 Edit policy
@@ -79,7 +79,8 @@ class EditPolicy extends Component {
                             key='confirm'
                             policyId={policyId}
                             threshold={ parseInt(complianceThreshold || previousThreshold) }
-                            businessObjective={editPolicyBusinessObjective}
+                            businessObjective={businessObjective}
+                            editPolicyBusinessObjective={editPolicyBusinessObjective}
                             onClick={this.handleModalToggle}
                         />
                     ]}
@@ -88,6 +89,7 @@ class EditPolicy extends Component {
                         <BusinessObjectiveField
                             businessObjective={businessObjective}
                             policyId={policyId}
+                            dispatch={dispatch}
                         />
                         <ProfileThresholdField previousThreshold={previousThreshold} />
                     </Form>
@@ -103,7 +105,8 @@ EditPolicy.propTypes = {
     businessObjective: propTypes.object,
     editPolicyBusinessObjective: propTypes.object,
     complianceThreshold: propTypes.string,
-    onClose: propTypes.func
+    onClose: propTypes.func,
+    dispatch: propTypes.func
 };
 
 const selector = formValueSelector('editPolicy');

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -9,7 +9,7 @@ import {
 } from '@patternfly/react-core';
 import React, { Component } from 'react';
 import propTypes from 'prop-types';
-import UpdateProfile from './UpdateProfile';
+import UpdateProfileButton from './UpdateProfileButton';
 import ProfileThresholdField from './ProfileThresholdField';
 import BusinessObjectiveField from './BusinessObjectiveField';
 import { formValueSelector } from 'redux-form';
@@ -75,7 +75,7 @@ class EditPolicy extends Component {
                         <Button key="cancel" variant="secondary" onClick={this.handleModalToggle}>
                             Cancel
                         </Button>,
-                        <UpdateProfile
+                        <UpdateProfileButton
                             key='confirm'
                             policyId={policyId}
                             threshold={ parseInt(complianceThreshold || previousThreshold) }

--- a/src/SmartComponents/EditPolicy/UpdateProfileButton.js
+++ b/src/SmartComponents/EditPolicy/UpdateProfileButton.js
@@ -35,12 +35,13 @@ export class UpdateProfileButton extends React.Component {
             return Promise.resolve(businessObjective ? businessObjective.id : null);
         }
 
-        if (editPolicyBusinessObjective && businessObjective
+        if (editPolicyBusinessObjective && !editPolicyBusinessObjective.create && businessObjective
             && (editPolicyBusinessObjective.value !== businessObjective.id)) {
             return Promise.resolve(editPolicyBusinessObjective.value);
         }
 
-        if (editPolicyBusinessObjective && businessObjective === null) {
+        if (editPolicyBusinessObjective && !editPolicyBusinessObjective.create
+            && businessObjective === null) {
             return Promise.resolve(editPolicyBusinessObjective.value);
         }
 

--- a/src/SmartComponents/EditPolicy/UpdateProfileButton.js
+++ b/src/SmartComponents/EditPolicy/UpdateProfileButton.js
@@ -27,7 +27,7 @@ mutation createBusinessObjective($input: createBusinessObjectiveInput!) {
 }
 `;
 
-class UpdateProfileButton extends React.Component {
+export class UpdateProfileButton extends React.Component {
     handleBusinessObjective = () => {
         const { businessObjective, editPolicyBusinessObjective, mutate } = this.props;
 

--- a/src/SmartComponents/EditPolicy/UpdateProfileButton.js
+++ b/src/SmartComponents/EditPolicy/UpdateProfileButton.js
@@ -31,34 +31,23 @@ export class UpdateProfileButton extends React.Component {
     handleBusinessObjective = () => {
         const { businessObjective, editPolicyBusinessObjective, mutate } = this.props;
 
-        // nothing changed
-        //  -> if there is a businessObjective return it's id
-        //  -> else null
         if (editPolicyBusinessObjective === undefined) {
             return Promise.resolve(businessObjective ? businessObjective.id : null);
         }
 
-        // The businessObjective changed to a different one
-        //  -> return the new id/value
         if (editPolicyBusinessObjective && businessObjective
             && (editPolicyBusinessObjective.value !== businessObjective.id)) {
             return Promise.resolve(editPolicyBusinessObjective.value);
         }
 
-        // The businessObjective changed to a different one from no BO
-        //  -> return the new id/value
         if (editPolicyBusinessObjective && businessObjective === null) {
             return Promise.resolve(editPolicyBusinessObjective.value);
         }
 
-        // Objective got unset
-        //  -> return null
         if (editPolicyBusinessObjective === null) {
             return Promise.resolve(null);
         }
 
-        // An objective needs to be created
-        // = -> return the id
         if (editPolicyBusinessObjective.create) {
             return mutate({
                 mutation: CREATE_BUSINESS_OBJECTIVE,

--- a/src/SmartComponents/EditPolicy/UpdateProfileButton.js
+++ b/src/SmartComponents/EditPolicy/UpdateProfileButton.js
@@ -96,5 +96,4 @@ UpdateProfileButton.propTypes = {
     onClick: propTypes.func
 };
 
-const UpdateProfile = graphql(UPDATE_PROFILE)(UpdateProfileButton);
-export default UpdateProfile;
+export default graphql(UPDATE_PROFILE)(UpdateProfileButton);

--- a/src/SmartComponents/EditPolicy/UpdateProfileButton.js
+++ b/src/SmartComponents/EditPolicy/UpdateProfileButton.js
@@ -62,7 +62,7 @@ export class UpdateProfileButton extends React.Component {
     onClick = () => {
         const { mutate, policyId, threshold, onClick } = this.props;
 
-        this.handleBusinessObjective().then((businessObjectiveId) => {
+        return this.handleBusinessObjective().then((businessObjectiveId) => {
             let input = {
                 id: policyId,
                 complianceThreshold: parseFloat(threshold)
@@ -89,12 +89,12 @@ export class UpdateProfileButton extends React.Component {
 }
 
 UpdateProfileButton.propTypes = {
-    policyId: propTypes.string,
+    policyId: propTypes.string.isRequired,
     businessObjective: propTypes.object,
     editPolicyBusinessObjective: propTypes.object,
-    mutate: propTypes.func,
+    mutate: propTypes.func.isRequired,
     threshold: propTypes.number,
-    onClick: propTypes.func
+    onClick: propTypes.func.isRequired
 };
 
 export default graphql(UPDATE_PROFILE)(UpdateProfileButton);

--- a/src/SmartComponents/EditPolicy/UpdateProfileButton.test.js
+++ b/src/SmartComponents/EditPolicy/UpdateProfileButton.test.js
@@ -11,7 +11,9 @@ describe('UpdateProfileButton', () => {
         editPolicyBusinessObjective: {
             title: 'Edited Test Objective',
             value: '2'
-        }
+        },
+        mutate: jest.fn(),
+        onClick: jest.fn()
     };
 
     it('expect to render without error', () => {
@@ -119,6 +121,23 @@ describe('UpdateProfileButton', () => {
                 expect(resultId).toBe('3');
             });
             expect(mutate).toHaveBeenCalled();
+        });
+    });
+
+    describe('.onClick', () => {
+        it('calls mutate and onClick', async () => {
+            const mutate = jest.fn();
+            const hBO = jest.fn(() => Promise.resolve(1));
+            const wrapper = shallow(
+                <UpdateProfileButton { ...defaultProps } mutate={ mutate } />
+            );
+            wrapper.instance().handleBusinessObjective = hBO;
+            wrapper.update();
+
+            await wrapper.instance().onClick();
+
+            expect(mutate).toHaveBeenCalled();
+            expect(hBO).toHaveBeenCalled();
         });
     });
 });

--- a/src/SmartComponents/EditPolicy/UpdateProfileButton.test.js
+++ b/src/SmartComponents/EditPolicy/UpdateProfileButton.test.js
@@ -1,0 +1,124 @@
+import toJson from 'enzyme-to-json';
+
+import { UpdateProfileButton } from './UpdateProfileButton';
+
+describe('UpdateProfileButton', () => {
+    const defaultProps = {
+        businessObjective: {
+            title: 'Test Objective',
+            id: '1'
+        },
+        editPolicyBusinessObjective: {
+            title: 'Edited Test Objective',
+            value: '2'
+        }
+    };
+
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <UpdateProfileButton { ...defaultProps } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    describe('.handleBusinessObjective', () => {
+        it('returns the businessObjective.id if editPolicyBusinessObjective is undefined', () => {
+            const wrapper = shallow(
+                <UpdateProfileButton { ...defaultProps }
+                    editPolicyBusinessObjective={ undefined } />
+            );
+            const instance = wrapper.instance();
+
+            instance.handleBusinessObjective().then((resultId) => {
+                expect(resultId).toBe(defaultProps.businessObjective.id);
+            });
+        });
+
+        it('returns null if editPolicyBusinessObjective is undefined and no businessObjective', () => {
+            const wrapper = shallow(
+                <UpdateProfileButton { ...defaultProps }
+                    businessObjective={ undefined }
+                    editPolicyBusinessObjective={ undefined } />
+            );
+            const instance = wrapper.instance();
+
+            instance.handleBusinessObjective().then((resultId) => {
+                expect(resultId).toBe(null);
+            });
+        });
+
+        it('returns the editPolicyBusinessObjective.value if it is defined and businessObjective is null', () => {
+            const wrapper = shallow(
+                <UpdateProfileButton { ...defaultProps }
+                    businessObjective={ null } />
+            );
+            const instance = wrapper.instance();
+
+            instance.handleBusinessObjective().then((resultId) => {
+                expect(resultId).toBe(defaultProps.editPolicyBusinessObjective.value);
+            });
+        });
+
+        it('returns the editPolicyBusinessObjective.value if it and businessObjective is defined', () => {
+            const wrapper = shallow(
+                <UpdateProfileButton { ...defaultProps } />
+            );
+            const instance = wrapper.instance();
+
+            instance.handleBusinessObjective().then((resultId) => {
+                expect(resultId).toBe(defaultProps.editPolicyBusinessObjective.value);
+            });
+        });
+
+        it('returns null when editPolicyBusinessObjective is null', () => {
+            const wrapper = shallow(
+                <UpdateProfileButton { ...defaultProps }
+                    editPolicyBusinessObjective={ null } />
+            );
+            const instance = wrapper.instance();
+
+            instance.handleBusinessObjective().then((resultId) => {
+                expect(resultId).toBe(null);
+            });
+        });
+
+        it('returns a new ID if editPolicyBusinessObjective has a create property and mutates', async () => {
+            const title = 'New Objective';
+            const mutate = jest.fn((query) => {
+                let id;
+
+                if (query.variables.input.title === title)  {
+                    id = '3';
+                } else {
+                    id = null;
+                }
+
+                return Promise.resolve({
+                    data: {
+                        createBusinessObjective: {
+                            businessObjective: {
+                                id
+                            }
+                        }
+                    }
+                });
+            });
+            const wrapper = shallow(
+                <UpdateProfileButton { ...defaultProps }
+                    mutate={ mutate }
+                    businessObjective={ undefined }
+                    editPolicyBusinessObjective={ {
+                        create: true,
+                        label: title
+                    } } />
+            );
+            const instance = wrapper.instance();
+
+            await instance.handleBusinessObjective().then((resultId) => {
+                expect(resultId).toBe('3');
+            });
+            expect(mutate).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/SmartComponents/EditPolicy/__snapshots__/UpdateProfileButton.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/UpdateProfileButton.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpdateProfileButton expect to render without error 1`] = `
+<Component
+  onClick={[Function]}
+  type="submit"
+  variant="primary"
+>
+  Save
+</Component>
+`;


### PR DESCRIPTION
This simplifies the `BusinessObjectiveField` and makes more use of [react-select](https://react-select.com/props) features and fixes the issues with setting initial options.

**tl;dr:**
 * A `loadOptions` function is passed to `Select` instead of handling options in `BusinessObjectiveField`
 * `BusinessObjectiveField` is now disconnected from redux-form and `dispatch` passed
 * `handleCreate` and `handleChange` are simplified
 * `handleChange` dispatches the redux-form change
 * `UpdateProfileButton` has now a very verbose `handleBusinessObjective`

**What to test:** (Checklist for manual and jest tests)

 * [x] Create a new BusinessObjective
 * [x] Remove the BusinessObjective and ensure it is unset
 * [x] Assign an existing BusinessObjective
 * [x] Create a new BusinessObjective while one is already assigned
 * [x] Change to a different BusinessObjective
 * [x] Don't change the BusinessObjective and make sure it is **not** unset
 * [x] Try saving without any BusinessObjective assigned