### PR TITLE
Fetch Inventory when ComplianceThreshold is changed

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -85,7 +85,7 @@ class SystemsTable extends React.Component {
 
     componentDidUpdate = (prevProps) => {
         if (prevProps.complianceThreshold !== this.props.complianceThreshold) {
-            this.systemFetch();
+            this.fetchInventory();
         }
     }
 


### PR DESCRIPTION
The previous call to `systemFetch` is worthless here, it just makes a call to GraphQL but it doesn't refresh the inventory. To refresh the Compliance Icons (:red_circle: to :green_heart: or viceversa), we need the inventory to be reloaded and trigger LOAD_ENTITIES_FULFILLED in the reducer, which in turns regenerates the icons. 

It'd be a better option to dispatch a new action which explicitly just updates the icons but nothing else. 