### PR TITLE
Revert "Add checkbox to optionally remove all test results aka. repor…

### DIFF
--- a/src/SmartComponents/DeletePolicy/DeletePolicy.js
+++ b/src/SmartComponents/DeletePolicy/DeletePolicy.js
@@ -1,19 +1,16 @@
 import {
     Modal,
     TextContent,
-    Button,
-    Checkbox
+    Button
 } from '@patternfly/react-core';
 import propTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useMutation } from '@apollo/react-hooks';
 import { DELETE_PROFILE } from '../../Utilities/graphql/mutations';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { dispatchAction } from '../../Utilities/Dispatcher';
 
 const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
-    const defaultDeleteAllState = false;
-    const [deleteAllTestResults, setDeleteAll] = useState(defaultDeleteAllState);
     const [deletePolicy] = useMutation(DELETE_PROFILE, {
         onCompleted: () => {
             dispatchAction(addNotification({
@@ -35,10 +32,6 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
     });
     const { name, id } = policy;
 
-    useEffect(() => {
-        setDeleteAll(defaultDeleteAllState);
-    }, [policy]);
-
     return (
         <Modal
             isSmall
@@ -50,8 +43,7 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
                 <Button key='destroy'
                     aria-label="delete"
                     variant='danger'
-                    onClick={() => deletePolicy({ variables: { input: { id, deleteAllTestResults } } })}
-                >
+                    onClick={() => deletePolicy({ variables: { input: { id } } })}>
                     Delete policy
                 </Button>,
                 <Button key='cancel' variant='secondary' onClick={toggle}>
@@ -65,13 +57,6 @@ const DeletePolicy = ({ isModalOpen, policy, toggle, onDelete }) => {
             <TextContent>
                 This cannot be undone.
             </TextContent>
-            <br />
-            <Checkbox
-                id={ `delete-all-reports-${id}` }
-                isChecked={ deleteAllTestResults }
-                onChange={ () => setDeleteAll(!deleteAllTestResults) }
-                aria-label="delete-all-reports-checkbox"
-                label="Delete all reports for this policy" />
         </Modal>
     );
 };

--- a/src/SmartComponents/DeletePolicy/DeletePolicy.test.js
+++ b/src/SmartComponents/DeletePolicy/DeletePolicy.test.js
@@ -51,21 +51,4 @@ describe('DeletePolicy', () => {
         expect(defaultProps.onDelete).toHaveBeenCalled();
         expect(toJson(component)).toMatchSnapshot();
     });
-
-    it('expect to call toggle and onDelete when clicked', () => {
-        const mockMutationReturn = jest.fn();
-        const expectedArguments = { variables: { input: { id: 1, deleteAllTestResults: true } } };
-        useMutation.mockImplementation(() => {
-            return [mockMutationReturn];
-        });
-        const component = mount(
-            <DeletePolicy { ...defaultProps } />
-        );
-        component.find('input[aria-label="delete-all-reports-checkbox"]').simulate('click');
-        // Again, somehow a click doesn't trigger a change, therefore manually
-        component.find('input[aria-label="delete-all-reports-checkbox"]').simulate('change');
-        component.find('button[aria-label="delete"]').simulate('click');
-
-        expect(mockMutationReturn).toHaveBeenCalledWith(expectedArguments);
-    });
 });

--- a/src/SmartComponents/DeletePolicy/__snapshots__/DeletePolicy.test.js.snap
+++ b/src/SmartComponents/DeletePolicy/__snapshots__/DeletePolicy.test.js.snap
@@ -93,24 +93,6 @@ exports[`DeletePolicy expect not to render anything for a closed modal 1`] = `
                   >
                     This cannot be undone.
                   </div>
-                  <br />
-                  <div
-                    class="pf-c-check"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="delete-all-reports-checkbox"
-                      class="pf-c-check__input"
-                      id="delete-all-reports-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="pf-c-check__label"
-                      for="delete-all-reports-1"
-                    >
-                      Delete all reports for this policy
-                    </label>
-                  </div>
                 </div>
                 <div
                   class="pf-c-modal-box__footer pf-m-align-left"
@@ -316,24 +298,6 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                   >
                     This cannot be undone.
                   </div>
-                  <br />
-                  <div
-                    class="pf-c-check"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="delete-all-reports-checkbox"
-                      class="pf-c-check__input"
-                      id="delete-all-reports-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="pf-c-check__label"
-                      for="delete-all-reports-1"
-                    >
-                      Delete all reports for this policy
-                    </label>
-                  </div>
                 </div>
                 <div
                   class="pf-c-modal-box__footer pf-m-align-left"
@@ -417,24 +381,6 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                     class="pf-c-content"
                   >
                     This cannot be undone.
-                  </div>
-                  <br />
-                  <div
-                    class="pf-c-check"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="delete-all-reports-checkbox"
-                      class="pf-c-check__input"
-                      id="delete-all-reports-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="pf-c-check__label"
-                      for="delete-all-reports-1"
-                    >
-                      Delete all reports for this policy
-                    </label>
                   </div>
                 </div>
                 <div
@@ -543,24 +489,6 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                     class="pf-c-content"
                   >
                     This cannot be undone.
-                  </div>
-                  <br />
-                  <div
-                    class="pf-c-check"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="delete-all-reports-checkbox"
-                      class="pf-c-check__input"
-                      id="delete-all-reports-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="pf-c-check__label"
-                      for="delete-all-reports-1"
-                    >
-                      Delete all reports for this policy
-                    </label>
                   </div>
                 </div>
                 <div
@@ -854,38 +782,6 @@ exports[`DeletePolicy expect to call toggle and onDelete when clicked 1`] = `
                             This cannot be undone.
                           </div>
                         </TextContent>
-                        <br />
-                        <Checkbox
-                          aria-label="delete-all-reports-checkbox"
-                          className=""
-                          id="delete-all-reports-1"
-                          isChecked={false}
-                          isDisabled={false}
-                          isValid={true}
-                          label="Delete all reports for this policy"
-                          onChange={[Function]}
-                        >
-                          <div
-                            className="pf-c-check"
-                          >
-                            <input
-                              aria-invalid={false}
-                              aria-label="delete-all-reports-checkbox"
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="delete-all-reports-1"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <label
-                              className="pf-c-check__label"
-                              htmlFor="delete-all-reports-1"
-                            >
-                              Delete all reports for this policy
-                            </label>
-                          </div>
-                        </Checkbox>
                       </div>
                     </ModalBoxBody>
                     <ModalBoxFooter
@@ -1130,24 +1026,6 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                   >
                     This cannot be undone.
                   </div>
-                  <br />
-                  <div
-                    class="pf-c-check"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="delete-all-reports-checkbox"
-                      class="pf-c-check__input"
-                      id="delete-all-reports-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="pf-c-check__label"
-                      for="delete-all-reports-1"
-                    >
-                      Delete all reports for this policy
-                    </label>
-                  </div>
                 </div>
                 <div
                   class="pf-c-modal-box__footer pf-m-align-left"
@@ -1243,24 +1121,6 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                     class="pf-c-content"
                   >
                     This cannot be undone.
-                  </div>
-                  <br />
-                  <div
-                    class="pf-c-check"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="delete-all-reports-checkbox"
-                      class="pf-c-check__input"
-                      id="delete-all-reports-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="pf-c-check__label"
-                      for="delete-all-reports-1"
-                    >
-                      Delete all reports for this policy
-                    </label>
                   </div>
                 </div>
                 <div
@@ -1472,38 +1332,6 @@ exports[`DeletePolicy expect to render an open modal without error 1`] = `
                             This cannot be undone.
                           </div>
                         </TextContent>
-                        <br />
-                        <Checkbox
-                          aria-label="delete-all-reports-checkbox"
-                          className=""
-                          id="delete-all-reports-1"
-                          isChecked={false}
-                          isDisabled={false}
-                          isValid={true}
-                          label="Delete all reports for this policy"
-                          onChange={[Function]}
-                        >
-                          <div
-                            className="pf-c-check"
-                          >
-                            <input
-                              aria-invalid={false}
-                              aria-label="delete-all-reports-checkbox"
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="delete-all-reports-1"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <label
-                              className="pf-c-check__label"
-                              htmlFor="delete-all-reports-1"
-                            >
-                              Delete all reports for this policy
-                            </label>
-                          </div>
-                        </Checkbox>
                       </div>
                     </ModalBoxBody>
                     <ModalBoxFooter


### PR DESCRIPTION
…ts (#392)"

This reverts commit 2571724bda570c7d3e13be7addf00dcdcb2261e0.

Since soft-deleting policies is something we're not doing for our current goal, we are now just deleting policies *and* test results always. I reverted the commit and included 'deleteAllTestResults: true'.