### PR TITLE
RHICOMPL-500 - Simplify routes and point all systems to /systems/:inventoryId

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -44,11 +44,8 @@ export const paths = {
     reports: '/reports',
     reportsSystems: '/reports/systems',
     complianceSystems: '/systems',
-    complianceSystemsInventoryDetail: '/systems/:inventoryId',
     policyDetails: '/policies/:policy_id',
-    policyDetailsInventoryDetail: '/policies/:policy_id/:inventoryId',
     reportDetails: '/reports/:report_id',
-    reportDetailsInventoryDetail: '/reports/:report_id/:inventoryId',
     systemDetails: '/systems/:inventoryId'
 };
 
@@ -73,8 +70,6 @@ export const Routes = (props: Props) => {
             <Route exact path={paths.reports} component={Reports} />
             <Route exact path={paths.reportsSystems} component={ReportsSystems} />
             <Route exact path={paths.complianceSystems} component={ComplianceSystems} />
-            <Route path={paths.complianceSystemsInventoryDetail} component={SystemDetails} />
-            <Route path={paths.policyDetailsInventoryDetail} component={SystemDetails} />
             <Route exact path={paths.reportDetails} component={ReportDetails} />
             <Route exact path={paths.policyDetails} component={PolicyDetails} />
             <Route path={paths.systemDetails} component={SystemDetails} />

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -5,15 +5,14 @@ import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/fronte
 
 const ComplianceSystems = () => {
     const columns = [{
-        composed: ['facts.os_release', 'display_name'],
         key: 'display_name',
         title: 'Name',
         props: {
             width: 40
         }
     }, {
-        key: 'facts.compliance.profiles',
-        title: 'Profiles',
+        key: 'facts.compliance.policies',
+        title: 'Policies',
         props: {
             width: 40
         }

--- a/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
+++ b/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
@@ -15,10 +15,6 @@ exports[`ComplianceSystems expect to render without error 1`] = `
       columns={
         Array [
           Object {
-            "composed": Array [
-              "facts.os_release",
-              "display_name",
-            ],
             "key": "display_name",
             "props": Object {
               "width": 40,
@@ -26,11 +22,11 @@ exports[`ComplianceSystems expect to render without error 1`] = `
             "title": "Name",
           },
           Object {
-            "key": "facts.compliance.profiles",
+            "key": "facts.compliance.policies",
             "props": Object {
               "width": 40,
             },
-            "title": "Profiles",
+            "title": "Policies",
           },
           Object {
             "key": "facts.compliance.compliance_score",

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -14,7 +14,7 @@ import { connect } from 'react-redux';
 const EditPolicySystems = ({ change, selectedSystemIds }) => {
     const columns = [{
         composed: ['facts.os_release', 'display_name'],
-        key: 'display_name',
+        key: 'facts.compliance.display_name',
         title: 'System name',
         props: {
             width: 40

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -5,8 +5,7 @@ import propTypes from 'prop-types';
 const PolicySystemsTab = ({ policy, complianceThreshold }) => (
     <SystemsTable policyId={policy.id}
         columns={[{
-            composed: ['facts.os_release', 'display_name'],
-            key: 'display_name',
+            key: 'facts.compliance.display_name',
             title: 'System name',
             props: {
                 width: 40

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -83,9 +83,8 @@ export const ReportDetails = ({ match }) => {
     }
 
     const columns = [{
-        composed: ['facts.os_release', 'display_name'],
-        key: 'display_name',
-        title: 'Name',
+        key: 'facts.compliance.display_name',
+        title: 'System name',
         props: {
             width: 30
         }

--- a/src/SmartComponents/ReportsSystems/ReportsSystems.js
+++ b/src/SmartComponents/ReportsSystems/ReportsSystems.js
@@ -5,15 +5,14 @@ import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/fronte
 
 const ReportsSystems = () => {
     const columns = [{
-        composed: ['facts.os_release', 'display_name'],
-        key: 'display_name',
+        key: 'facts.compliance.display_name',
         title: 'System name',
         props: {
             width: 40
         }
     }, {
-        key: 'facts.compliance.profiles',
-        title: 'Profiles',
+        key: 'facts.compliance.policies',
+        title: 'Policies',
         props: {
             width: 40
         }

--- a/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
+++ b/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
@@ -15,22 +15,18 @@ exports[`ReportsSystems expect to render without error in beta 1`] = `
       columns={
         Array [
           Object {
-            "composed": Array [
-              "facts.os_release",
-              "display_name",
-            ],
-            "key": "display_name",
+            "key": "facts.compliance.display_name",
             "props": Object {
               "width": 40,
             },
             "title": "System name",
           },
           Object {
-            "key": "facts.compliance.profiles",
+            "key": "facts.compliance.policies",
             "props": Object {
               "width": 40,
             },
-            "title": "Profiles",
+            "title": "Policies",
           },
           Object {
             "key": "facts.compliance.compliance_score",
@@ -68,22 +64,18 @@ exports[`ReportsSystems expect to render without error in stable 1`] = `
       columns={
         Array [
           Object {
-            "composed": Array [
-              "facts.os_release",
-              "display_name",
-            ],
-            "key": "display_name",
+            "key": "facts.compliance.display_name",
             "props": Object {
               "width": 40,
             },
             "title": "System name",
           },
           Object {
-            "key": "facts.compliance.profiles",
+            "key": "facts.compliance.policies",
             "props": Object {
               "width": 40,
             },
-            "title": "Profiles",
+            "title": "Policies",
           },
           Object {
             "key": "facts.compliance.compliance_score",

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -90,7 +90,10 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, pr
                         entity.facts.release
                 },
                 compliance: {
-                    profiles: matchingSystem.profileNames,
+                    display_name: { title: <Link to={{ pathname: `/systems/${matchingSystem.id}` }}>
+                        { entity.display_name }
+                    </Link> },
+                    policies: matchingSystem.profileNames,
                     rules_passed: matchingSystem.rulesPassed,
                     rules_failed: { title: <Link to={{
                         pathname: `/systems/${matchingSystem.id}`,

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -54,6 +54,15 @@ Array [
            40%
         </React.Fragment>,
         "compliance_score_text": " 40%",
+        "display_name": Object {
+          "title": <Link
+            to={
+              Object {
+                "pathname": "/systems/d5bc2459-21ce-4d11-bc0b-03ea7513dfa6",
+              }
+            }
+          />,
+        },
         "last_scanned": Object {
           "title": <DateFormat
             date={1574346739000}
@@ -61,7 +70,7 @@ Array [
           />,
         },
         "last_scanned_text": 2019-11-21T14:32:19.000Z,
-        "profiles": "Standard System Security Profile for Red Hat Enterprise Linux 7, DISA STIG for Red Hat Enterprise Linux 7, United States Government Configuration Baseline, C2S for Red Hat Enterprise Linux 7",
+        "policies": "Standard System Security Profile for Red Hat Enterprise Linux 7, DISA STIG for Red Hat Enterprise Linux 7, United States Government Configuration Baseline, C2S for Red Hat Enterprise Linux 7",
         "rules_failed": Object {
           "title": <Link
             to={


### PR DESCRIPTION
This accomplishes a few things:

- Links are fixed, before, you could not reach the system details page from policy details or report details, only from the list of all systems.
- Our routes are now cleaner - system details is *exclusively* reached through /systems/:inventoryId. Good riddance to the old long URLs with both the policy ID and the system ID. 
- 'Name' was renamed to 'System name' and 'Profiles' to 'Policies' wherever needed as we discussed during the UXD review this week.