### PR TITLE
RHICOMPL-389 - Show rules/lastScan/compliant per profile on systems table

### DIFF
--- a/src/PresentationalComponents/ComplianceScore/ComplianceScore.js
+++ b/src/PresentationalComponents/ComplianceScore/ComplianceScore.js
@@ -11,7 +11,7 @@ const CompliantIcon = (system) => (
         {
             ((system.rulesPassed + system.rulesFailed) === 0) ?
                 <QuestionCircleIcon style={{ color: 'var(--pf-global--disabled-color--100)' }}/> :
-                system.profiles.every(profile => profile.compliant === true) ?
+                system.compliant ?
                     <CheckCircleIcon style={{ color: 'var(--pf-global--success-color--100)' }}/> :
                     <ExclamationCircleIcon style={{ color: 'var(--pf-global--danger-color--100)' }}/>
         }

--- a/src/PresentationalComponents/ComplianceScore/ComplianceScore.test.js
+++ b/src/PresentationalComponents/ComplianceScore/ComplianceScore.test.js
@@ -2,35 +2,18 @@ import ComplianceScore from './ComplianceScore';
 import renderer from 'react-test-renderer';
 
 describe('auxiliary functions to reducer', () => {
-    it('should show a danger icon if the host is not compliant in any profile', () => {
+    it('should show a danger icon if the host is not compliant', () => {
         const system = {
             rulesPassed: 30,
             rulesFailed: 300,
-            profiles: [
-                { compliant: false },
-                { compliant: false }
-            ]
+            compliant: false
         };
 
         const dangerIcon = renderer.create(<ComplianceScore { ...system } />).toJSON();
         expect(dangerIcon).toMatchSnapshot();
     });
 
-    it('should show a danger icon if the host is not compliant in some profile', () => {
-        const system = {
-            rulesPassed: 30,
-            rulesFailed: 3,
-            profiles: [
-                { compliant: true },
-                { compliant: false }
-            ]
-        };
-
-        const dangerIcon = renderer.create(<ComplianceScore { ...system } />).toJSON();
-        expect(dangerIcon).toMatchSnapshot();
-    });
-
-    it('should show a success icon if the host is compliant in all profiles', () => {
+    it('should show a success icon if the host is compliant', () => {
         const system = {
             rulesPassed: 30,
             rulesFailed: 3,

--- a/src/PresentationalComponents/ComplianceScore/__snapshots__/ComplianceScore.test.js.snap
+++ b/src/PresentationalComponents/ComplianceScore/__snapshots__/ComplianceScore.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`auxiliary functions to reducer should show a danger icon if the host is not compliant in any profile 1`] = `
+exports[`auxiliary functions to reducer should show a danger icon if the host is not compliant 1`] = `
 Array [
   <svg
     aria-hidden={true}
@@ -22,31 +22,6 @@ Array [
     />
   </svg>,
   " 9%",
-]
-`;
-
-exports[`auxiliary functions to reducer should show a danger icon if the host is not compliant in some profile 1`] = `
-Array [
-  <svg
-    aria-hidden={true}
-    aria-labelledby={null}
-    fill="currentColor"
-    height="1em"
-    role="img"
-    style={
-      Object {
-        "color": "var(--pf-global--danger-color--100)",
-      }
-    }
-    viewBox="0 0 512 512"
-    width="1em"
-  >
-    <path
-      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-      transform=""
-    />
-  </svg>,
-  " 91%",
 ]
 `;
 
@@ -75,7 +50,7 @@ Array [
 ]
 `;
 
-exports[`auxiliary functions to reducer should show a success icon if the host is compliant in all profiles 1`] = `
+exports[`auxiliary functions to reducer should show a success icon if the host is compliant 1`] = `
 Array [
   <svg
     aria-hidden={true}
@@ -85,14 +60,14 @@ Array [
     role="img"
     style={
       Object {
-        "color": "var(--pf-global--success-color--100)",
+        "color": "var(--pf-global--danger-color--100)",
       }
     }
     viewBox="0 0 512 512"
     width="1em"
   >
     <path
-      d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
       transform=""
     />
   </svg>,

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -34,7 +34,8 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
                 id
                 name
                 profiles {
-                    name,
+                    id
+                    name
                     rulesPassed
                     rulesFailed
                     lastScanned
@@ -198,7 +199,7 @@ class SystemsTable extends React.Component {
     }, 500)
 
     async fetchInventory() {
-        const { columns } = this.props;
+        const { columns, policyId, showAllSystems } = this.props;
         const {
             inventoryConnector,
             INVENTORY_ACTION_TYPES,
@@ -214,7 +215,7 @@ class SystemsTable extends React.Component {
         this.getRegistry().register({
             ...mergeWithEntities(
                 entitiesReducer(
-                    INVENTORY_ACTION_TYPES, () => this.state.items, columns, this.isGraphqlFinished, this.props.showAllSystems
+                    INVENTORY_ACTION_TYPES, () => this.state.items, columns, this.isGraphqlFinished, showAllSystems, policyId
                 ))
         });
 

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -9,24 +9,39 @@ import {
     complianceScoreString
 } from 'PresentationalComponents';
 
-export const lastScanned = (system) => {
-    if (system.profiles === undefined) { return 'Never'; }
+const findProfiles = (system, defaultReturn, profileId) => {
+    if (system.profiles === undefined) { return defaultReturn; }
 
-    const dates = system.profiles.map((profile) => new Date(profile.lastScanned));
+    let profiles = system.profiles;
+
+    if (profileId !== undefined && profileId !== '') {
+        profiles = profiles.filter((profile) => profile.id === profileId);
+    }
+
+    return profiles;
+};
+
+export const lastScanned = (system, profileId) => {
+    const profiles = findProfiles(system, 'Never', profileId);
+    const dates = profiles.map((profile) => new Date(profile.lastScanned));
     const last = new Date(Math.max.apply(null, dates.filter((date) => isFinite(date))));
     const result = (last instanceof Date && isFinite(last)) ? last : 'Never';
 
     return result;
 };
 
-export const rulesCount = (system, rulesMethod) => {
-    if (system.profiles === undefined) { return 0; }
-
-    const rulesCount = system.profiles.map((profile) => profile[rulesMethod]);
+export const rulesCount = (system, rulesMethod, profileId) => {
+    const profiles = findProfiles(system, 0, profileId);
+    const rulesCount = profiles.map((profile) => profile[rulesMethod]);
     return (rulesCount.length > 0 && rulesCount.reduce((acc, curr) => acc + curr)) || 0;
 };
 
-export const systemsToInventoryEntities = (systems, entities, showAllSystems) =>
+export const compliant = (system, profileId) => {
+    const profiles = findProfiles(system, false, profileId);
+    return profiles.every(profile => profile.compliant === true);
+};
+
+export const systemsToInventoryEntities = (systems, entities, showAllSystems, profileId) =>
     entities.map(entity => {
         // This should compare the inventory ID instead with
         // the ID in compliance
@@ -43,9 +58,10 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems) =>
 
         matchingSystem.profileNames = matchingSystem === {} ? '' :
             matchingSystem.profiles.map((profile) => profile.name).join(', ');
-        matchingSystem.rulesPassed = rulesCount(matchingSystem, 'rulesPassed');
-        matchingSystem.rulesFailed = rulesCount(matchingSystem, 'rulesFailed');
-        matchingSystem.lastScanned = lastScanned(matchingSystem);
+        matchingSystem.rulesPassed = rulesCount(matchingSystem, 'rulesPassed', profileId);
+        matchingSystem.rulesFailed = rulesCount(matchingSystem, 'rulesFailed', profileId);
+        matchingSystem.lastScanned = lastScanned(matchingSystem, profileId);
+        matchingSystem.compliant = compliant(matchingSystem, profileId);
 
         return {
             /* eslint-disable camelcase */
@@ -97,14 +113,15 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems) =>
         };
     }).filter(value => value !== undefined);
 
-export const entitiesReducer = (INVENTORY_ACTION, systems, columns, isGraphqlFinished, showAllSystems) => applyReducerHash(
+export const entitiesReducer = (INVENTORY_ACTION, systems, columns, isGraphqlFinished, showAllSystems,
+    profileId) => applyReducerHash(
     {
         [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => {
             if (!isGraphqlFinished()) {
                 return { ...state, loaded: false };
             }
 
-            state.rows = systemsToInventoryEntities(systems(), state.rows, showAllSystems);
+            state.rows = systemsToInventoryEntities(systems(), state.rows, showAllSystems, profileId);
             state.count = state.rows.length;
             state.total = state.rows.length;
             state.columns = [];

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -9,20 +9,20 @@ import {
     complianceScoreString
 } from 'PresentationalComponents';
 
-const findProfiles = (system, defaultReturn, profileId) => {
+const findProfiles = (system, defaultReturn, profileIds) => {
     if (system.profiles === undefined) { return defaultReturn; }
 
     let profiles = system.profiles;
 
-    if (profileId !== undefined && profileId !== '') {
-        profiles = profiles.filter((profile) => profile.id === profileId);
+    if (profileIds !== undefined && profileIds !== '') {
+        profiles = profiles.filter((profile) => profileIds.includes(profile.id));
     }
 
     return profiles;
 };
 
 export const lastScanned = (system, profileId) => {
-    const profiles = findProfiles(system, 'Never', profileId);
+    const profiles = findProfiles(system, 'Never', [profileId]);
     const dates = profiles.map((profile) => new Date(profile.lastScanned));
     const last = new Date(Math.max.apply(null, dates.filter((date) => isFinite(date))));
     const result = (last instanceof Date && isFinite(last)) ? last : 'Never';
@@ -31,13 +31,13 @@ export const lastScanned = (system, profileId) => {
 };
 
 export const rulesCount = (system, rulesMethod, profileId) => {
-    const profiles = findProfiles(system, 0, profileId);
+    const profiles = findProfiles(system, 0, [profileId]);
     const rulesCount = profiles.map((profile) => profile[rulesMethod]);
     return (rulesCount.length > 0 && rulesCount.reduce((acc, curr) => acc + curr)) || 0;
 };
 
 export const compliant = (system, profileId) => {
-    const profiles = findProfiles(system, false, profileId);
+    const profiles = findProfiles(system, false, [profileId]);
     return profiles.every(profile => profile.compliant === true);
 };
 

--- a/src/store/Reducers/SystemStore.test.js
+++ b/src/store/Reducers/SystemStore.test.js
@@ -1,6 +1,7 @@
 import {
     rulesCount,
     lastScanned,
+    compliant,
     systemsToInventoryEntities
 } from './SystemStore';
 import { systems, entities } from './SystemStore.fixtures';
@@ -61,6 +62,17 @@ describe('.rulesCount', () => {
         expect(rulesCount(system, 'rulesPassed')).toEqual(0);
         expect(rulesCount(system, 'rulesFailed')).toEqual(0);
     });
+
+    it('should set rules count for a specific profile', () => {
+        const system = {
+            profiles: [
+                { id: '1', rulesPassed: 3, rulesFailed: 1 },
+                { id: '2', rulesPassed: 10, rulesFailed: 3 }
+            ]
+        };
+        expect(rulesCount(system, 'rulesPassed', '1')).toEqual(3);
+        expect(rulesCount(system, 'rulesFailed', '1')).toEqual(1);
+    });
 });
 
 describe('.lastScanned', () => {
@@ -89,4 +101,49 @@ describe('.lastScanned', () => {
         expect(lastScanned({ profiles: [] })).toEqual('Never');
         expect(lastScanned({ profiles: [{ lastScanned: 'Never' }] })).toEqual('Never');
     });
+
+    it('should find the latest scan date for a specific profile', () => {
+        const system = {
+            profiles: [
+                { id: '1', lastScanned: '2019-10-23T15:59:49Z' },
+                { id: '2', lastScanned: '2018-12-23T17:59:49Z' }
+            ]
+        };
+        expect(lastScanned(system, '1')).toEqual(new Date('2019-10-23T15:59:49Z'));
+        expect(lastScanned(system, '2')).toEqual(new Date('2018-12-23T17:59:49Z'));
+    });
 });
+
+describe('.compliant', () => {
+    it('should set false if there is one non-compliant profile', () => {
+        const system = {
+            profiles: [
+                { compliant: true },
+                { compliant: false }
+            ]
+        };
+        expect(compliant(system)).toEqual(false);
+    });
+
+    it('should set true if all profiles are compliant', () => {
+        const system = {
+            profiles: [
+                { compliant: true },
+                { compliant: true }
+            ]
+        };
+        expect(compliant(system)).toEqual(true);
+    });
+
+    it('should return value for a specific profile', () => {
+        const system = {
+            profiles: [
+                { id: '1', compliant: true },
+                { id: '2', compliant: false }
+            ]
+        };
+        expect(compliant(system, '1')).toEqual(true);
+        expect(compliant(system, '2')).toEqual(false);
+    });
+});
+

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -11,6 +11,7 @@ Array [
       "compliance": Object {
         "compliance_score": <React.Fragment>
           <CompliantIcon
+            compliant={false}
             id="d5bc2459-21ce-4d11-bc0b-03ea7513dfa6"
             lastScanned={2019-11-21T14:32:19.000Z}
             name="demo.lobatolan.home"


### PR DESCRIPTION
Before, the systems table displayed the *global* compliance, *global* failed rules count, and *global* last scanned, even when you visit the ReportDetails page, or the PolicyDetails page. 

Now, on the "Reports" "By systems" page, we show the global values, but on every specific "ReportDetails" or "PolicyDetails" page, we only see the values related to that profile. 