### PR TITLE
RHICOMPL-423 - Remove compliance ui root from breadcrumb onNavigate

### DIFF
--- a/src/Utilities/Breadcrumbs.js
+++ b/src/Utilities/Breadcrumbs.js
@@ -1,4 +1,7 @@
+import { COMPLIANCE_UI_ROOT } from '../constants';
+
 export function onNavigate(event) {
     event.preventDefault();
-    this.props.history.push(event.target.pathname);
+    const path = event.target.pathname.replace(COMPLIANCE_UI_ROOT, '');
+    this.props.history.push(path);
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 import { version } from './../package.json';
 export const COMPLIANCE_API_ROOT = '/api/compliance';
+export const COMPLIANCE_UI_ROOT = '/rhel/compliance';
 export const COMPLIANCE_WS_ROOT = process.env.NODE_ENV === 'production'
     ? 'wss://localhost:3000/cable'
     : 'ws://localhost:3000/cable';


### PR DESCRIPTION
When navigating via breadcrumbs on either `PolicyDetails` or `SystemsDetails` the paths would not be found by the router and fall back to the policies list, which breaks navigating to the systems list from a system details page. On policy details this would not be obvious as the wrong path would still be directing the user to the policy list.

This removes the UI root path from paths of Breadcrumbs and allow matching the correct routes in the router.