### PR TITLE
Add TabSwitcher for PolicyDetails component

### DIFF
--- a/src/PresentationalComponents/TabSwitcher/TabSwitcher.js
+++ b/src/PresentationalComponents/TabSwitcher/TabSwitcher.js
@@ -1,0 +1,16 @@
+import propTypes from 'prop-types';
+
+export const Tab = ({ children }) => (children);
+
+const TabSwitcher = (props) => (
+    props.children.map((tab) => (
+        tab.props.tabId === props.activeTab ? tab : undefined
+    )).filter((c) => (!!c))
+);
+
+TabSwitcher.propTypes = {
+    activeTab: propTypes.number,
+    children: propTypes.node
+};
+
+export default TabSwitcher;

--- a/src/PresentationalComponents/TabSwitcher/TabSwitcher.test.js
+++ b/src/PresentationalComponents/TabSwitcher/TabSwitcher.test.js
@@ -1,0 +1,27 @@
+import toJson from 'enzyme-to-json';
+
+import TabSwitcher, { Tab } from './TabSwitcher';
+
+describe('TabSwitcher', () => {
+    it('expect to render first tab', () => {
+        const wrapper = shallow(
+            <TabSwitcher activeTab={0}>
+                <Tab tabId={0}>First Tab</Tab>
+                <Tab tabId={1}>Second Tab</Tab>
+            </TabSwitcher>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render second tab', () => {
+        const wrapper = shallow(
+            <TabSwitcher activeTab={1}>
+                <Tab tabId={0}>First Tab</Tab>
+                <Tab tabId={1}>Second Tab</Tab>
+            </TabSwitcher>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/TabSwitcher/__snapshots__/TabSwitcher.test.js.snap
+++ b/src/PresentationalComponents/TabSwitcher/__snapshots__/TabSwitcher.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabSwitcher expect to render first tab 1`] = `
+<Tab
+  tabId={0}
+>
+  First Tab
+</Tab>
+`;
+
+exports[`TabSwitcher expect to render second tab 1`] = `
+<Tab
+  tabId={1}
+>
+  Second Tab
+</Tab>
+`;

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -13,3 +13,4 @@ export { default as ReportDetailsContentLoader } from './ReportDetailsContentLoa
 export { default as PolicyDetailsDescription } from './PolicyDetailsDescription/PolicyDetailsDescription';
 export { default as ReportDetailsDescription } from './ReportDetailsDescription/ReportDetailsDescription';
 export { default as PolicyTabs } from './PolicyTabs/PolicyTabs';
+export { default as TabSwitcher, Tab } from './TabSwitcher/TabSwitcher';

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -5,7 +5,9 @@ import { onNavigate } from '../../Utilities/Breadcrumbs';
 import {
     PolicyDetailsDescription,
     PolicyDetailsContentLoader,
-    PolicyTabs
+    PolicyTabs,
+    TabSwitcher,
+    Tab
 } from 'PresentationalComponents';
 import EditPolicy from '../EditPolicy/EditPolicy';
 import PolicyRulesTab from './PolicyRulesTab';
@@ -75,17 +77,6 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
     const [activeTab, setActiveTab] = useState(0);
     let policy = {};
 
-    const currentTab = (activeTab) => {
-        switch (activeTab) {
-            case 0:
-                return <PolicyDetailsDescription policy={policy} />;
-            case 1:
-                return <PolicyRulesTab policy={policy} loading={loading} />;
-            case 2:
-                return <PolicySystemsTab policy={policy} systemsTableRef={systemsTable} />;
-        }
-    };
-
     if (error) {
         if (error.networkError.statusCode === 401) {
             window.insights.chrome.auth.logout();
@@ -138,7 +129,17 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
                 <PolicyTabs activeTab={activeTab} setActiveTab={setActiveTab} />
             </PageHeader>
             <Main>
-                { currentTab(activeTab) }
+                <TabSwitcher activeTab={activeTab}>
+                    <Tab tabId={0}>
+                        <PolicyDetailsDescription policy={policy} />
+                    </Tab>
+                    <Tab tabId={1}>
+                        <PolicyRulesTab policy={policy} loading={loading} />
+                    </Tab>
+                    <Tab tabId={2}>
+                        <PolicySystemsTab policy={policy} complianceThreshold={policy.complianceThreshold} />
+                    </Tab>
+                </TabSwitcher>
             </Main>
         </React.Fragment>
     );


### PR DESCRIPTION
This adds a small `TabSwitcher` component to select a specific component to render via a `tabId`. 

The `Tab` component is purely decorational, the switcher component only checks for a `tabID` prop and not for any specifc component type.