### PR TITLE
Seperate allSystems from showAllSystems

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -40,7 +40,7 @@ const ComplianceSystems = () => {
                 { !beta && <ComplianceTabs/> }
             </PageHeader>
             <Main>
-                <SystemsTable allSystems columns={columns} />
+                <SystemsTable showAllSystems columns={columns} />
             </Main>
         </React.Fragment>
     );

--- a/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
+++ b/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
@@ -12,7 +12,6 @@ exports[`ComplianceSystems expect to render without error 1`] = `
   </PageHeader>
   <Connect(Main)>
     <Connect(withApollo(SystemsTable))
-      allSystems={true}
       columns={
         Array [
           Object {
@@ -49,6 +48,7 @@ exports[`ComplianceSystems expect to render without error 1`] = `
           },
         ]
       }
+      showAllSystems={true}
     />
   </Connect(Main)>
 </Fragment>

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -48,7 +48,7 @@ const EditPolicySystems = ({ change, selectedSystemIds }) => {
                     columns={columns}
                     remediationsEnabled={false}
                     compact={true}
-                    allSystems
+                    showAllSystems
                     enableExport={ false }/>
             </Form>
         </React.Fragment>

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -208,7 +208,7 @@ class SystemsTable extends React.Component {
         this.getRegistry().register({
             ...mergeWithEntities(
                 entitiesReducer(
-                    INVENTORY_ACTION_TYPES, () => this.state.items, columns, this.isGraphqlFinished, this.props.allSystems
+                    INVENTORY_ACTION_TYPES, () => this.state.items, columns, this.isGraphqlFinished, this.props.showAllSystems
                 ))
         });
 
@@ -218,7 +218,7 @@ class SystemsTable extends React.Component {
     }
 
     render() {
-        const { remediationsEnabled, compact, enableExport, allSystems } = this.props;
+        const { remediationsEnabled, compact, enableExport, showAllSystems } = this.props;
         const {
             page, totalCount, perPage, items, InventoryCmp, filterChips,
             selectedSystemId, selectedSystemFqdn, isAssignPoliciesModalOpen } = this.state;
@@ -253,7 +253,7 @@ class SystemsTable extends React.Component {
             exportConfig
         };
 
-        if (!allSystems) {
+        if (!showAllSystems) {
             inventoryTableProps.total = totalCount;
             inventoryTableProps.items = items.map((edge) => edge.node.id);
             inventoryTableProps.filterConfig = filterConfig;
@@ -268,7 +268,7 @@ class SystemsTable extends React.Component {
         }
 
         return <InventoryCmp { ...inventoryTableProps }>
-            { !allSystems && <reactCore.ToolbarGroup>
+            { !showAllSystems && <reactCore.ToolbarGroup>
                 { remediationsEnabled &&
                     <reactCore.ToolbarItem style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}>
                         <ComplianceRemediationButton
@@ -297,7 +297,7 @@ SystemsTable.propTypes = {
     selectedEntities: propTypes.array,
     exportToCSV: propTypes.func,
     enableExport: propTypes.bool,
-    allSystems: propTypes.bool
+    showAllSystems: propTypes.bool
 };
 
 SystemsTable.defaultProps = {
@@ -305,7 +305,7 @@ SystemsTable.defaultProps = {
     remediationsEnabled: true,
     compact: false,
     enableExport: true,
-    allSystems: false
+    showAllSystems: false
 };
 
 const mapStateToProps = state => {

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -26,7 +26,7 @@ export const rulesCount = (system, rulesMethod) => {
     return (rulesCount.length > 0 && rulesCount.reduce((acc, curr) => acc + curr)) || 0;
 };
 
-export const systemsToInventoryEntities = (systems, entities, allSystems) =>
+export const systemsToInventoryEntities = (systems, entities, showAllSystems) =>
     entities.map(entity => {
         // This should compare the inventory ID instead with
         // the ID in compliance
@@ -36,7 +36,7 @@ export const systemsToInventoryEntities = (systems, entities, allSystems) =>
             return entity.id === system.id;
         });
         if (matchingSystem === undefined) {
-            if (!allSystems) { return; }
+            if (!showAllSystems) { return; }
 
             matchingSystem = { profiles: [] };
         }
@@ -97,14 +97,14 @@ export const systemsToInventoryEntities = (systems, entities, allSystems) =>
         };
     }).filter(value => value !== undefined);
 
-export const entitiesReducer = (INVENTORY_ACTION, systems, columns, isGraphqlFinished, allSystems) => applyReducerHash(
+export const entitiesReducer = (INVENTORY_ACTION, systems, columns, isGraphqlFinished, showAllSystems) => applyReducerHash(
     {
         [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => {
             if (!isGraphqlFinished()) {
                 return { ...state, loaded: false };
             }
 
-            state.rows = systemsToInventoryEntities(systems(), state.rows, allSystems);
+            state.rows = systemsToInventoryEntities(systems(), state.rows, showAllSystems);
             state.count = state.rows.length;
             state.total = state.rows.length;
             state.columns = [];

--- a/src/store/Reducers/SystemStore.test.js
+++ b/src/store/Reducers/SystemStore.test.js
@@ -10,7 +10,7 @@ describe('mapping systems to inventory entities', () => {
         expect(systemsToInventoryEntities([], entities, false)).toEqual([]);
     });
 
-    it('should return all systems if allSystems is true', () => {
+    it('should return all systems if showAllSystems is true', () => {
         expect(systemsToInventoryEntities([], entities, true).length).toEqual(entities.length);
     });
 
@@ -21,7 +21,7 @@ describe('mapping systems to inventory entities', () => {
         expect(inventoryEntities).toMatchSnapshot();
     });
 
-    it('should only return all systems if all have a matching in the inventory for allSystems=false', () => {
+    it('should only return all systems if all have a matching in the inventory for showAllSystems=false', () => {
         const inventoryEntities = systemsToInventoryEntities(systems, entities, false);
         const systemIds = systems.map(system => system.node.id);
         const systemNames = systems.map(system => system.node.name);
@@ -33,7 +33,7 @@ describe('mapping systems to inventory entities', () => {
         toEqual(systemComplianceScores.sort());
     });
 
-    it('should always return all systems for allSystems=true', () => {
+    it('should always return all systems for showAllSystems=true', () => {
         const inventoryEntities = systemsToInventoryEntities(systems, entities, true);
         const systemComplianceScores = [' 40%', ' N/A', ' N/A', ' N/A'];
         expect(inventoryEntities.length).toBe(entities.length);


### PR DESCRIPTION
Notice the prop passed in here https://github.com/RedHatInsights/compliance-frontend/pull/393/files#diff-8d895559dea653c589c26d45256675efR317

This change should just be a refactoring to clear up any confusion between the two props.

Signed-off-by: Andrew Kofink <akofink@redhat.com>