### PR TITLE
RHICOMPL-555 - Show empty state only if no policies were created

### DIFF
--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -173,9 +173,9 @@ export class PoliciesTable extends React.Component {
     }
 
     render() {
-        const { onWizardFinish } = this.props;
+        const { policies, onWizardFinish } = this.props;
         const { rows, currentRows, columns, page, itemsPerPage, policyToDelete, isDeleteModalOpen } = this.state;
-        if (rows.length === 0) {
+        if (policies.length === 0) {
             return <CompliancePoliciesEmptyState />;
         }
 

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.test.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.test.js
@@ -42,6 +42,17 @@ describe('PoliciesTable', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
+    it('expect not to render emptystate if rows are empty but initial policies were not', async () => {
+        const wrapper = shallow(
+            <PoliciesTable policies={policies.edges.map(profile => profile.node)} />
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+        const instance = wrapper.instance();
+        await instance.handleSearch('impossiblesearch');
+        expect(wrapper.state('currentRows')).toEqual([]);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
     describe('Pagination and search', () => {
         let wrapper;
 

--- a/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -1,5 +1,375 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PoliciesTable expect not to render emptystate if rows are empty but initial policies were not 1`] = `
+<Fragment>
+  <DeletePolicy
+    isModalOpen={false}
+    policy={Object {}}
+    toggle={[Function]}
+  />
+  <TableToolbar
+    isFooter={false}
+  >
+    <Level
+      gutter="md"
+    >
+      <LevelItem>
+        <InputGroup>
+          <SimpleFilter
+            buttonTitle={null}
+            className=""
+            onButtonClick={[Function]}
+            onFilterChange={[Function]}
+            onOptionSelect={[Function]}
+            placeholder="Search"
+            searchIcon={true}
+          />
+        </InputGroup>
+      </LevelItem>
+      <LevelItem>
+        13
+         results
+      </LevelItem>
+      <LevelItem>
+        <Connect(CreatePolicy) />
+      </LevelItem>
+    </Level>
+    <Component
+      dropDirection="down"
+      itemCount={13}
+      onPerPageSelect={[Function]}
+      onSetPage={[Function]}
+      page={1}
+      perPage={10}
+    />
+  </TableToolbar>
+  <Component
+    actionResolver={[Function]}
+    aria-label="policies"
+    cells={
+      Array [
+        Object {
+          "title": "Policy name",
+        },
+        Object {
+          "title": "Operating system",
+        },
+        Object {
+          "title": "Systems",
+        },
+        Object {
+          "title": "Business objective",
+        },
+        Object {
+          "title": "Compliance threshold",
+        },
+      ]
+    }
+    className="compliance-policies-table"
+    rows={
+      Array [
+        Object {
+          "cells": Array [
+            Object {
+              "original": "United States Government Configuration Baseline23",
+              "title": <UNDEFINED
+                to="/policies/b71376fd-015e-4209-99af-4543e82e5dc5"
+              >
+                United States Government Configuration Baseline23
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "100%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+              "title": <UNDEFINED
+                to="/policies/719999b6-d230-4ba5-8dba-7ab3dc6561e0"
+              >
+                PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "67%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "United States Government Configuration Baseline2",
+              "title": <UNDEFINED
+                to="/policies/dae0487d-3201-4ee0-af5f-b94cde2af818"
+              >
+                United States Government Configuration Baseline2
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "100%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "C2S for Red Hat Enterprise Linux 7",
+              "title": <UNDEFINED
+                to="/policies/20a9d997-62a6-40cc-a5f3-19d466eb975e"
+              >
+                C2S for Red Hat Enterprise Linux 7
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "69.5%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "Criminal Justice Information Services (CJIS) Security Policy",
+              "title": <UNDEFINED
+                to="/policies/6d345bd2-d597-4df8-9bcf-71c41155b42c"
+              >
+                Criminal Justice Information Services (CJIS) Security Policy
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "100%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
+              "title": <UNDEFINED
+                to="/policies/c8e15347-9c2b-495d-8e54-503c2f9582b6"
+              >
+                Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "100%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+              "title": <UNDEFINED
+                to="/policies/3c4823a1-2c16-46ae-b2fe-0cebf5a03931"
+              >
+                PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "100%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
+              "title": <UNDEFINED
+                to="/policies/f7b7977a-403b-4cd1-ab90-20b6f9a5a359"
+              >
+                Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "100%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "Health Insurance Portability and Accountability Act (HIPAA)",
+              "title": <UNDEFINED
+                to="/policies/36abc364-6dc3-4e35-94f4-d10fa77e866e"
+              >
+                Health Insurance Portability and Accountability Act (HIPAA)
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "100%",
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "United States Government Configuration Baseline",
+              "title": <UNDEFINED
+                to="/policies/d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220"
+              >
+                United States Government Configuration Baseline
+              </UNDEFINED>,
+            },
+            "RHEL 7",
+            10,
+            "--",
+            "100%",
+          ],
+        },
+      ]
+    }
+  >
+    <TableHeader />
+    <TableBody />
+  </Component>
+  <TableToolbar
+    className="ins-c-inventory__table--toolbar"
+    isFooter={true}
+  >
+    <Component
+      dropDirection="up"
+      itemCount={13}
+      onPerPageSelect={[Function]}
+      onSetPage={[Function]}
+      page={1}
+      perPage={10}
+      variant="bottom"
+    />
+  </TableToolbar>
+</Fragment>
+`;
+
+exports[`PoliciesTable expect not to render emptystate if rows are empty but initial policies were not 2`] = `
+<Fragment>
+  <DeletePolicy
+    isModalOpen={false}
+    policy={Object {}}
+    toggle={[Function]}
+  />
+  <TableToolbar
+    isFooter={false}
+  >
+    <Level
+      gutter="md"
+    >
+      <LevelItem>
+        <InputGroup>
+          <SimpleFilter
+            buttonTitle={null}
+            className=""
+            onButtonClick={[Function]}
+            onFilterChange={[Function]}
+            onOptionSelect={[Function]}
+            placeholder="Search"
+            searchIcon={true}
+          />
+        </InputGroup>
+      </LevelItem>
+      <LevelItem>
+        0
+         results
+      </LevelItem>
+      <LevelItem>
+        <Connect(CreatePolicy) />
+      </LevelItem>
+    </Level>
+    <Component
+      dropDirection="down"
+      itemCount={0}
+      onPerPageSelect={[Function]}
+      onSetPage={[Function]}
+      page={1}
+      perPage={10}
+    />
+  </TableToolbar>
+  <Component
+    actionResolver={[Function]}
+    aria-label="policies"
+    cells={
+      Array [
+        Object {
+          "title": "Policy name",
+        },
+        Object {
+          "title": "Operating system",
+        },
+        Object {
+          "title": "Systems",
+        },
+        Object {
+          "title": "Business objective",
+        },
+        Object {
+          "title": "Compliance threshold",
+        },
+      ]
+    }
+    className="compliance-policies-table"
+    rows={
+      Array [
+        Object {
+          "cells": Array [
+            Object {
+              "props": Object {
+                "colSpan": 5,
+              },
+              "title": <EmptyTable>
+                <Bullseye>
+                  <EmptyState
+                    variant="full"
+                  >
+                    <Title
+                      headingLevel="h5"
+                      size="lg"
+                    >
+                      No matching policies found
+                    </Title>
+                    <EmptyStateBody>
+                      This filter criteria matches no policies. 
+                      <br />
+                       Try changing your filter settings.
+                    </EmptyStateBody>
+                  </EmptyState>
+                </Bullseye>
+              </EmptyTable>,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TableHeader />
+    <TableBody />
+  </Component>
+  <TableToolbar
+    className="ins-c-inventory__table--toolbar"
+    isFooter={true}
+  >
+    <Component
+      dropDirection="up"
+      itemCount={0}
+      onPerPageSelect={[Function]}
+      onSetPage={[Function]}
+      page={1}
+      perPage={10}
+      variant="bottom"
+    />
+  </TableToolbar>
+</Fragment>
+`;
+
 exports[`PoliciesTable expect to render emptystate 1`] = `
 <CompliancePoliciesEmptyState
   title="No policies"


### PR DESCRIPTION
If no policies are available in the account, we should show the empty
state. Otherwise, we should show the empty state for the table if just
the filter makes it show no policies.

![Screencast_2020年04月08日_12時25分37秒 webm](https://user-images.githubusercontent.com/598891/78773863-23be0d80-7994-11ea-9008-46acb87a5236.gif)
