### PR TITLE
Increase testcoverage and refactor #3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10173,6 +10173,11 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -13629,6 +13634,16 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.5.tgz",
@@ -14956,9 +14971,9 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "requires": {
         "isarray": "0.0.1"
       }
@@ -16459,37 +16474,34 @@
       }
     },
     "react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
+      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
         "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
+      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
         "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
+        "prop-types": "^15.6.2",
+        "react-router": "5.1.2",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-select": {
@@ -21658,6 +21670,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^16.5.1",
     "react-intl": "^2.8.0",
     "react-redux": "^5.0.7",
-    "react-router-dom": "^4.2.2",
+    "react-router-dom": "^5.1.2",
     "react-show-more-text": "^1.0.4",
     "react-truncate": "^2.4.0",
     "redux": "^3.7.2",
@@ -55,7 +55,7 @@
       "!src/{App|Routes|entry|entry-dev}.js",
       "!src/__fixtures__/*.js",
       "!src/{SmartComponents|PresentationalComponents|store}/index.js",
-      "!src/Utilities/asyncComponent.js"
+      "!src/Utilities/(asyncComponent|ReducerRegistry).js"
     ],
     "setupFiles": [
       "<rootDir>/config/setupTests.js"
@@ -64,7 +64,11 @@
       "<rootDir>/src/"
     ],
     "moduleNameMapper": {
-      "\\.(css|scss)$": "identity-obj-proxy"
+      "\\.(css|scss)$": "identity-obj-proxy",
+      "^SmartComponents$": "<rootDir>/src/SmartComponents",
+      "^PresentationalComponents": "<rootDir>/src/PresentationalComponents",
+      "^Utilities": "<rootDir>/src/Utilities",
+      "^Store": "<rootDir>/src/store"
     }
   },
   "devDependencies": {

--- a/src/PresentationalComponents/CompliancePolicyCard/__snapshots__/CompliancePolicyCard.test.js.snap
+++ b/src/PresentationalComponents/CompliancePolicyCard/__snapshots__/CompliancePolicyCard.test.js.snap
@@ -112,7 +112,6 @@ exports[`CompliancePolicyCard expect to render without error 1`] = `
               }
             >
               <Link
-                replace={false}
                 to="/policies/ID"
               >
                 More details

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -15,7 +15,7 @@ import {
     GridItem
 } from '@patternfly/react-core';
 
-const QUERY = gql`
+export const QUERY = gql`
 {
     allProfiles {
         id
@@ -32,7 +32,7 @@ const QUERY = gql`
 }
 `;
 
-const CompliancePolicies = () => {
+export const CompliancePolicies = () => {
     const { data, error, loading } = useQuery(QUERY);
 
     if (error) { return <ErrorPage error={error}/>; }

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -15,7 +15,7 @@ import {
     GridItem
 } from '@patternfly/react-core';
 
-export const QUERY = gql`
+const QUERY = gql`
 {
     allProfiles {
         id

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.test.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.test.js
@@ -1,0 +1,69 @@
+import toJson from 'enzyme-to-json';
+import { useQuery } from '@apollo/react-hooks';
+
+import { CompliancePolicies, QUERY } from './CompliancePolicies.js';
+
+jest.mock('@apollo/react-hooks')
+
+describe('CompliancePolicies', () => {
+    it('expect to render without error', () => {
+        useQuery.mockImplementation(() => ({
+            data: {
+                allProfiles: [{
+                    id: '1',
+                    refId: '121212',
+                    name: 'profile1',
+                    description: 'profile description',
+                    totalHostCount: 1,
+                    complianceThreshold: 1,
+                    compliantHostCount: 1,
+                    businessObjective: {
+                        id: '1',
+                        title: 'BO 1'
+                    }
+                }]
+            }, error: false, loading: false }));
+
+        const wrapper = shallow(
+            <CompliancePolicies />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render emptystate', () => {
+        useQuery.mockImplementation(() => ({
+            data: {
+                allProfiles: []
+            }, error: false, loading: false }));
+
+        const wrapper = shallow(
+            <CompliancePolicies />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render an error', () => {
+        const error = {
+            networkError: { statusCode: 500 },
+            error: 'Test Error loading'
+        };
+        useQuery.mockImplementation(() => ({ data: {}, error, loading: false }));
+        const wrapper = shallow(
+            <CompliancePolicies />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render loading', () => {
+        useQuery.mockImplementation(() => ({ data: {}, error: false, loading: true }));
+        const wrapper = shallow(
+            <CompliancePolicies />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+});

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.test.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.test.js
@@ -1,9 +1,9 @@
 import toJson from 'enzyme-to-json';
 import { useQuery } from '@apollo/react-hooks';
 
-import { CompliancePolicies, QUERY } from './CompliancePolicies.js';
+import { CompliancePolicies } from './CompliancePolicies.js';
 
-jest.mock('@apollo/react-hooks')
+jest.mock('@apollo/react-hooks');
 
 describe('CompliancePolicies', () => {
     it('expect to render without error', () => {

--- a/src/SmartComponents/CompliancePolicies/__snapshots__/CompliancePolicies.test.js.snap
+++ b/src/SmartComponents/CompliancePolicies/__snapshots__/CompliancePolicies.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CompliancePolicies expect to render an error 1`] = `
+<ErrorPage
+  error={
+    Object {
+      "error": "Test Error loading",
+      "networkError": Object {
+        "statusCode": 500,
+      },
+    }
+  }
+/>
+`;
+
+exports[`CompliancePolicies expect to render emptystate 1`] = `
+<Fragment>
+  <PageHeader
+    style={
+      Object {
+        "paddingBottom": 22,
+      }
+    }
+  >
+    <PageHeaderTitle
+      title="Compliance"
+    />
+  </PageHeader>
+  <Connect(Main)>
+    <div
+      className="policies-donuts"
+    >
+      <Grid
+        gutter="md"
+      >
+        <CompliancePoliciesEmptyState />
+      </Grid>
+    </div>
+  </Connect(Main)>
+</Fragment>
+`;
+
+exports[`CompliancePolicies expect to render loading 1`] = `
+<Fragment>
+  <PageHeader>
+    <PageHeaderTitle
+      title="Compliance"
+    />
+  </PageHeader>
+  <Connect(Main)>
+    <div
+      className="policies-donuts"
+    >
+      <Grid
+        gutter="md"
+      >
+        <LoadingComplianceCards />
+      </Grid>
+    </div>
+  </Connect(Main)>
+</Fragment>
+`;
+
+exports[`CompliancePolicies expect to render without error 1`] = `
+<Fragment>
+  <PageHeader>
+    <PageHeaderTitle
+      title="Compliance"
+    />
+    <withRouter(Connect(RouterParams)) />
+  </PageHeader>
+  <Connect(Main)>
+    <div
+      className="policies-donuts"
+    >
+      <Grid
+        gutter="md"
+      >
+        <GridItem
+          key="0"
+          lg={6}
+          md={12}
+          sm={12}
+          xl={4}
+        >
+          <CompliancePolicyCard
+            key="0"
+            policy={
+              Object {
+                "businessObjective": Object {
+                  "id": "1",
+                  "title": "BO 1",
+                },
+                "complianceThreshold": 1,
+                "compliantHostCount": 1,
+                "description": "profile description",
+                "id": "1",
+                "name": "profile1",
+                "refId": "121212",
+                "totalHostCount": 1,
+              }
+            }
+          />
+        </GridItem>
+      </Grid>
+    </div>
+  </Connect(Main)>
+</Fragment>
+`;

