### PR TITLE
RHICOMPL-394 - Move to page 1 after searching systems

### DIFF
--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -139,6 +139,7 @@ export class PoliciesTable extends React.Component {
         const filteredRows = allRows.filter(row => row.cells[0].match(search));
         this.setState({
             search,
+            page: 1,
             rows: filteredRows,
             currentRows: filteredRows.slice(0, itemsPerPage)
         });

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -111,7 +111,7 @@ class SystemsTable extends React.Component {
             variables: { filter: this.buildFilter(), perPage, page, policyId } })
         .then((items) => {
             this.setState({
-                page,
+                page: 1,
                 perPage,
                 items: items.data.systems.edges,
                 totalCount: items.data.systems.totalCount,

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -101,7 +101,7 @@ class SystemsTable extends React.Component {
     }
 
     handleSearch = debounce(search => {
-        this.setState({ search }, this.systemFetch);
+        this.setState({ search, page: 1 }, this.systemFetch);
     }, 500)
 
     systemFetch = () => {
@@ -111,7 +111,7 @@ class SystemsTable extends React.Component {
             variables: { filter: this.buildFilter(), perPage, page, policyId } })
         .then((items) => {
             this.setState({
-                page: 1,
+                page,
                 perPage,
                 items: items.data.systems.edges,
                 totalCount: items.data.systems.totalCount,


### PR DESCRIPTION
![Peek 2020-02-07 08-54](https://user-images.githubusercontent.com/598891/74011281-bab41c80-4987-11ea-8620-3bb47eb294ef.gif)

Without moving back to page 1, the table fails to show the results that should be on the 1st page for searches with results that only cover 1 page.