### PR TITLE
Use prop instead of ref to trigger systemFetch

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
 import { onNavigate } from '../../Utilities/Breadcrumbs';
@@ -66,13 +66,6 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
     const { data, error, loading, refetch } = useQuery(QUERY, {
         variables: { policyId }
     });
-    let systemsTable = useRef();
-
-    const forceUpdate = () => {
-        refetch();
-        systemsTable.current.getWrappedInstance().systemFetch();
-        systemsTable.current.getWrappedInstance().forceUpdate();
-    };
 
     const [activeTab, setActiveTab] = useState(0);
     let policy = {};
@@ -120,9 +113,7 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
                         <EditPolicy policyId={policy.id}
                             previousThreshold={policy.complianceThreshold}
                             businessObjective={policy.businessObjective}
-                            onClose={ () => {
-                                forceUpdate();
-                            }}
+                            onClose={ () => refetch() }
                         />
                     </GridItem>
                 </Grid>

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -2,7 +2,7 @@ import { SystemsTable } from 'SmartComponents';
 import React from 'react';
 import propTypes from 'prop-types';
 
-const PolicySystemsTab = ({ policy, systemsTableRef }) => (
+const PolicySystemsTab = ({ policy, complianceThreshold }) => (
     <SystemsTable policyId={policy.id}
         columns={[{
             composed: ['facts.os_release', 'display_name'],
@@ -24,7 +24,7 @@ const PolicySystemsTab = ({ policy, systemsTableRef }) => (
                 width: 10
             }
         }]}
-        ref={systemsTableRef}
+        complianceThreshold={ complianceThreshold }
     />
 );
 
@@ -32,7 +32,7 @@ PolicySystemsTab.propTypes = {
     policy: propTypes.shape({
         id: propTypes.string.isRequired
     }),
-    systemsTableRef: propTypes.object
+    complianceThreshold: propTypes.number
 };
 
 export default PolicySystemsTab;

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useQuery } from '@apollo/react-hooks';
 import { Grid, GridItem } from '@patternfly/react-core';
 import propTypes from 'prop-types';
@@ -52,7 +52,6 @@ export const ReportDetails = ({ match }) => {
     const { data, error, loading } = useQuery(QUERY, {
         variables: { policyId: match.params.report_id }
     });
-    let systemsTable = useRef();
     let donutValues = [];
     let donutId = 'loading-donut';
     let policy = {};
@@ -163,9 +162,7 @@ export const ReportDetails = ({ match }) => {
             <Main>
                 <Grid gutter='md'>
                     <GridItem span={12}>
-                        <SystemsTable policyId={policy.id}
-                            columns={columns}
-                            ref={systemsTable} />
+                        <SystemsTable policyId={policy.id} columns={columns} />
                     </GridItem>
                 </Grid>
             </Main>

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -69,7 +69,7 @@ class SystemsTable extends React.Component {
 
     state = {
         ...loadingState,
-        InventoryCmp: () => <SkeletonTable colSize={2} rowSize={15} />,
+        InventoryCmp: React.forwardRef((_, ref) => <SkeletonTable ref={ref} colSize={2} rowSize={15} />), // eslint-disable-line
         policyId: this.props.policyId,
         perPage: 50,
         totalCount: 0,
@@ -79,6 +79,12 @@ class SystemsTable extends React.Component {
 
     componentDidMount = () => {
         this.fetchInventory();
+    }
+
+    componentDidUpdate = (prevProps) => {
+        if (prevProps.complianceThreshold !== this.props.complianceThreshold) {
+            this.systemFetch();
+        }
     }
 
     onRefresh = ({ page, per_page: perPage }) => {
@@ -297,7 +303,8 @@ SystemsTable.propTypes = {
     selectedEntities: propTypes.array,
     exportToCSV: propTypes.func,
     enableExport: propTypes.bool,
-    showAllSystems: propTypes.bool
+    showAllSystems: propTypes.bool,
+    complianceThreshold: propTypes.number
 };
 
 SystemsTable.defaultProps = {
@@ -305,7 +312,8 @@ SystemsTable.defaultProps = {
     remediationsEnabled: true,
     compact: false,
     enableExport: true,
-    showAllSystems: false
+    showAllSystems: false,
+    complianceThreshold: 0
 };
 
 const mapStateToProps = state => {
@@ -327,7 +335,7 @@ const mapDispatchToProps = dispatch => {
 };
 
 export { SystemsTable };
-export const SystemsTableWithApollo = withApollo(SystemsTable, { withRef: true });
+export const SystemsTableWithApollo = withApollo(SystemsTable);
 export default connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -80,7 +80,7 @@ Object {
 `;
 
 exports[`SystemsTable expect to not render a loading state 1`] = `
-<InventoryCmp
+<ForwardRef
   actions={
     Array [
       Object {
@@ -186,7 +186,7 @@ exports[`SystemsTable expect to not render a loading state 1`] = `
       />
     </ToolbarItem>
   </ToolbarGroup>
-</InventoryCmp>
+</ForwardRef>
 `;
 
 exports[`SystemsTable expect to render a loading state 1`] = `


### PR DESCRIPTION
With the changes to tabs it is not guaranteed that there is a `SystemsTable`.
Trying to just  guard the `systemFetch` and `forceUpdate` calls with an `if (systemsTable.current.getWrappedInstance()) ...` turned out to be unreliable and cause different unexpected behavior on each tab.

This removes the `Ref` and allows `SystemsTable` to trigger a call to `systemFetch` on it's own when the compliance threshold prop changes, which seems to be the only case where we want(ed) to trigger a refresh from the outside.