### PR TITLE
 RHICOMPL-469 - Compliance Reports should have a By Systems tab 

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -8,7 +8,7 @@
 }
 
 .beta-page-header {
-    padding-bottom: 22px;
+    padding-bottom: 0px;
 }
 
 .pf-l-tabs, .pf-c-tabs {

--- a/src/PresentationalComponents/ComplianceTabs/ComplianceTabs.js
+++ b/src/PresentationalComponents/ComplianceTabs/ComplianceTabs.js
@@ -9,7 +9,7 @@ export const ComplianceTabs = (props) => {
     const { match: { path } } = props;
 
     const tabPaths = {
-        0: paths.Reports,
+        0: paths.reports,
         1: paths.compliancePolicies,
         2: paths.complianceSystems
     };

--- a/src/PresentationalComponents/ReportTabs/ReportTabs.js
+++ b/src/PresentationalComponents/ReportTabs/ReportTabs.js
@@ -5,13 +5,12 @@ import { paths } from '../../Routes';
 import { Tabs, Tab } from '@patternfly/react-core';
 import invert from 'lodash/invert';
 
-export const ComplianceTabs = (props) => {
+export const ReportTabs = (props) => {
     const { match: { path } } = props;
 
     const tabPaths = {
-        0: paths.Reports,
-        1: paths.compliancePolicies,
-        2: paths.complianceSystems
+        0: paths.reports,
+        1: paths.reportsSystems
     };
 
     const redirect = (_, tabIndex) => {
@@ -21,21 +20,20 @@ export const ComplianceTabs = (props) => {
     let currentKey = Number(invert(tabPaths)[path]);
 
     const tabs = [
-        <Tab title={'Reports'} key={0} eventKey={0}></Tab>,
-        <Tab title={'Policies'} key={1} eventKey={1}></Tab>,
-        <Tab title={'Systems'} key={2} eventKey={2}></Tab>
+        <Tab title={'By policy'} key={0} eventKey={0}></Tab>,
+        <Tab title={'By systems'} key={1} eventKey={1}></Tab>
     ];
 
     return (
-        <Tabs activeKey={currentKey} onSelect={redirect} aria-label="Compliance Tabs">
+        <Tabs activeKey={currentKey} onSelect={redirect} aria-label="Report Tabs">
             { tabs }
         </Tabs>
     );
 };
 
-ComplianceTabs.propTypes = {
+ReportTabs.propTypes = {
     history: propTypes.object,
     match: propTypes.object
 };
 
-export default routerParams(ComplianceTabs);
+export default routerParams(ReportTabs);

--- a/src/PresentationalComponents/ReportTabs/ReportTabs.test.js
+++ b/src/PresentationalComponents/ReportTabs/ReportTabs.test.js
@@ -1,0 +1,21 @@
+import toJson from 'enzyme-to-json';
+import { paths } from '../../Routes';
+
+import { ReportTabs } from './ReportTabs';
+
+describe('ReportTabs', () => {
+    const defaultProps = {
+        history: {},
+        match: {
+            path: paths.complianceSystems
+        }
+    };
+
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <ReportTabs { ...defaultProps } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/ReportTabs/__snapshots__/ReportTabs.test.js.snap
+++ b/src/PresentationalComponents/ReportTabs/__snapshots__/ReportTabs.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportTabs expect to render without error 1`] = `
+<Component
+  activeKey={NaN}
+  aria-label="Report Tabs"
+  onSelect={[Function]}
+>
+  <Tab
+    eventKey={0}
+    key="0"
+    title="By policy"
+  />
+  <Tab
+    eventKey={1}
+    key="1"
+    title="By systems"
+  />
+</Component>
+`;

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -1,4 +1,5 @@
 export { default as ComplianceTabs } from './ComplianceTabs/ComplianceTabs';
+export { default as ReportTabs } from './ReportTabs/ReportTabs';
 export { default as LoadingComplianceCards } from './LoadingComplianceCards/LoadingComplianceCards';
 export { default as LoadingPoliciesTable } from './LoadingPoliciesTable/LoadingPoliciesTable';
 export { default as ReportCard } from './ReportCard/ReportCard';

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -20,8 +20,11 @@ import some from 'lodash/some';
 const CompliancePolicies = asyncComponent(() =>
     import(/* webpackChunkName: "CompliancePolicies" */ 'SmartComponents/CompliancePolicies/CompliancePolicies')
 );
-const ComplianceReports = asyncComponent(() =>
-    import(/* webpackChunkName: "ComplianceReports" */ './SmartComponents/ComplianceReports/ComplianceReports')
+const Reports = asyncComponent(() =>
+    import(/* webpackChunkName: "Reports" */ './SmartComponents/Reports/Reports')
+);
+const ReportsSystems = asyncComponent(() =>
+    import(/* webpackChunkName: "ReportsSystems" */ './SmartComponents/ReportsSystems/ReportsSystems')
 );
 const ComplianceSystems = asyncComponent(() =>
     import(/* webpackChunkName: "ComplianceSystems" */ 'SmartComponents/ComplianceSystems/ComplianceSystems')
@@ -35,7 +38,8 @@ const SystemDetails = asyncComponent(() =>
 
 export const paths = {
     compliancePolicies: '/policies',
-    complianceReports: '/reports',
+    reports: '/reports',
+    reportsSystems: '/reports/systems',
     complianceSystems: '/systems',
     complianceSystemsInventoryDetail: '/systems/:inventoryId',
     policyDetails: '/policies/:policy_id',
@@ -61,7 +65,8 @@ export const Routes = (props: Props) => {
     return (
         <Switch>
             <Route exact path={paths.compliancePolicies} component={CompliancePolicies} />
-            <Route exact path={paths.complianceReports} component={ComplianceReports} />
+            <Route exact path={paths.reports} component={Reports} />
+            <Route exact path={paths.reportsSystems} component={ReportsSystems} />
             <Route exact path={paths.complianceSystems} component={ComplianceSystems} />
             <Route path={paths.complianceSystemsInventoryDetail} component={SystemDetails} />
             <Route path={paths.policyDetailsInventoryDetail} component={SystemDetails} />
@@ -69,7 +74,7 @@ export const Routes = (props: Props) => {
             <Route path={paths.systemDetails} component={SystemDetails} />
 
             {/* Finally, catch all unmatched routes */}
-            <Route render={() => (some(paths, p => p === path) ? null : <Redirect to={paths.complianceReports} />)} />
+            <Route render={() => (some(paths, p => p === path) ? null : <Redirect to={paths.reports} />)} />
         </Switch>
     );
 };

--- a/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
+++ b/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
@@ -11,7 +11,8 @@ exports[`ComplianceSystems expect to render without error 1`] = `
     <withRouter(Connect(RouterParams)) />
   </PageHeader>
   <Connect(Main)>
-    <Connect(withApollo(SystemsTable))
+    <withApollo(SystemsTable)
+      allSystems={true}
       columns={
         Array [
           Object {

--- a/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
+++ b/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
@@ -11,7 +11,7 @@ exports[`ComplianceSystems expect to render without error 1`] = `
     <withRouter(Connect(RouterParams)) />
   </PageHeader>
   <Connect(Main)>
-    <withApollo(SystemsTable)
+    <Connect(withApollo(SystemsTable))
       allSystems={true}
       columns={
         Array [

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -48,6 +48,7 @@ const EditPolicySystems = ({ change, selectedSystemIds }) => {
                     columns={columns}
                     remediationsEnabled={false}
                     compact={true}
+                    allSystems
                     enableExport={ false }/>
             </Form>
         </React.Fragment>

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
     ComplianceTabs,
+    ReportTabs,
     LoadingComplianceCards,
     ReportCard,
     CompliancePoliciesEmptyState,
@@ -34,7 +35,7 @@ const QUERY = gql`
 }
 `;
 
-export const ComplianceReports = () => {
+export const Reports = () => {
     const { data, error, loading } = useQuery(QUERY);
 
     if (error) { return <ErrorPage error={error}/>; }
@@ -64,7 +65,7 @@ export const ComplianceReports = () => {
     if (policies.length) {
         pageHeader = <PageHeader className={ beta ? 'beta-page-header' : 'stable-page-header' }>
             <PageHeaderTitle title="Compliance reports" />
-            { !beta && <ComplianceTabs/> }
+            { beta ? <ReportTabs/> : <ComplianceTabs/> }
 
         </PageHeader>;
         reportCards = policies.map(
@@ -95,4 +96,4 @@ export const ComplianceReports = () => {
     );
 };
 
-export default routerParams(ComplianceReports);
+export default routerParams(Reports);

--- a/src/SmartComponents/Reports/Reports.test.js
+++ b/src/SmartComponents/Reports/Reports.test.js
@@ -1,11 +1,11 @@
 import toJson from 'enzyme-to-json';
 import { useQuery } from '@apollo/react-hooks';
 
-import { ComplianceReports } from './ComplianceReports.js';
+import { Reports } from './Reports.js';
 
 jest.mock('@apollo/react-hooks');
 
-describe('ComplianceReports', () => {
+describe('Reports', () => {
     it('expect to render without error', () => {
         useQuery.mockImplementation(() => ({
             data: {
@@ -25,7 +25,7 @@ describe('ComplianceReports', () => {
             }, error: false, loading: false }));
 
         const wrapper = shallow(
-            <ComplianceReports />
+            <Reports />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -38,7 +38,7 @@ describe('ComplianceReports', () => {
             }, error: false, loading: false }));
 
         const wrapper = shallow(
-            <ComplianceReports />
+            <Reports />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -51,7 +51,7 @@ describe('ComplianceReports', () => {
         };
         useQuery.mockImplementation(() => ({ data: {}, error, loading: false }));
         const wrapper = shallow(
-            <ComplianceReports />
+            <Reports />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -60,7 +60,7 @@ describe('ComplianceReports', () => {
     it('expect to render loading', () => {
         useQuery.mockImplementation(() => ({ data: {}, error: false, loading: true }));
         const wrapper = shallow(
-            <ComplianceReports />
+            <Reports />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
+++ b/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ComplianceReports expect to render an error 1`] = `
+exports[`Reports expect to render an error 1`] = `
 <ErrorPage
   error={
     Object {
@@ -13,7 +13,7 @@ exports[`ComplianceReports expect to render an error 1`] = `
 />
 `;
 
-exports[`ComplianceReports expect to render emptystate 1`] = `
+exports[`Reports expect to render emptystate 1`] = `
 <Fragment>
   <PageHeader
     style={
@@ -40,7 +40,7 @@ exports[`ComplianceReports expect to render emptystate 1`] = `
 </Fragment>
 `;
 
-exports[`ComplianceReports expect to render loading 1`] = `
+exports[`Reports expect to render loading 1`] = `
 <Fragment>
   <PageHeader>
     <PageHeaderTitle
@@ -61,7 +61,7 @@ exports[`ComplianceReports expect to render loading 1`] = `
 </Fragment>
 `;
 
-exports[`ComplianceReports expect to render without error 1`] = `
+exports[`Reports expect to render without error 1`] = `
 <Fragment>
   <PageHeader
     className="stable-page-header"

--- a/src/SmartComponents/ReportsSystems/ReportsSystems.js
+++ b/src/SmartComponents/ReportsSystems/ReportsSystems.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import SystemsTable from '../SystemsTable/SystemsTable';
-import { ComplianceTabs } from 'PresentationalComponents';
+import { ComplianceTabs, ReportTabs } from 'PresentationalComponents';
 import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/frontend-components';
 
-const ComplianceSystems = () => {
+const ReportsSystems = () => {
     const columns = [{
         composed: ['facts.os_release', 'display_name'],
         key: 'display_name',
-        title: 'Name',
+        title: 'System name',
         props: {
             width: 40
         }
@@ -30,20 +30,19 @@ const ComplianceSystems = () => {
             width: 10
         }
     }];
-
     const beta = window.location.pathname.split('/')[1] === 'beta';
 
     return (
         <React.Fragment>
             <PageHeader className={ beta ? 'beta-page-header' : 'stable-page-header' } >
-                <PageHeaderTitle title="Compliance systems" />
-                { !beta && <ComplianceTabs/> }
+                <PageHeaderTitle title="Compliance reports" />
+                { beta ? <ReportTabs/> : <ComplianceTabs/> }
             </PageHeader>
             <Main>
-                <SystemsTable allSystems columns={columns} />
+                <SystemsTable columns={columns} />
             </Main>
         </React.Fragment>
     );
 };
 
-export default ComplianceSystems;
+export default ReportsSystems;

--- a/src/SmartComponents/ReportsSystems/ReportsSystems.js
+++ b/src/SmartComponents/ReportsSystems/ReportsSystems.js
@@ -30,7 +30,7 @@ const ReportsSystems = () => {
             width: 10
         }
     }];
-    const beta = window.location.pathname.split('/')[1] === 'beta';
+    const beta = window.insights.chrome.isBeta();
 
     return (
         <React.Fragment>

--- a/src/SmartComponents/ReportsSystems/ReportsSystems.test.js
+++ b/src/SmartComponents/ReportsSystems/ReportsSystems.test.js
@@ -7,7 +7,23 @@ jest.mock('@redhat-cloud-services/frontend-components-inventory-compliance', () 
 );
 
 describe('ReportsSystems', () => {
-    it('expect to render without error', () => {
+    it('expect to render without error in beta', () => {
+        window.insights = {
+            chrome: { isBeta: jest.fn(() => true) }
+        };
+
+        const wrapper = shallow(
+            <ReportsSystems />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render without error in stable', () => {
+        window.insights = {
+            chrome: { isBeta: jest.fn(() => false) }
+        };
+
         const wrapper = shallow(
             <ReportsSystems />
         );

--- a/src/SmartComponents/ReportsSystems/ReportsSystems.test.js
+++ b/src/SmartComponents/ReportsSystems/ReportsSystems.test.js
@@ -1,0 +1,17 @@
+import toJson from 'enzyme-to-json';
+
+import ReportsSystems from './ReportsSystems.js';
+
+jest.mock('@redhat-cloud-services/frontend-components-inventory-compliance', () =>
+    () => 'Mocked ComplianceSystemDetails'
+);
+
+describe('ReportsSystems', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <ReportsSystems />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
+++ b/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportsSystems expect to render without error 1`] = `
+<Fragment>
+  <PageHeader
+    className="stable-page-header"
+  >
+    <PageHeaderTitle
+      title="Compliance reports"
+    />
+    <withRouter(Connect(RouterParams)) />
+  </PageHeader>
+  <Connect(Main)>
+    <withApollo(SystemsTable)
+      columns={
+        Array [
+          Object {
+            "composed": Array [
+              "facts.os_release",
+              "display_name",
+            ],
+            "key": "display_name",
+            "props": Object {
+              "width": 40,
+            },
+            "title": "System name",
+          },
+          Object {
+            "key": "facts.compliance.compliance_score",
+            "props": Object {
+              "width": 10,
+            },
+            "title": "Compliance score",
+          },
+          Object {
+            "key": "facts.compliance.last_scanned",
+            "props": Object {
+              "width": 10,
+            },
+            "title": "Last scanned",
+          },
+        ]
+      }
+    />
+  </Connect(Main)>
+</Fragment>
+`;

--- a/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
+++ b/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
@@ -26,6 +26,13 @@ exports[`ReportsSystems expect to render without error 1`] = `
             "title": "System name",
           },
           Object {
+            "key": "facts.compliance.profiles",
+            "props": Object {
+              "width": 40,
+            },
+            "title": "Profiles",
+          },
+          Object {
             "key": "facts.compliance.compliance_score",
             "props": Object {
               "width": 10,

--- a/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
+++ b/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
@@ -11,7 +11,7 @@ exports[`ReportsSystems expect to render without error 1`] = `
     <withRouter(Connect(RouterParams)) />
   </PageHeader>
   <Connect(Main)>
-    <withApollo(SystemsTable)
+    <Connect(withApollo(SystemsTable))
       columns={
         Array [
           Object {

--- a/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
+++ b/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
@@ -1,6 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ReportsSystems expect to render without error 1`] = `
+exports[`ReportsSystems expect to render without error in beta 1`] = `
+<Fragment>
+  <PageHeader
+    className="beta-page-header"
+  >
+    <PageHeaderTitle
+      title="Compliance reports"
+    />
+    <withRouter(Connect(RouterParams)) />
+  </PageHeader>
+  <Connect(Main)>
+    <Connect(withApollo(SystemsTable))
+      columns={
+        Array [
+          Object {
+            "composed": Array [
+              "facts.os_release",
+              "display_name",
+            ],
+            "key": "display_name",
+            "props": Object {
+              "width": 40,
+            },
+            "title": "System name",
+          },
+          Object {
+            "key": "facts.compliance.profiles",
+            "props": Object {
+              "width": 40,
+            },
+            "title": "Profiles",
+          },
+          Object {
+            "key": "facts.compliance.compliance_score",
+            "props": Object {
+              "width": 10,
+            },
+            "title": "Compliance score",
+          },
+          Object {
+            "key": "facts.compliance.last_scanned",
+            "props": Object {
+              "width": 10,
+            },
+            "title": "Last scanned",
+          },
+        ]
+      }
+    />
+  </Connect(Main)>
+</Fragment>
+`;
+
+exports[`ReportsSystems expect to render without error in stable 1`] = `
 <Fragment>
   <PageHeader
     className="stable-page-header"

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -300,7 +300,7 @@ class SystemsTable extends React.Component {
             onRefresh={ this.onRefresh }
             page={ page }
             ref={ this.inventory }
-            total={ totalCount }
+            total={totalCount}
             perPage={ perPage }
             variant={ compact ? pfReactTable.TableVariant.compact : null }
             items={ allSystems ? undefined : items.map((edge) => edge.node.id) }

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -268,9 +268,9 @@ class SystemsTable extends React.Component {
     }
 
     render() {
-        const { remediationsEnabled, compact, enableExport } = this.props;
+        const { remediationsEnabled, compact, enableExport, allSystems } = this.props;
         const {
-            page, totalCount, perPage, items, InventoryCmp, filterChips, allSystems,
+            page, totalCount, perPage, items, InventoryCmp, filterChips,
             selectedSystemId, selectedSystemFqdn, isAssignPoliciesModalOpen } = this.state;
         const filterConfig = this.filterConfig.buildConfiguration(
             this.updateFilter,
@@ -300,13 +300,13 @@ class SystemsTable extends React.Component {
             onRefresh={ this.onRefresh }
             page={ page }
             ref={ this.inventory }
-            total={totalCount}
+            total={ allSystems ? undefined : totalCount}
             perPage={ perPage }
             variant={ compact ? pfReactTable.TableVariant.compact : null }
             items={ allSystems ? undefined : items.map((edge) => edge.node.id) }
-            filterConfig={ filterConfig }
+            filterConfig={ allSystems ? undefined : filterConfig }
             exportConfig={ exportConfig }
-            activeFiltersConfig={{
+            activeFiltersConfig={allSystems ? undefined : {
                 filters: filterChips,
                 onDelete: this.onFilterDelete
             }}>

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -278,9 +278,8 @@ class SystemsTable extends React.Component {
             { hideLabel: true }
         );
         const exportConfig = enableExport ? { onSelect: this.onExportSelect } : {};
-
-        return <InventoryCmp
-            actions={[
+        const inventoryTableProps = {
+            actions: [
                 {
                     title: 'Edit policies for this system',
                     onClick: (_event, _index, { id, fqdn }) => {
@@ -296,20 +295,29 @@ class SystemsTable extends React.Component {
                         window.location.href = `${window.location.origin}/rhel/inventory/${id}`;
                     }
                 }
-            ]}
-            onRefresh={ this.onRefresh }
-            page={ page }
-            ref={ this.inventory }
-            total={ allSystems ? undefined : totalCount}
-            perPage={ perPage }
-            variant={ compact ? pfReactTable.TableVariant.compact : null }
-            items={ allSystems ? undefined : items.map((edge) => edge.node.id) }
-            filterConfig={ allSystems ? undefined : filterConfig }
-            exportConfig={ exportConfig }
-            activeFiltersConfig={allSystems ? undefined : {
+            ],
+            onRefresh: this.onRefresh,
+            ref: this.inventory,
+            page,
+            perPage,
+            exportConfig
+        };
+
+        if (!allSystems) {
+            inventoryTableProps.total = totalCount;
+            inventoryTableProps.items = items.map((edge) => edge.node.id);
+            inventoryTableProps.filterConfig = filterConfig;
+            inventoryTableProps.activeFiltersConfig = {
                 filters: filterChips,
                 onDelete: this.onFilterDelete
-            }}>
+            };
+        }
+
+        if (compact) {
+            inventoryTableProps.variant = pfReactTable.TableVariant.compact;
+        }
+
+        return <InventoryCmp { ...inventoryTableProps }>
             { !allSystems && <reactCore.ToolbarGroup>
                 { remediationsEnabled &&
                     <reactCore.ToolbarItem style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}>

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -105,7 +105,6 @@ Object {
           "page": 1,
           "perPage": 50,
           "total": 0,
-          "variant": null,
         },
         Object {},
       ],
@@ -260,7 +259,6 @@ Object {
           "page": 1,
           "perPage": 50,
           "total": 0,
-          "variant": null,
         },
         Object {},
       ],
@@ -414,7 +412,6 @@ Object {
           "page": 1,
           "perPage": 50,
           "total": 0,
-          "variant": null,
         },
         Object {},
       ],
@@ -558,7 +555,6 @@ Object {
           "page": 1,
           "perPage": 50,
           "total": 0,
-          "variant": null,
         },
         Object {},
       ],
@@ -704,7 +700,6 @@ exports[`SystemsTable expect to not render a loading state 1`] = `
   page={1}
   perPage={50}
   total={0}
-  variant={null}
 >
   <ToolbarGroup>
     <ToolbarItem
@@ -1282,7 +1277,6 @@ exports[`SystemsTable expect to set loading state correctly on systemfetch 1`] =
   page={1}
   perPage={50}
   total={1}
-  variant={null}
 >
   <ToolbarGroup>
     <ToolbarItem


### PR DESCRIPTION
The "By systems" tab is now the old systems table, which only contains hosts with compliance policies assigned:  
![Screenshot from 2020-02-21 17-11-31](https://user-images.githubusercontent.com/598891/75051211-bd595a80-54cd-11ea-8637-6aed757aca2c.png)

And the /systems page is now the whole inventory with the actions to assign the policies:
![Screenshot from 2020-02-21 17-11-09](https://user-images.githubusercontent.com/598891/75051278-da8e2900-54cd-11ea-8506-e4ae594a1ecf.png)

