### PR TITLE
Use DateFormat component to get dates with tooltips

### DIFF
--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import { Link } from 'react-router-dom';
-import { FormattedRelative } from 'react-intl';
 import { EXPORT_TO_CSV } from '../ActionTypes';
 import { downloadCsv } from 'Utilities/Export';
 import {
     ComplianceScore as complianceScore,
     complianceScoreString
-} from '../../PresentationalComponents';
+} from 'PresentationalComponents';
 
 export const lastScanned = (system) => {
     if (system.profiles === undefined) { return 'Never'; }
@@ -88,7 +88,7 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems) =>
                     compliance_score: complianceScore(matchingSystem),
                     compliance_score_text: complianceScoreString(matchingSystem),
                     last_scanned: (matchingSystem.lastScanned instanceof Date) ?
-                        { title: <FormattedRelative value={Date.parse(matchingSystem.lastScanned)} /> } :
+                        { title: <DateFormat date={Date.parse(matchingSystem.lastScanned)} type='relative' /> } :
                         matchingSystem.lastScanned,
                     last_scanned_text: matchingSystem.lastScanned
                 }

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -54,9 +54,9 @@ Array [
         </React.Fragment>,
         "compliance_score_text": " 40%",
         "last_scanned": Object {
-          "title": <FormattedRelative
-            updateInterval={10000}
-            value={1574346739000}
+          "title": <DateFormat
+            date={1574346739000}
+            type="relative"
           />,
         },
         "last_scanned_text": 2019-11-21T14:32:19.000Z,


### PR DESCRIPTION
Relative dates should have the full datetime displayed in a tooltip. 
Using DateFormat provides that.

![Screenshot 2020-02-27 at 11 34 24](https://user-images.githubusercontent.com/7757/75436910-a0051000-5955-11ea-965c-92b06a87aff8.png)
