### PR TITLE
Only return the latest SSG version to create a new policy

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.test.js
@@ -35,7 +35,7 @@ describe('CreatePolicy', () => {
     });
 
     it('expect to render the wizard', async () => {
-        useQuery.mockImplementation(() => ({ data: { allBenchmarks: benchmarksQuery }, error: false, loading: false }));
+        useQuery.mockImplementation(() => ({ data: { latestBenchmarks: benchmarksQuery }, error: false, loading: false }));
         const wrapper = mount(
             <Provider store={store}>
                 <CreatePolicy isOpen />

--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
@@ -17,7 +17,7 @@ import propTypes from 'prop-types';
 
 const BENCHMARKS_AND_PROFILES = gql`
 query benchmarksAndProfiles {
-    allBenchmarks {
+    latestBenchmarks {
         id
         title
         version
@@ -52,7 +52,7 @@ const CreateSCAPPolicy = ({ selectedBenchmarkId }) => {
 
     if (loading) { return <Spinner/>; }
 
-    const benchmarks = data.allBenchmarks;
+    const benchmarks = data.latestBenchmarks;
     let selectedBenchmark;
     let validProfiles;
     if (selectedBenchmarkId) {

--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.test.js
@@ -37,7 +37,7 @@ describe('CreateSCAPPolicy', () => {
     });
 
     it('should render benchmarks and no policies until one is selected', () => {
-        useQuery.mockImplementation(() => ({ data: { allBenchmarks: benchmarksQuery }, error: false, loading: false }));
+        useQuery.mockImplementation(() => ({ data: { latestBenchmarks: benchmarksQuery }, error: false, loading: false }));
         component = renderer.create(
             <Provider store={store}>
                 <CreateSCAPPolicy />
@@ -51,7 +51,7 @@ describe('CreateSCAPPolicy', () => {
             values: { benchmark: benchmarksQuery[0].id }
         } } });
         useQuery.mockImplementation(() => ({
-            data: { allBenchmarks: benchmarksQuery, profiles: profileRefIdsQuery }, error: false, loading: false
+            data: { latestBenchmarks: benchmarksQuery, profiles: profileRefIdsQuery }, error: false, loading: false
         }));
         component = renderer.create(
             <Provider store={store}>


### PR DESCRIPTION
Hopefully the title is self-explanatory - this reduces the list of possible benchmarks to the latest SSG versions 