--- a/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
+++ b/src/SmartComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
@@ -1,3 +1,6 @@
+/*
+    TODO: Replace with frontend-components version
+*/
 import React from 'react';
 import { compose } from 'redux';
 import propTypes from 'prop-types';
@@ -33,6 +36,7 @@ const FailedRulesQuery = graphql(GET_FAILED_RULES, {
 });
 
 class ComplianceRemediationButton extends React.Component {
+
     /* eslint-disable camelcase */
     formatRule = ({ title, refId }, profile, systems) => ({
         id: `ssg:rhel7|${profile}|${refId}`,

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.test.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.test.js
@@ -1,0 +1,13 @@
+import toJson from 'enzyme-to-json';
+
+import ComplianceSystems from './ComplianceSystems.js';
+
+describe('ComplianceSystems', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <ComplianceSystems />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
+++ b/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ComplianceSystems expect to render without error 1`] = `
+<Fragment>
+  <PageHeader>
+    <PageHeaderTitle
+      title="Compliance"
+    />
+    <withRouter(Connect(RouterParams)) />
+  </PageHeader>
+  <Connect(Main)>
+    <withApollo(SystemsTable)
+      columns={
+        Array [
+          Object {
+            "composed": Array [
+              "facts.os_release",
+              "display_name",
+            ],
+            "key": "display_name",
+            "props": Object {
+              "width": 40,
+            },
+            "title": "Name",
+          },
+          Object {
+            "key": "facts.compliance.profiles",
+            "props": Object {
+              "width": 40,
+            },
+            "title": "Profiles",
+          },
+          Object {
+            "key": "facts.compliance.compliance_score",
+            "props": Object {
+              "width": 10,
+            },
+            "title": "Compliance score",
+          },
+          Object {
+            "key": "facts.compliance.last_scanned",
+            "props": Object {
+              "width": 10,
+            },
+            "title": "Last scanned",
+          },
+        ]
+      }
+    />
+  </Connect(Main)>
+</Fragment>
+`;

--- a/src/SmartComponents/DownloadTableButton/DownloadTableButton.js
+++ b/src/SmartComponents/DownloadTableButton/DownloadTableButton.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { Dropdown, KebabToggle, DropdownItem, Tooltip } from '@patternfly/react-core';
 import { exportToCSV } from '../../store/ActionTypes.js';
 
-class DownloadTableButton extends React.Component {
+export class DownloadTableButton extends React.Component {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/SmartComponents/DownloadTableButton/DownloadTableButton.test.js
+++ b/src/SmartComponents/DownloadTableButton/DownloadTableButton.test.js
@@ -1,0 +1,18 @@
+import toJson from 'enzyme-to-json';
+
+import { DownloadTableButton } from './DownloadTableButton.js';
+
+describe('DownloadTableButton', () => {
+    const defaultProps = {
+        exportToCSV: jest.fn(),
+        selectedEntities: [1, 2, 3]
+    };
+
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <DownloadTableButton { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/DownloadTableButton/__snapshots__/DownloadTableButton.test.js.snap
+++ b/src/SmartComponents/DownloadTableButton/__snapshots__/DownloadTableButton.test.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DownloadTableButton expect to render without error 1`] = `
+<Fragment>
+  <Tooltip
+    appendTo={[Function]}
+    aria="describedby"
+    boundary="window"
+    className=""
+    content={
+      <div>
+        More actions
+      </div>
+    }
+    distance={15}
+    enableFlip={true}
+    entryDelay={500}
+    exitDelay={500}
+    flipBehavior={
+      Array [
+        "top",
+        "right",
+        "bottom",
+        "left",
+        "top",
+        "right",
+        "bottom",
+      ]
+    }
+    id=""
+    isAppLauncher={false}
+    isContentLeftAligned={false}
+    isVisible={false}
+    maxWidth="18.75rem"
+    position="top"
+    tippyProps={Object {}}
+    trigger="mouseenter focus"
+    zIndex={9999}
+  >
+    <Dropdown
+      dropdownItems={
+        Array [
+          <DropdownItem
+            onClick={[MockFunction]}
+          >
+            Export as CSV
+          </DropdownItem>,
+          <DropdownItem
+            href="/api/compliance/systems.json?search=(id ^ (1,2,3))"
+            target="_blank"
+          >
+            Export as JSON
+          </DropdownItem>,
+        ]
+      }
+      isOpen={false}
+      isPlain={true}
+      onSelect={[Function]}
+      toggle={
+        <KebabToggle
+          onToggle={[Function]}
+          style={
+            Object {
+              "color": "var(--pf-global--icon--Color--light)",
+            }
+          }
+        />
+      }
+    />
+  </Tooltip>
+</Fragment>
+`;

--- a/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
+++ b/src/SmartComponents/EditPolicy/BusinessObjectiveField.js
@@ -16,7 +16,7 @@ query businessObjectives {
 }
 `;
 
-class BusinessObjectiveField extends React.Component {
+export class BusinessObjectiveField extends React.Component {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/SmartComponents/EditPolicy/BusinessObjectiveField.test.js
+++ b/src/SmartComponents/EditPolicy/BusinessObjectiveField.test.js
@@ -1,0 +1,19 @@
+import toJson from 'enzyme-to-json';
+
+import { BusinessObjectiveField } from './BusinessObjectiveField';
+
+describe('BusinessObjectiveField', () => {
+    const defaultProps = {
+        businessObjective: {
+            title: 'BO title',
+            id: 1
+        }
+    };
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <BusinessObjectiveField { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -15,7 +15,7 @@ import BusinessObjectiveField from './BusinessObjectiveField';
 import { formValueSelector } from 'redux-form';
 import { connect } from 'react-redux';
 
-class EditPolicy extends Component {
+export class EditPolicy extends Component {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/SmartComponents/EditPolicy/EditPolicy.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.test.js
@@ -1,0 +1,24 @@
+import toJson from 'enzyme-to-json';
+
+import { EditPolicy } from './EditPolicy.js';
+
+describe('EditPolicy', () => {
+    const defaultProps = {
+        policyId: 'POLICY_ID',
+        businessObjective: {
+            title: 'BO title',
+            id: 1
+        },
+        complianceThreshold: '30',
+        onClose: jest.fn(),
+        dispatch: jest.fn()
+    };
+
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <EditPolicy { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/EditPolicy/ProfileThresholdField.js
+++ b/src/SmartComponents/EditPolicy/ProfileThresholdField.js
@@ -4,7 +4,7 @@ import { FormGroup, Title } from '@patternfly/react-core';
 import { ReduxFormTextInput } from 'PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers';
 import propTypes from 'prop-types';
 
-class ProfileThresholdField extends React.Component {
+export class ProfileThresholdField extends React.Component {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/SmartComponents/EditPolicy/ProfileThresholdField.test.js
+++ b/src/SmartComponents/EditPolicy/ProfileThresholdField.test.js
@@ -1,0 +1,16 @@
+import toJson from 'enzyme-to-json';
+
+import { ProfileThresholdField } from './ProfileThresholdField';
+
+describe('ProfileThresholdField', () => {
+    const defaultProps = {
+        previousThreshold: 10
+    };
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <ProfileThresholdField { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/EditPolicy/__snapshots__/BusinessObjectiveField.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/BusinessObjectiveField.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BusinessObjectiveField expect to render without error 1`] = `
+<Fragment>
+  <Title
+    headingLevel="h3"
+    size="xl"
+  >
+    Business objective
+  </Title>
+  This is an optional field that can be used to label policies that are related to specific business objectives.
+  <FormGroup
+    field-id="edit-policy-business-objective"
+    helperText="e.g Project Gemini"
+    label="Business objective"
+  >
+    <Field
+      aria-label="Select a business objective"
+      ariaLabelledBy="business-objective-typeahead"
+      id="businessObjective"
+      isClearable={true}
+      loadOptions={[Function]}
+      name="businessObjective"
+      onChange={[Function]}
+      onCreateOption={[Function]}
+      placeholder="Type to select and create"
+      selected={
+        Object {
+          "label": "BO title",
+          "value": 1,
+        }
+      }
+    />
+  </FormGroup>
+</Fragment>
+`;

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditPolicy expect to render without error 1`] = `
+<Fragment>
+  <Dropdown
+    className="policy-details-dropdown"
+    dropdownItems={
+      Array [
+        <DropdownItem
+          component="button"
+          onClick={[Function]}
+        >
+          Edit policy
+        </DropdownItem>,
+      ]
+    }
+    isOpen={false}
+    onSelect={[Function]}
+    position="right"
+    toggle={
+      <DropdownToggle
+        onToggle={[Function]}
+      >
+        Actions
+      </DropdownToggle>
+    }
+  />
+  <Modal
+    actions={
+      Array [
+        <Unknown
+          onClick={[Function]}
+          variant="secondary"
+        >
+          Cancel
+        </Unknown>,
+        <Apollo(UpdateProfileButton)
+          businessObjective={
+            Object {
+              "id": 1,
+              "title": "BO title",
+            }
+          }
+          onClick={[Function]}
+          policyId="POLICY_ID"
+          threshold={30}
+        />,
+      ]
+    }
+    appendTo={<body />}
+    ariaDescribedById=""
+    className=""
+    hideTitle={false}
+    isFooterLeftAligned={true}
+    isLarge={false}
+    isOpen={false}
+    isSmall={true}
+    onClose={[Function]}
+    showClose={true}
+    title="Edit policy details"
+  >
+    <Form>
+      <withApollo(ReduxForm)
+        businessObjective={
+          Object {
+            "id": 1,
+            "title": "BO title",
+          }
+        }
+        dispatch={[MockFunction]}
+        policyId="POLICY_ID"
+      />
+      <ReduxForm
+        destroyOnUnmount={true}
+        enableReinitialize={false}
+        forceUnregisterOnUnmount={false}
+        form="editPolicy"
+        getFormState={[Function]}
+        keepDirtyOnReinitialize={false}
+        persistentSubmitErrors={false}
+        pure={true}
+        shouldAsyncValidate={[Function]}
+        shouldError={[Function]}
+        shouldValidate={[Function]}
+        shouldWarn={[Function]}
+        submitAsSideEffect={false}
+        touchOnBlur={true}
+        touchOnChange={false}
+        updateUnregisteredFields={false}
+      />
+    </Form>
+  </Modal>
+</Fragment>
+`;

--- a/src/SmartComponents/EditPolicy/__snapshots__/ProfileThresholdField.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/ProfileThresholdField.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProfileThresholdField expect to render without error 1`] = `
+<Fragment>
+  <Title
+    headingLevel="h3"
+    size="xl"
+  >
+    Compliance threshold
+  </Title>
+  The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
+  <FormGroup
+    field-id="policy-threshold"
+    helperText="A value of 95% or higher is recommended"
+    helperTextInvalid="Threshold has to be a number between 0 and 100"
+    isValid={true}
+    label="Compliance threshold (%)"
+  >
+    <Field
+      aria-label="compliance threshold"
+      defaultValue={10}
+      id="complianceThreshold"
+      isRequired={true}
+      isValid={true}
+      name="complianceThreshold"
+      onChange={[Function]}
+      style={
+        Object {
+          "display": "block",
+          "width": "60%",
+        }
+      }
+      type="number"
+    />
+  </FormGroup>
+</Fragment>
+`;

--- a/src/SmartComponents/InventoryDetails/InventoryDetails.test.js
+++ b/src/SmartComponents/InventoryDetails/InventoryDetails.test.js
@@ -1,0 +1,35 @@
+import toJson from 'enzyme-to-json';
+
+import InventoryDetails from './InventoryDetails';
+
+const MockComponent = jest.fn(({ children, loaded }) => {
+    return children && loaded ? children : 'Loading...';
+});
+
+describe('InventoryDetails', () => {
+    const defaultProps = {
+
+    };
+
+    beforeEach(() => {
+        global.insights = {
+            loadInventory: jest.fn(() => {
+                return Promise.resolve({
+                    inventoryConnector: () => ({
+                        InventoryDetails: MockComponent
+                    }),
+                    INVENTORY_ACTION_TYPES: {},
+                    mergeWithEntities: () => ({})
+                });
+            })
+        };
+    });
+
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <InventoryDetails { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/InventoryDetails/__snapshots__/InventoryDetails.test.js.snap
+++ b/src/SmartComponents/InventoryDetails/__snapshots__/InventoryDetails.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InventoryDetails expect to render without error 1`] = `
+<Fragment>
+  <InventoryCmp
+    hideBack={true}
+  />
+</Fragment>
+`;

--- a/src/SmartComponents/SystemDetails/SystemDetails.test.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.test.js
@@ -1,0 +1,89 @@
+import toJson from 'enzyme-to-json';
+import { useQuery } from '@apollo/react-hooks';
+
+import { SystemDetails } from './SystemDetails.js';
+
+jest.mock('react-router-dom', () => ({
+    ...require.requireActual('react-router-dom'),
+    useHistory: jest.fn(),
+    useLocation: jest.fn(() => ({
+        query: {
+            hidePassed: false
+        }
+    }))
+}));
+
+jest.mock('SmartComponents', () => ({
+    InventoryDetails: () => 'Details'
+}));
+jest.mock('@apollo/react-hooks');
+
+jest.mock('@redhat-cloud-services/frontend-components-inventory-compliance', () =>
+    () => 'Mocked ComplianceSystemDetails'
+);
+
+describe('SystemDetails', () => {
+    const defaultProps = {
+        exportToCSV: jest.fn(),
+        selectedEntities: [1, 2, 3],
+        match: {
+            params: {
+                inventoryId: 1
+            }
+        }
+    };
+    it('expect to render loading', () => {
+        useQuery.mockImplementation(() => ({ data: {}, error: false, loading: true }));
+        const wrapper = shallow(
+            <SystemDetails { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render without error', () => {
+        useQuery.mockImplementation(() => ({
+            data: {
+                system: {
+                    name: 'test.host.local'
+                }
+            }, error: false, loading: false }));
+
+        const wrapper = shallow(
+            <SystemDetails { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render an error', () => {
+        const error = {
+            networkError: { statusCode: 500 },
+            error: 'Test Error loading'
+        };
+        useQuery.mockImplementation(() => ({ data: {}, error, loading: false }));
+        const wrapper = shallow(
+            <SystemDetails { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render an error', () => {
+        window.insights = {
+            chrome: { auth: { logout: jest.fn(() => 'Logout') } }
+        };
+        const error = {
+            networkError: { statusCode: 401 },
+            error: 'Test Error loading'
+        };
+        useQuery.mockImplementation(() => ({ data: {}, error, loading: false }));
+        const wrapper = shallow(
+            <SystemDetails { ...defaultProps }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(window.insights.chrome.auth.logout).toHaveBeenCalled();
+    });
+
+});

--- a/src/SmartComponents/SystemDetails/__snapshots__/SystemDetails.test.js.snap
+++ b/src/SmartComponents/SystemDetails/__snapshots__/SystemDetails.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SystemDetails expect to render an error 1`] = `"Oops! Error loading Systems data: [object Object]"`;
+
+exports[`SystemDetails expect to render an error 2`] = `"Oops! Error loading Systems data: [object Object]"`;
+
+exports[`SystemDetails expect to render loading 1`] = `
+<PageHeader>
+  <Skeleton
+    isDark={false}
+    size="md"
+  />
+</PageHeader>
+`;
+
+exports[`SystemDetails expect to render without error 1`] = `
+<Fragment>
+  <PageHeader>
+    <Component>
+      <BreadcrumbItem
+        onClick={[Function]}
+        to="/rhel/compliance/systems"
+      >
+        Systems
+      </BreadcrumbItem>
+      <BreadcrumbItem
+        isActive={true}
+      >
+        test.host.local
+      </BreadcrumbItem>
+    </Component>
+    <[object Object] />
+    <br />
+  </PageHeader>
+  <Connect(Main)>
+    <Component
+      hidePassed={false}
+    />
+  </Connect(Main)>
+</Fragment>
+`;

--- a/src/SmartComponents/index.js
+++ b/src/SmartComponents/index.js
@@ -1,2 +1,4 @@
 export { default as ComplianceRemediationButton } from './ComplianceRemediationButton/ComplianceRemediationButton';
 export { default as DownloadTableButton } from './DownloadTableButton/DownloadTableButton';
+export { default as ComplianceSystems } from './ComplianceSystems/ComplianceSystems';
+export { default } from './InventoryDetails/InventoryDetails';

--- a/src/Utilities/Breadcrumbs.js
+++ b/src/Utilities/Breadcrumbs.js
@@ -1,7 +1,7 @@
 import { COMPLIANCE_UI_ROOT } from '../constants';
 
-export function onNavigate(event) {
+export function onNavigate(event, history) {
     event.preventDefault();
     const path = event.target.pathname.replace(COMPLIANCE_UI_ROOT, '');
-    this.props.history.push(path);
+    (history ? history : this.props.history).push(path);
 }

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -62,8 +62,7 @@ Array [
         "last_scanned_text": 2019-11-21T14:32:19.000Z,
         "profiles": "Standard System Security Profile for Red Hat Enterprise Linux 7, DISA STIG for Red Hat Enterprise Linux 7, United States Government Configuration Baseline, C2S for Red Hat Enterprise Linux 7",
         "rules_failed": Object {
-          "title": <Link
-            replace={false}
+          "title": <ForwardRef
             to={
               Object {
                 "pathname": "/systems/d5bc2459-21ce-4d11-bc0b-03ea7513dfa6",
@@ -74,7 +73,7 @@ Array [
             }
           >
             505
-          </Link>,
+          </ForwardRef>,
         },
         "rules_failed_text": 505,
         "rules_passed": 336,


### PR DESCRIPTION

 * Update react-router-com to support hooks
 * Add tests for:
   * CompliancePolicies
   * DownloadTableButton
   * BusinessObjectiveField
   * EditPolicy
   * ProfileThresholdField
   * SystemDetails
   * InventoryDetails
* Rewrites the SystemsDetails component to use hooks
* + minor fixes and updates

This brings us to about 66% coverage, removing the ComplianceRemidiationsButton and replacing it with the frontend-component version will bring us to about 75% code coverage.

The remaining 25% of uncovered code are mostly minor functions, but a branch with tests covering those is in progress.
