### PR TITLE
Set key for compliance icon

### DIFF
--- a/src/PresentationalComponents/ComplianceScore/ComplianceScore.js
+++ b/src/PresentationalComponents/ComplianceScore/ComplianceScore.js
@@ -28,7 +28,7 @@ export const complianceScoreString = (system) => {
 
 const ComplianceScore = (system) => (
     <React.Fragment>
-        <CompliantIcon { ...system } />
+        <CompliantIcon key={ `system-compliance-icon-${system.id}` } { ...system } />
         { complianceScoreString(system) }
     </React.Fragment>
 );


### PR DESCRIPTION
Eliminates: 
```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `BodyRow`. See https://fb.me/react-warning-keys for more information.
    in CompliantIcon
    in BodyRow (created by BaseBody)
    in tbody (created by BodyWrapper)
    in BodyWrapper (created by BaseBody)
    in BaseBody (created by Context.Consumer)
    in Body (created by ContextBody)
    in ContextBody (created by Context.Consumer)
    in TableBody
```