### PR TITLE
Add operating system to Policies table and details

### DIFF
--- a/src/PresentationalComponents/LoadingPoliciesTable/LoadingPoliciesTable.js
+++ b/src/PresentationalComponents/LoadingPoliciesTable/LoadingPoliciesTable.js
@@ -7,7 +7,8 @@ const LoadingPoliciesTable = () => (
         aria-label='policies-table'
         cells={ [
             { title: 'Policy name' },
-            { title: 'Policy type' },
+            { title: 'Operating system' },
+            { title: 'Systems' },
             { title: 'Business initiative' },
             { title: 'Compliance threshold' }
         ] }

--- a/src/PresentationalComponents/LoadingPoliciesTable/__snapshots__/LoadingPoliciesTable.test.js.snap
+++ b/src/PresentationalComponents/LoadingPoliciesTable/__snapshots__/LoadingPoliciesTable.test.js.snap
@@ -9,7 +9,10 @@ exports[`LoadingPoliciesTable expect to render without error 1`] = `
         "title": "Policy name",
       },
       Object {
-        "title": "Policy type",
+        "title": "Operating system",
+      },
+      Object {
+        "title": "Systems",
       },
       Object {
         "title": "Business initiative",

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -20,6 +20,7 @@ const QUERY = gql`
                 refId
                 complianceThreshold
                 totalHostCount
+                majorOsVersion
                 businessObjective {
                     id
                     title

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -48,7 +48,7 @@ export class PoliciesTable extends React.Component {
         this.state = {
             columns: [
                 { title: 'Policy name' },
-                { title: 'Policy type' },
+                { title: 'Operating system' },
                 { title: 'Systems' },
                 { title: 'Business objective' },
                 { title: 'Compliance threshold' }
@@ -91,7 +91,7 @@ export class PoliciesTable extends React.Component {
             return {
                 cells: [
                     policy.name,
-                    'External',
+                    `RHEL ${policy.majorOsVersion}`,
                     policy.totalHostCount,
                     policy.businessObjective && policy.businessObjective.title || '--',
                     `${policy.complianceThreshold}%`

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -43,24 +43,22 @@ const emptyRows = [{
 }];
 
 export class PoliciesTable extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            columns: [
-                { title: 'Policy name' },
-                { title: 'Operating system' },
-                { title: 'Systems' },
-                { title: 'Business objective' },
-                { title: 'Compliance threshold' }
-            ],
-            page: 1,
-            itemsPerPage: 10,
-            search: '',
-            rows: [],
-            currentRows: [],
-            isDeleteModalOpen: false,
-            policyToDelete: {}
-        };
+    columns = [
+        { title: 'Policy name' },
+        { title: 'Operating system' },
+        { title: 'Systems' },
+        { title: 'Business objective' },
+        { title: 'Compliance threshold' }
+    ]
+    state = {
+        columns: this.columns,
+        page: 1,
+        itemsPerPage: 10,
+        search: '',
+        rows: [],
+        currentRows: [],
+        isDeleteModalOpen: false,
+        policyToDelete: {}
     }
 
     componentDidMount = () => {

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.test.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.test.js
@@ -47,7 +47,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -65,7 +65,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'United States Government Configuration Baseline23',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -74,7 +74,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '67%'
@@ -83,7 +83,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'United States Government Configuration Baseline2',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -92,7 +92,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'C2S for Red Hat Enterprise Linux 7',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '69.5%'
@@ -101,7 +101,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'Criminal Justice Information Services (CJIS) Security Policy',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -110,7 +110,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -119,7 +119,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -128,7 +128,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -137,7 +137,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'Health Insurance Portability and Accountability Act (HIPAA)',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -146,7 +146,7 @@ describe('PoliciesTable', () => {
                 {
                     cells: [
                         'United States Government Configuration Baseline',
-                        'External',
+                        'RHEL 7',
                         10,
                         '--',
                         '100%'
@@ -156,21 +156,21 @@ describe('PoliciesTable', () => {
             const secondPage = [
                 { cells: [
                     'Standard System Security Profile for Red Hat Enterprise Linux 7',
-                    'External',
+                    'RHEL 7',
                     10,
                     '--',
                     '100%'
                 ] },
                 { cells: [
                     'DISA STIG for Red Hat Enterprise Linux 7',
-                    'External',
+                    'RHEL 7',
                     10,
                     '--',
                     '100%'
                 ] },
                 { cells: [
                     'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72',
-                    'External',
+                    'RHEL 7',
                     10,
                     '--',
                     '100%'

--- a/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -52,7 +52,7 @@ exports[`PoliciesTable expect to render emptystate 1`] = `
           "title": "Policy name",
         },
         Object {
-          "title": "Policy type",
+          "title": "Operating system",
         },
         Object {
           "title": "Systems",
@@ -171,7 +171,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
           "title": "Policy name",
         },
         Object {
-          "title": "Policy type",
+          "title": "Operating system",
         },
         Object {
           "title": "Systems",
@@ -190,7 +190,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "United States Government Configuration Baseline23",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "100%",
@@ -199,7 +199,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "67%",
@@ -208,7 +208,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "United States Government Configuration Baseline2",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "100%",
@@ -217,7 +217,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "C2S for Red Hat Enterprise Linux 7",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "69.5%",
@@ -226,7 +226,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "Criminal Justice Information Services (CJIS) Security Policy",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "100%",
@@ -235,7 +235,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "100%",
@@ -244,7 +244,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "100%",
@@ -253,7 +253,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "100%",
@@ -262,7 +262,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "Health Insurance Portability and Accountability Act (HIPAA)",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "100%",
@@ -271,7 +271,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         Object {
           "cells": Array [
             "United States Government Configuration Baseline",
-            "External",
+            "RHEL 7",
             10,
             "--",
             "100%",

--- a/src/SmartComponents/PoliciesTable/fixtures.js
+++ b/src/SmartComponents/PoliciesTable/fixtures.js
@@ -8,6 +8,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -20,6 +21,7 @@ export const policies = {
                 complianceThreshold: 67,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -32,6 +34,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -44,6 +47,7 @@ export const policies = {
                 complianceThreshold: 69.5,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -56,6 +60,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -68,6 +73,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -80,6 +86,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -92,6 +99,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -104,6 +112,7 @@ export const policies = {
                 complianceThreshold: 100,
                 totalHostCount: 10,
                 businessObjective: null,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -116,6 +125,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -128,6 +138,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -140,6 +151,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'
@@ -152,6 +164,7 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                majorOsVersion: 7,
                 __typename: 'Profile'
             },
             __typename: 'ProfileEdge'

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -44,6 +44,7 @@ query Profile($policyId: String!){
         totalHostCount
         compliantHostCount
         complianceThreshold
+        majorOsVersion
         businessObjective {
             id
             title
@@ -212,6 +213,14 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
                                     </Text>
                                 </span>
                             </Tooltip>
+                            <Text component={TextVariants.h5}>
+                                <b>
+                                    Operating system
+                                </b>
+                            </Text>
+                            <Text component={TextVariants.p}>
+                                RHEL { policy.majorOsVersion }
+                            </Text>
                         </TextContent>
                     </GridItem>
                 </Grid>

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -267,6 +267,20 @@ exports[`PolicyDetails expect to render without error 1`] = `
               1.0%
             </p>
           </span>
+          <h5
+            class=""
+            data-pf-content="true"
+          >
+            <b>
+              Operating system
+            </b>
+          </h5>
+          <p
+            class=""
+            data-pf-content="true"
+          >
+            RHEL 
+          </p>
         </div>
       </div>
     </div>
@@ -561,6 +575,20 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
               1.0%
             </p>
           </span>
+          <h5
+            class=""
+            data-pf-content="true"
+          >
+            <b>
+              Operating system
+            </b>
+          </h5>
+          <p
+            class=""
+            data-pf-content="true"
+          >
+            RHEL 
+          </p>
         </div>
       </div>
     </div>
@@ -855,6 +883,20 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
               1.0%
             </p>
           </span>
+          <h5
+            class=""
+            data-pf-content="true"
+          >
+            <b>
+              Operating system
+            </b>
+          </h5>
+          <p
+            class=""
+            data-pf-content="true"
+          >
+            RHEL 
+          </p>
         </div>
       </div>
     </div>
@@ -1071,6 +1113,18 @@ exports[`PolicyDetailsQuery passes loading on to SystemTable 1`] = `
               </Text>
             </span>
           </Tooltip>
+          <Text
+            component="h5"
+          >
+            <b>
+              Operating system
+            </b>
+          </Text>
+          <Text
+            component="p"
+          >
+            RHEL 
+          </Text>
         </TextContent>
       </GridItem>
     </Grid>
@@ -1401,6 +1455,20 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
               1.0%
             </p>
           </span>
+          <h5
+            class=""
+            data-pf-content="true"
+          >
+            <b>
+              Operating system
+            </b>
+          </h5>
+          <p
+            class=""
+            data-pf-content="true"
+          >
+            RHEL 
+          </p>
         </div>
       </div>
     </div>
@@ -1695,6 +1763,20 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
               1.0%
             </p>
           </span>
+          <h5
+            class=""
+            data-pf-content="true"
+          >
+            <b>
+              Operating system
+            </b>
+          </h5>
+          <p
+            class=""
+            data-pf-content="true"
+          >
+            RHEL 
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
⚠️ **Requires** https://github.com/RedHatInsights/compliance-backend/pull/313

This adds the operating system to the policies table as well as the header in the policy details:
![Screenshot 2020-02-10 at 17 14 11](https://user-images.githubusercontent.com/7757/74167858-2ec11f80-4c29-11ea-9234-432457a0a173.png)

![Screenshot 2020-02-10 at 17 16 06](https://user-images.githubusercontent.com/7757/74167864-3254a680-4c29-11ea-9409-ac0a2ee9871b.png)
