### PR TITLE
Add checkbox to optionally remove all test results aka. reports

### DIFF
--- a/src/SmartComponents/DeletePolicy/DeletePolicy.js
+++ b/src/SmartComponents/DeletePolicy/DeletePolicy.js
@@ -1,16 +1,18 @@
 import {
     Modal,
     TextContent,
-    Button
+    Button,
+    Checkbox
 } from '@patternfly/react-core';
 import propTypes from 'prop-types';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useMutation } from '@apollo/react-hooks';
 import { DELETE_PROFILE } from '../../Utilities/graphql/mutations';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { dispatchAction } from '../../Utilities/Dispatcher';
 
 const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
+    const [deleteAllTestResults, setDeleteAll] = useState(false);
     const [deletePolicy] = useMutation(DELETE_PROFILE, {
         onCompleted: () => {
             dispatchAction(addNotification({
@@ -31,6 +33,16 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
         }
     });
     const { name, id } = policy;
+    const variables = {
+        input: {
+            id,
+            deleteAllTestResults
+        }
+    };
+
+    useEffect(() => {
+        setDeleteAll(false);
+    }, [policy]);
 
     return (
         <Modal
@@ -43,7 +55,7 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
                 <Button key='destroy'
                     aria-label="delete"
                     variant='danger'
-                    onClick={() => deletePolicy({ variables: { input: { id } } })}>
+                    onClick={() => deletePolicy({ variables }) }>
                     Delete policy
                 </Button>,
                 <Button key='cancel' variant='secondary' onClick={toggle}>
@@ -57,6 +69,12 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
             <TextContent>
                 This cannot be undone.
             </TextContent>
+            <Checkbox
+                id={ `delete-all-reports-${id}` }
+                isChecked={ deleteAllTestResults }
+                onChange={ () => setDeleteAll(!deleteAllTestResults) }
+                aria-label="controlled checkbox example"
+                label="Delete all reports for this policy" />
         </Modal>
     );
 };

--- a/src/SmartComponents/DeletePolicy/DeletePolicy.js
+++ b/src/SmartComponents/DeletePolicy/DeletePolicy.js
@@ -12,7 +12,8 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import { dispatchAction } from '../../Utilities/Dispatcher';
 
 const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
-    const [deleteAllTestResults, setDeleteAll] = useState(false);
+    const defaultDeleteAllState = false;
+    const [deleteAllTestResults, setDeleteAll] = useState(defaultDeleteAllState);
     const [deletePolicy] = useMutation(DELETE_PROFILE, {
         onCompleted: () => {
             dispatchAction(addNotification({
@@ -33,15 +34,9 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
         }
     });
     const { name, id } = policy;
-    const variables = {
-        input: {
-            id,
-            deleteAllTestResults
-        }
-    };
 
     useEffect(() => {
-        setDeleteAll(false);
+        setDeleteAll(defaultDeleteAllState);
     }, [policy]);
 
     return (
@@ -55,7 +50,8 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
                 <Button key='destroy'
                     aria-label="delete"
                     variant='danger'
-                    onClick={() => deletePolicy({ variables }) }>
+                    onClick={() => deletePolicy({ variables: { input: { id, deleteAllTestResults } } })}
+                >
                     Delete policy
                 </Button>,
                 <Button key='cancel' variant='secondary' onClick={toggle}>
@@ -69,11 +65,12 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
             <TextContent>
                 This cannot be undone.
             </TextContent>
+            <br />
             <Checkbox
                 id={ `delete-all-reports-${id}` }
                 isChecked={ deleteAllTestResults }
                 onChange={ () => setDeleteAll(!deleteAllTestResults) }
-                aria-label="controlled checkbox example"
+                aria-label="delete-all-reports-checkbox"
                 label="Delete all reports for this policy" />
         </Modal>
     );

--- a/src/SmartComponents/DeletePolicy/DeletePolicy.test.js
+++ b/src/SmartComponents/DeletePolicy/DeletePolicy.test.js
@@ -51,4 +51,21 @@ describe('DeletePolicy', () => {
         expect(defaultProps.onDelete).toHaveBeenCalled();
         expect(toJson(component)).toMatchSnapshot();
     });
+
+    it('expect to call toggle and onDelete when clicked', () => {
+        const mockMutationReturn = jest.fn();
+        const expectedArguments = { variables: { input: { id: 1, deleteAllTestResults: true } } };
+        useMutation.mockImplementation(() => {
+            return [mockMutationReturn];
+        });
+        const component = mount(
+            <DeletePolicy { ...defaultProps } />
+        );
+        component.find('input[aria-label="delete-all-reports-checkbox"]').simulate('click');
+        // Again, somehow a click doesn't trigger a change, therefore manually
+        component.find('input[aria-label="delete-all-reports-checkbox"]').simulate('change');
+        component.find('button[aria-label="delete"]').simulate('click');
+
+        expect(mockMutationReturn).toHaveBeenCalledWith(expectedArguments);
+    });
 });

--- a/src/SmartComponents/DeletePolicy/__snapshots__/DeletePolicy.test.js.snap
+++ b/src/SmartComponents/DeletePolicy/__snapshots__/DeletePolicy.test.js.snap
@@ -93,6 +93,23 @@ exports[`DeletePolicy expect not to render anything for a closed modal 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <div
+                    class="pf-c-check"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="controlled checkbox example"
+                      class="pf-c-check__input"
+                      id="delete-all-reports-1"
+                      type="checkbox"
+                    />
+                    <label
+                      class="pf-c-check__label"
+                      for="delete-all-reports-1"
+                    >
+                      Delete all reports for this policy
+                    </label>
+                  </div>
                 </div>
                 <div
                   class="pf-c-modal-box__footer pf-m-align-left"
@@ -298,6 +315,23 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <div
+                    class="pf-c-check"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="controlled checkbox example"
+                      class="pf-c-check__input"
+                      id="delete-all-reports-1"
+                      type="checkbox"
+                    />
+                    <label
+                      class="pf-c-check__label"
+                      for="delete-all-reports-1"
+                    >
+                      Delete all reports for this policy
+                    </label>
+                  </div>
                 </div>
                 <div
                   class="pf-c-modal-box__footer pf-m-align-left"
@@ -381,6 +415,23 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                     class="pf-c-content"
                   >
                     This cannot be undone.
+                  </div>
+                  <div
+                    class="pf-c-check"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="controlled checkbox example"
+                      class="pf-c-check__input"
+                      id="delete-all-reports-1"
+                      type="checkbox"
+                    />
+                    <label
+                      class="pf-c-check__label"
+                      for="delete-all-reports-1"
+                    >
+                      Delete all reports for this policy
+                    </label>
                   </div>
                 </div>
                 <div
@@ -489,6 +540,23 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                     class="pf-c-content"
                   >
                     This cannot be undone.
+                  </div>
+                  <div
+                    class="pf-c-check"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="controlled checkbox example"
+                      class="pf-c-check__input"
+                      id="delete-all-reports-1"
+                      type="checkbox"
+                    />
+                    <label
+                      class="pf-c-check__label"
+                      for="delete-all-reports-1"
+                    >
+                      Delete all reports for this policy
+                    </label>
                   </div>
                 </div>
                 <div
@@ -782,6 +850,37 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                             This cannot be undone.
                           </div>
                         </TextContent>
+                        <Checkbox
+                          aria-label="controlled checkbox example"
+                          className=""
+                          id="delete-all-reports-1"
+                          isChecked={false}
+                          isDisabled={false}
+                          isValid={true}
+                          label="Delete all reports for this policy"
+                          onChange={[Function]}
+                        >
+                          <div
+                            className="pf-c-check"
+                          >
+                            <input
+                              aria-invalid={false}
+                              aria-label="controlled checkbox example"
+                              checked={false}
+                              className="pf-c-check__input"
+                              disabled={false}
+                              id="delete-all-reports-1"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <label
+                              className="pf-c-check__label"
+                              htmlFor="delete-all-reports-1"
+                            >
+                              Delete all reports for this policy
+                            </label>
+                          </div>
+                        </Checkbox>
                       </div>
                     </ModalBoxBody>
                     <ModalBoxFooter
@@ -1026,6 +1125,23 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <div
+                    class="pf-c-check"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="controlled checkbox example"
+                      class="pf-c-check__input"
+                      id="delete-all-reports-1"
+                      type="checkbox"
+                    />
+                    <label
+                      class="pf-c-check__label"
+                      for="delete-all-reports-1"
+                    >
+                      Delete all reports for this policy
+                    </label>
+                  </div>
                 </div>
                 <div
                   class="pf-c-modal-box__footer pf-m-align-left"
@@ -1121,6 +1237,23 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                     class="pf-c-content"
                   >
                     This cannot be undone.
+                  </div>
+                  <div
+                    class="pf-c-check"
+                  >
+                    <input
+                      aria-invalid="false"
+                      aria-label="controlled checkbox example"
+                      class="pf-c-check__input"
+                      id="delete-all-reports-1"
+                      type="checkbox"
+                    />
+                    <label
+                      class="pf-c-check__label"
+                      for="delete-all-reports-1"
+                    >
+                      Delete all reports for this policy
+                    </label>
                   </div>
                 </div>
                 <div
@@ -1332,6 +1465,37 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                             This cannot be undone.
                           </div>
                         </TextContent>
+                        <Checkbox
+                          aria-label="controlled checkbox example"
+                          className=""
+                          id="delete-all-reports-1"
+                          isChecked={false}
+                          isDisabled={false}
+                          isValid={true}
+                          label="Delete all reports for this policy"
+                          onChange={[Function]}
+                        >
+                          <div
+                            className="pf-c-check"
+                          >
+                            <input
+                              aria-invalid={false}
+                              aria-label="controlled checkbox example"
+                              checked={false}
+                              className="pf-c-check__input"
+                              disabled={false}
+                              id="delete-all-reports-1"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <label
+                              className="pf-c-check__label"
+                              htmlFor="delete-all-reports-1"
+                            >
+                              Delete all reports for this policy
+                            </label>
+                          </div>
+                        </Checkbox>
                       </div>
                     </ModalBoxBody>
                     <ModalBoxFooter

--- a/src/SmartComponents/DeletePolicy/__snapshots__/DeletePolicy.test.js.snap
+++ b/src/SmartComponents/DeletePolicy/__snapshots__/DeletePolicy.test.js.snap
@@ -93,12 +93,13 @@ exports[`DeletePolicy expect not to render anything for a closed modal 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <br />
                   <div
                     class="pf-c-check"
                   >
                     <input
                       aria-invalid="false"
-                      aria-label="controlled checkbox example"
+                      aria-label="delete-all-reports-checkbox"
                       class="pf-c-check__input"
                       id="delete-all-reports-1"
                       type="checkbox"
@@ -315,12 +316,13 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <br />
                   <div
                     class="pf-c-check"
                   >
                     <input
                       aria-invalid="false"
-                      aria-label="controlled checkbox example"
+                      aria-label="delete-all-reports-checkbox"
                       class="pf-c-check__input"
                       id="delete-all-reports-1"
                       type="checkbox"
@@ -416,12 +418,13 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <br />
                   <div
                     class="pf-c-check"
                   >
                     <input
                       aria-invalid="false"
-                      aria-label="controlled checkbox example"
+                      aria-label="delete-all-reports-checkbox"
                       class="pf-c-check__input"
                       id="delete-all-reports-1"
                       type="checkbox"
@@ -541,12 +544,13 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <br />
                   <div
                     class="pf-c-check"
                   >
                     <input
                       aria-invalid="false"
-                      aria-label="controlled checkbox example"
+                      aria-label="delete-all-reports-checkbox"
                       class="pf-c-check__input"
                       id="delete-all-reports-1"
                       type="checkbox"
@@ -850,8 +854,9 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                             This cannot be undone.
                           </div>
                         </TextContent>
+                        <br />
                         <Checkbox
-                          aria-label="controlled checkbox example"
+                          aria-label="delete-all-reports-checkbox"
                           className=""
                           id="delete-all-reports-1"
                           isChecked={false}
@@ -865,7 +870,7 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                           >
                             <input
                               aria-invalid={false}
-                              aria-label="controlled checkbox example"
+                              aria-label="delete-all-reports-checkbox"
                               checked={false}
                               className="pf-c-check__input"
                               disabled={false}
@@ -1125,12 +1130,13 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <br />
                   <div
                     class="pf-c-check"
                   >
                     <input
                       aria-invalid="false"
-                      aria-label="controlled checkbox example"
+                      aria-label="delete-all-reports-checkbox"
                       class="pf-c-check__input"
                       id="delete-all-reports-1"
                       type="checkbox"
@@ -1238,12 +1244,13 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                   >
                     This cannot be undone.
                   </div>
+                  <br />
                   <div
                     class="pf-c-check"
                   >
                     <input
                       aria-invalid="false"
-                      aria-label="controlled checkbox example"
+                      aria-label="delete-all-reports-checkbox"
                       class="pf-c-check__input"
                       id="delete-all-reports-1"
                       type="checkbox"
@@ -1465,8 +1472,9 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                             This cannot be undone.
                           </div>
                         </TextContent>
+                        <br />
                         <Checkbox
-                          aria-label="controlled checkbox example"
+                          aria-label="delete-all-reports-checkbox"
                           className=""
                           id="delete-all-reports-1"
                           isChecked={false}
@@ -1480,7 +1488,7 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                           >
                             <input
                               aria-invalid={false}
-                              aria-label="controlled checkbox example"
+                              aria-label="delete-all-reports-checkbox"
                               checked={false}
                               className="pf-c-check__input"
                               disabled={false}


### PR DESCRIPTION
Adds a checkbox to optionally remove reports for a given policy.
![Screenshot 2020-02-24 at 09 55 36](https://user-images.githubusercontent.com/7757/75139007-e35c4600-56eb-11ea-8f85-ea662d34e29c.png)

Accompanying backend PR: https://github.com/RedHatInsights/compliance-backend/pull/326