### PR TITLE
Update cache-settings for Reports page

### DIFF
--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -32,7 +32,7 @@ const QUERY = gql`
 `;
 
 export const CompliancePolicies = () => {
-    const { data, error, loading, refetch } = useQuery(QUERY, { fetchPolicy: 'network-only' });
+    const { data, error, loading, refetch } = useQuery(QUERY, { fetchPolicy: 'cache-and-network' });
 
     if (error) { return <ErrorPage error={error}/>; }
 

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -42,7 +42,7 @@ const QUERY = gql`
 `;
 
 export const Reports = () => {
-    const { data, error, loading } = useQuery(QUERY);
+    const { data, error, loading } = useQuery(QUERY, { fetchPolicy: 'cache-and-network' });
     let reportCards;
     let pageHeader;
 


### PR DESCRIPTION
The Reports page is not updating properly when you do stuff such as
removing a policy, or clicking back and forth between the vertical
navigation elements. Instead, we can use cache-and-network which returns
the cache elements first - and makes a network call in the backend,
which is only used to populate the data if it's different to what was in
the cache.