### PR TITLE
Edit Policy button responsiveness

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -19,8 +19,9 @@
     background: white
 }
 
-.policy-details-dropdown {
-    float: right
+.policy-details-button {
+    display: flex;
+    justify-content: right;
 }
 
 .chart-inline tspan {

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -1,8 +1,4 @@
 import {
-    Dropdown,
-    DropdownPosition,
-    DropdownToggle,
-    DropdownItem,
     Modal,
     Form,
     Button
@@ -39,37 +35,15 @@ export class EditPolicy extends Component {
         this.props.onClose();
     };
 
-    onToggle = isOpen => {
-        this.setState({
-            isOpen
-        });
-    };
-
-    onSelect = () => {
-        this.setState({
-            isOpen: !this.state.isOpen
-        });
-    };
-
     render() {
-        const { policyId, isOpen, isModalOpen, businessObjective } = this.state;
+        const { policyId, isModalOpen, businessObjective } = this.state;
         const { previousThreshold, editPolicyBusinessObjective, complianceThreshold, dispatch } = this.props;
-        const dropdownItems = [
-            <DropdownItem key="action" onClick={this.handleModalToggle} component="button">
-                Edit policy
-            </DropdownItem>
-        ];
 
         return (
             <React.Fragment>
-                <Dropdown
-                    onSelect={this.onSelect}
-                    className='policy-details-dropdown'
-                    position={DropdownPosition.right}
-                    toggle={<DropdownToggle onToggle={this.onToggle}>Actions</DropdownToggle>}
-                    isOpen={isOpen}
-                    dropdownItems={dropdownItems}
-                />
+                <Button variant='secondary' onClick={this.handleModalToggle}>
+                    Edit policy
+                </Button>
                 <Modal
                     isSmall
                     title="Edit policy details"

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -2,29 +2,12 @@
 
 exports[`EditPolicy expect to render without error 1`] = `
 <Fragment>
-  <Dropdown
-    className="policy-details-dropdown"
-    dropdownItems={
-      Array [
-        <DropdownItem
-          component="button"
-          onClick={[Function]}
-        >
-          Edit policy
-        </DropdownItem>,
-      ]
-    }
-    isOpen={false}
-    onSelect={[Function]}
-    position="right"
-    toggle={
-      <DropdownToggle
-        onToggle={[Function]}
-      >
-        Actions
-      </DropdownToggle>
-    }
-  />
+  <Component
+    onClick={[Function]}
+    variant="secondary"
+  >
+    Edit policy
+  </Component>
   <Modal
     actions={
       Array [

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -114,18 +114,18 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
                     </BreadcrumbItem>
                     <BreadcrumbItem isActive>{policy.name}</BreadcrumbItem>
                 </Breadcrumb>
-                <Grid>
-                    <GridItem span={10}>
+                <Grid gutter='lg'>
+                    <GridItem xl2={9} xl={8} lg={12} md={12} sm={12}>
                         <PageHeaderTitle title={policy.name} />
                     </GridItem>
-                    <GridItem span={1}>
+                    <GridItem className='policy-details-button' xl2={2} xl={2} lg={2} md={3} sm={3}>
                         <Link to={'/reports/' + policy.id} >
                             <Button variant='primary'>
                                 View reports
                             </Button>
                         </Link>
                     </GridItem>
-                    <GridItem span={1}>
+                    <GridItem className='policy-details-button' xl2={1} xl={2} lg={2} md={3} sm={3}>
                         <EditPolicy policyId={policy.id}
                             previousThreshold={policy.complianceThreshold}
                             businessObjective={policy.businessObjective}

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -49,10 +49,10 @@ exports[`PolicyDetails expect to render without error 1`] = `
       </ol>
     </nav>
     <div
-      class="pf-l-grid"
+      class="pf-l-grid pf-m-gutter"
     >
       <div
-        class="pf-l-grid__item pf-m-10-col"
+        class="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-12-col-on-lg pf-m-8-col-on-xl pf-m-9-col-on-2xl"
       >
         <h1
           class="pf-c-title pf-m-2xl"
@@ -64,7 +64,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
         </h1>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-2-col-on-2xl policy-details-button"
       >
         <a
           href="/reports/1"
@@ -78,7 +78,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
         </a>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-1-col-on-2xl policy-details-button"
       >
         <div>
           Edit Policy
@@ -330,10 +330,10 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
       </ol>
     </nav>
     <div
-      class="pf-l-grid"
+      class="pf-l-grid pf-m-gutter"
     >
       <div
-        class="pf-l-grid__item pf-m-10-col"
+        class="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-12-col-on-lg pf-m-8-col-on-xl pf-m-9-col-on-2xl"
       >
         <h1
           class="pf-c-title pf-m-2xl"
@@ -345,7 +345,7 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
         </h1>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-2-col-on-2xl policy-details-button"
       >
         <a
           href="/reports/1"
@@ -359,7 +359,7 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
         </a>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-1-col-on-2xl policy-details-button"
       >
         <div>
           Edit Policy
@@ -611,10 +611,10 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
       </ol>
     </nav>
     <div
-      class="pf-l-grid"
+      class="pf-l-grid pf-m-gutter"
     >
       <div
-        class="pf-l-grid__item pf-m-10-col"
+        class="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-12-col-on-lg pf-m-8-col-on-xl pf-m-9-col-on-2xl"
       >
         <h1
           class="pf-c-title pf-m-2xl"
@@ -626,7 +626,7 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
         </h1>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-2-col-on-2xl policy-details-button"
       >
         <a
           href="/reports/1"
@@ -640,7 +640,7 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
         </a>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-1-col-on-2xl policy-details-button"
       >
         <div>
           Edit Policy
@@ -892,10 +892,10 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
       </ol>
     </nav>
     <div
-      class="pf-l-grid"
+      class="pf-l-grid pf-m-gutter"
     >
       <div
-        class="pf-l-grid__item pf-m-10-col"
+        class="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-12-col-on-lg pf-m-8-col-on-xl pf-m-9-col-on-2xl"
       >
         <h1
           class="pf-c-title pf-m-2xl"
@@ -907,7 +907,7 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
         </h1>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-2-col-on-2xl policy-details-button"
       >
         <a
           href="/reports/1"
@@ -921,7 +921,7 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
         </a>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-1-col-on-2xl policy-details-button"
       >
         <div>
           Edit Policy
@@ -1173,10 +1173,10 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
       </ol>
     </nav>
     <div
-      class="pf-l-grid"
+      class="pf-l-grid pf-m-gutter"
     >
       <div
-        class="pf-l-grid__item pf-m-10-col"
+        class="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-12-col-on-lg pf-m-8-col-on-xl pf-m-9-col-on-2xl"
       >
         <h1
           class="pf-c-title pf-m-2xl"
@@ -1188,7 +1188,7 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
         </h1>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-2-col-on-2xl policy-details-button"
       >
         <a
           href="/reports/1"
@@ -1202,7 +1202,7 @@ exports[`PolicyDetailsQuery renders without error 2`] = `
         </a>
       </div>
       <div
-        class="pf-l-grid__item pf-m-1-col"
+        class="pf-l-grid__item pf-m-3-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg pf-m-2-col-on-xl pf-m-1-col-on-2xl policy-details-button"
       >
         <div>
           Edit Policy


### PR DESCRIPTION
This PR contains updates to the responsiveness of the page, to at least make it impossible for buttons to collapse upon each other when shrinking the page (which happened before this change). Besides that, it also updates the Dropdown to a Button to Edit Policies as indicated on the mocks. 