### PR TITLE
Do not expand wizard to full width

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -92,8 +92,6 @@ class CreatePolicy extends React.Component {
                     <Wizard
                         isOpen={isOpen}
                         onClose={this.toggleOpen}
-                        isFullWidth
-                        isFullHeight
                         isFooterLeftAligned
                         title="Create SCAP policy"
                         description="Create a new policy for managing SCAP compliance"

--- a/src/SmartComponents/CreatePolicy/__snapshots__/CreatePolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/CreatePolicy.test.js.snap
@@ -28,8 +28,8 @@ exports[`CreatePolicy expect to render the wizard 1`] = `
   height={null}
   isCompactNav={false}
   isFooterLeftAligned={true}
-  isFullHeight={true}
-  isFullWidth={true}
+  isFullHeight={false}
+  isFullWidth={false}
   isInPage={false}
   isOpen={true}
   nextButtonText="Next"
@@ -102,7 +102,7 @@ exports[`CreatePolicy expect to render the wizard 1`] = `
                 aria-describedby="pf-wizard-description-0"
                 aria-labelledby="pf-wizard-title-0"
                 aria-modal="true"
-                class="pf-c-wizard pf-m-full-width pf-m-full-height"
+                class="pf-c-wizard"
                 role="dialog"
               >
                 <div
@@ -410,7 +410,7 @@ exports[`CreatePolicy expect to render the wizard 1`] = `
                   aria-describedby="pf-wizard-description-0"
                   aria-labelledby="pf-wizard-title-0"
                   aria-modal="true"
-                  className="pf-c-wizard pf-m-full-width pf-m-full-height"
+                  className="pf-c-wizard"
                   isFooterLeftAligned={true}
                   role="dialog"
                 >


### PR DESCRIPTION
According to UX the Wizard should use the default sizing and not stretch full width and height.

![Screenshot 2020-04-08 at 19 13 07](https://user-images.githubusercontent.com/7757/78813491-60f2c180-79cd-11ea-814f-c10644585cb5.png)
