### PR TITLE
Fix filter chip deletion on SystemsTable

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -178,7 +178,7 @@ class SystemsTable extends React.Component {
     }
 
     onFilterDelete = debounce((_event, chips, clearAll = false) => {
-        clearAll ? this.clearAllFilter() : this.deleteFilter(chips);
+        clearAll ? this.clearAllFilter() : this.deleteFilter(chips[0]);
     }, 500)
 
     async fetchInventory() {


### PR DESCRIPTION
Deleting a filter broke on the SystemsTable, this issue snuck in. 

The chips come as an array for the callback, but we only need the the first. 
This is the same as already in `PoliciesTable`[1].

[1] https://github.com/RedHatInsights/compliance-frontend/blob/master/src/SmartComponents/PoliciesTable/PoliciesTable.js#L136