### PR TITLE
Cleanup systemdetails

### DIFF
--- a/src/PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers.test.js
+++ b/src/PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers.test.js
@@ -46,7 +46,8 @@ describe('ReduxFormCheckboxInput', () => {
                 onChange: jest.fn(),
                 value: 'Value'
             },
-            additionalProp: 'Prop1'
+            additionalProp: 'Prop1',
+            id: 'checkbox-id'
         };
         const wrapper = shallow(
             <ReduxFormCheckboxInput { ...field } />

--- a/src/PresentationalComponents/ReduxFormWrappers/__snapshots__/ReduxFormWrappers.test.js.snap
+++ b/src/PresentationalComponents/ReduxFormWrappers/__snapshots__/ReduxFormWrappers.test.js.snap
@@ -4,6 +4,7 @@ exports[`ReduxFormCheckboxInput expect to render without error 1`] = `
 <Checkbox
   additionalProp="Prop1"
   className=""
+  id="checkbox-id"
   input={
     Object {
       "onChange": [MockFunction],

--- a/src/SmartComponents/EditPolicy/UpdateProfileButton.test.js
+++ b/src/SmartComponents/EditPolicy/UpdateProfileButton.test.js
@@ -8,6 +8,7 @@ describe('UpdateProfileButton', () => {
             title: 'Test Objective',
             id: '1'
         },
+        policyId: '12345',
         editPolicyBusinessObjective: {
             title: 'Edited Test Objective',
             value: '2'

--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -1,21 +1,29 @@
 import React from 'react';
-import { useQuery } from '@apollo/react-hooks';
-import { useHistory, useLocation } from 'react-router-dom';
-import propTypes from 'prop-types';
+import gql from 'graphql-tag';
+import {
+    useQuery
+} from '@apollo/react-hooks';
+import {
+    useHistory,
+    useLocation,
+    useParams
+} from 'react-router-dom';
 import {
     PageHeader,
     Main,
     Skeleton,
     SkeletonSize
 } from '@redhat-cloud-services/frontend-components';
-import { onNavigate } from '../../Utilities/Breadcrumbs';
 import {
     Breadcrumb,
     BreadcrumbItem
 } from '@patternfly/react-core';
-import InventoryDetails from 'SmartComponents';
 import ComplianceSystemDetails from '@redhat-cloud-services/frontend-components-inventory-compliance';
-import gql from 'graphql-tag';
+import {
+    onNavigate
+} from 'Utilities/Breadcrumbs';
+
+import InventoryDetails from 'SmartComponents';
 
 const QUERY = gql`
 query System($inventoryId: String!){
@@ -25,16 +33,15 @@ query System($inventoryId: String!){
 }
 `;
 
-export const SystemDetails = (props) => {
-    let history = useHistory();
-    let location = useLocation();
-    const {
-        match: { params: { inventoryId } }
-    } = props;
+const SystemDetails = () => {
+    const history = useHistory();
+    const location = useLocation();
     const hidePassed = location.query && location.query.hidePassed;
+    const { inventoryId } = useParams();
     const { data, error, loading } = useQuery(QUERY, {
         variables: { inventoryId }
     });
+    const onClick = (event) => onNavigate(event, history);
 
     if (error) {
         if (error.networkError.statusCode === 401) {
@@ -52,25 +59,20 @@ export const SystemDetails = (props) => {
         <React.Fragment>
             <PageHeader>
                 <Breadcrumb>
-                    <BreadcrumbItem to='/rhel/compliance/systems' onClick={ (event) => onNavigate(event, history) }>
+                    <BreadcrumbItem to='/rhel/compliance/systems' onClick={ onClick }>
                         Systems
                     </BreadcrumbItem>
-                    <BreadcrumbItem isActive>{data.system.name}</BreadcrumbItem>
+                    <BreadcrumbItem isActive>{ data.system.name }</BreadcrumbItem>
                 </Breadcrumb>
                 <InventoryDetails />
                 <br/>
             </PageHeader>
             <Main>
-                { (inventoryId !== null && typeof(inventoryId) !== 'undefined') &&
-                <ComplianceSystemDetails hidePassed={hidePassed} inventoryId={ inventoryId } /> }
+                { inventoryId &&
+                    <ComplianceSystemDetails hidePassed={ hidePassed } inventoryId={ inventoryId } /> }
             </Main>
         </React.Fragment>
     );
-};
-
-SystemDetails.propTypes = {
-    match: propTypes.object,
-    location: propTypes.object
 };
 
 export default SystemDetails;

--- a/src/SmartComponents/SystemDetails/SystemDetails.test.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.test.js
@@ -1,75 +1,101 @@
 import toJson from 'enzyme-to-json';
 import { useQuery } from '@apollo/react-hooks';
+import { useLocation } from 'react-router-dom';
+import { onNavigate } from 'Utilities/Breadcrumbs';
 
-import { SystemDetails } from './SystemDetails.js';
+import SystemDetails from './SystemDetails.js';
+
+jest.mock('SmartComponents', () => ({
+    InventoryDetails: () => 'MockedInventoryDetails'
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components-inventory-compliance', () =>
+    () => 'MockedComplianceSystemDetails'
+);
+
+jest.mock('@apollo/react-hooks');
 
 jest.mock('react-router-dom', () => ({
     ...require.requireActual('react-router-dom'),
     useHistory: jest.fn(),
-    useLocation: jest.fn(() => ({
-        query: {
-            hidePassed: false
-        }
+    useLocation: jest.fn(),
+    useParams: jest.fn(() => ({
+        inventoryId: 1
     }))
 }));
 
-jest.mock('SmartComponents', () => ({
-    InventoryDetails: () => 'Details'
+jest.mock('Utilities/Breadcrumbs', () => ({
+    onNavigate: jest.fn()
 }));
-jest.mock('@apollo/react-hooks');
-
-jest.mock('@redhat-cloud-services/frontend-components-inventory-compliance', () =>
-    () => 'Mocked ComplianceSystemDetails'
-);
 
 describe('SystemDetails', () => {
-    const defaultProps = {
-        exportToCSV: jest.fn(),
-        selectedEntities: [1, 2, 3],
-        match: {
-            params: {
-                inventoryId: 1
-            }
+    const defaultLocation = {
+        query: {
+            hidePassed: false
         }
     };
-    it('expect to render loading', () => {
-        useQuery.mockImplementation(() => ({ data: {}, error: false, loading: true }));
-        const wrapper = shallow(
-            <SystemDetails { ...defaultProps }/>
-        );
+    const data = {
+        system: {
+            name: 'test.host.local'
+        }
+    };
+    const defaultQuery = {
+        data, error: false, loading: false
+    };
 
-        expect(toJson(wrapper)).toMatchSnapshot();
+    beforeEach(() => {
+        useLocation.mockImplementation(jest.fn(() => defaultLocation));
+        useQuery.mockImplementation(() => defaultQuery);
     });
 
     it('expect to render without error', () => {
-        useQuery.mockImplementation(() => ({
-            data: {
-                system: {
-                    name: 'test.host.local'
-                }
-            }, error: false, loading: false }));
-
         const wrapper = shallow(
-            <SystemDetails { ...defaultProps }/>
+            <SystemDetails />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('expect to render an error', () => {
+    it('expect to call onNavigate on breadcrumb click', () => {
+        const wrapper = shallow(
+            <SystemDetails />
+        );
+        wrapper.find('BreadcrumbItem[to="/rhel/compliance/systems"]').simulate('click');
+        expect(onNavigate).toHaveBeenCalled();
+    });
+
+    it('expect to render loading', () => {
+        useQuery.mockImplementation(() => ({ ...defaultQuery, loading: true }));
+        const wrapper = shallow(
+            <SystemDetails />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render and pass hidePassed correctly', () => {
+        useLocation.mockImplementation(() => ({ query: { hidePassed: true } }));
+        const wrapper = shallow(
+            <SystemDetails />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render a 500 error', () => {
         const error = {
             networkError: { statusCode: 500 },
             error: 'Test Error loading'
         };
-        useQuery.mockImplementation(() => ({ data: {}, error, loading: false }));
+        useQuery.mockImplementation(() => ({ ...defaultQuery, error }));
         const wrapper = shallow(
-            <SystemDetails { ...defaultProps }/>
+            <SystemDetails />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('expect to render an error', () => {
+    it('expect to render a 401 error when logged out', () => {
         window.insights = {
             chrome: { auth: { logout: jest.fn(() => 'Logout') } }
         };
@@ -77,13 +103,12 @@ describe('SystemDetails', () => {
             networkError: { statusCode: 401 },
             error: 'Test Error loading'
         };
-        useQuery.mockImplementation(() => ({ data: {}, error, loading: false }));
+        useQuery.mockImplementation(() => ({ ...defaultQuery, error }));
         const wrapper = shallow(
-            <SystemDetails { ...defaultProps }/>
+            <SystemDetails />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
         expect(window.insights.chrome.auth.logout).toHaveBeenCalled();
     });
-
 });

--- a/src/SmartComponents/SystemDetails/__snapshots__/SystemDetails.test.js.snap
+++ b/src/SmartComponents/SystemDetails/__snapshots__/SystemDetails.test.js.snap
@@ -1,8 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SystemDetails expect to render an error 1`] = `"Oops! Error loading Systems data: [object Object]"`;
+exports[`SystemDetails expect to render a 401 error when logged out 1`] = `"Oops! Error loading Systems data: [object Object]"`;
 
-exports[`SystemDetails expect to render an error 2`] = `"Oops! Error loading Systems data: [object Object]"`;
+exports[`SystemDetails expect to render a 500 error 1`] = `"Oops! Error loading Systems data: [object Object]"`;
+
+exports[`SystemDetails expect to render and pass hidePassed correctly 1`] = `
+<Fragment>
+  <PageHeader>
+    <Component>
+      <BreadcrumbItem
+        onClick={[Function]}
+        to="/rhel/compliance/systems"
+      >
+        Systems
+      </BreadcrumbItem>
+      <BreadcrumbItem
+        isActive={true}
+      >
+        test.host.local
+      </BreadcrumbItem>
+    </Component>
+    <[object Object] />
+    <br />
+  </PageHeader>
+  <Connect(Main)>
+    <Component
+      hidePassed={true}
+      inventoryId={1}
+    />
+  </Connect(Main)>
+</Fragment>
+`;
 
 exports[`SystemDetails expect to render loading 1`] = `
 <PageHeader>


### PR DESCRIPTION
Just a clean up of the `SystemDetails` component after fixing the issues we had with `withRouter`.
It now uses the `useParams` hook to access get the `inventoryId` and tests are a bit cleaner.

There were also two required props missing in the tests for the Checkbox component (that we don't seem to actaully use) and the UpdateProfileButton.