### PR TITLE
Send selectedRuleRefIds without requiring user interaction

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicyRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyRules.js
@@ -59,6 +59,10 @@ export const EditPolicyRules = ({ profileId, benchmarkId, dispatch, change }) =>
 
     selected = data.profile.rules.map((rule) => rule.refId);
 
+    useEffect(() => {
+        change('selectedRuleRefIds', selected);
+    }, [selected]);
+
     return (
         <SystemRulesTable
             remediationsEnabled={false}


### PR DESCRIPTION
Before this commit, the dispatch action to set the selectedRuleRefIds is
called only if you enable/disable a rule. Instead, we need to send the
selectedRuleRefIds whenever the component receives the rules for the
first time.