### PR TITLE
RHICOMPL-449 - Fix floating point thresholds

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -78,7 +78,7 @@ export class EditPolicy extends Component {
                         <UpdateProfileButton
                             key='confirm'
                             policyId={policyId}
-                            threshold={ parseInt(complianceThreshold || previousThreshold) }
+                            threshold={ parseFloat(complianceThreshold || previousThreshold) }
                             businessObjective={businessObjective}
                             editPolicyBusinessObjective={editPolicyBusinessObjective}
                             onClick={this.handleModalToggle}

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -208,7 +208,7 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
                                         </b>
                                     </Text>
                                     <Text className='threshold-tooltip' component={TextVariants.p}>
-                                        { fixedPercentage(policy.complianceThreshold) }
+                                        { fixedPercentage(policy.complianceThreshold, 1) }
                                     </Text>
                                 </span>
                             </Tooltip>

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -266,7 +266,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1%
+              1.0%
             </p>
           </span>
         </div>
@@ -562,7 +562,7 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1%
+              1.0%
             </p>
           </span>
         </div>
@@ -858,7 +858,7 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1%
+              1.0%
             </p>
           </span>
         </div>
@@ -1073,7 +1073,7 @@ exports[`PolicyDetailsQuery passes loading on to SystemTable 1`] = `
                 className="threshold-tooltip"
                 component="p"
               >
-                1%
+                1.0%
               </Text>
             </span>
           </Tooltip>
@@ -1406,7 +1406,7 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1%
+              1.0%
             </p>
           </span>
         </div>
@@ -1702,7 +1702,7 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
               class="threshold-tooltip"
               data-pf-content="true"
             >
-              1%
+              1.0%
             </p>
           </span>
         </div>


### PR DESCRIPTION
Before this PR, a `parseInt` was rounding the compliance threshold value, not allowing the compliance threshold to be set to a float. 