### PR TITLE
RHICOMPL-568 - Pass only selected hosts to Remediations

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -208,7 +208,7 @@ class SystemsTable extends React.Component {
     }
 
     render() {
-        const { remediationsEnabled, compact, enableExport, showAllSystems, showActions } = this.props;
+        const { remediationsEnabled, compact, enableExport, showAllSystems, showActions, selectedEntities } = this.props;
         const {
             page, totalCount, perPage, items, InventoryCmp, selectedSystemId,
             selectedSystemFqdn, isAssignPoliciesModalOpen
@@ -268,7 +268,7 @@ class SystemsTable extends React.Component {
                 { remediationsEnabled &&
                     <reactCore.ToolbarItem style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}>
                         <ComplianceRemediationButton
-                            allSystems={ items.map((edge) => edge.node) }
+                            allSystems={ items.map((edge) => edge.node).filter(system => selectedEntities.includes(system.id)) }
                             selectedRules={ [] } />
                     </reactCore.ToolbarItem>
                 }
@@ -311,7 +311,8 @@ SystemsTable.defaultProps = {
     showAllSystems: false,
     complianceThreshold: 0,
     showOnlySystemsWithTestResults: false,
-    showActions: true
+    showActions: true,
+    selectedEntities: []
 };
 
 const mapStateToProps = state => {

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -503,13 +503,7 @@ exports[`SystemsTable expect to set loading state correctly on systemfetch 1`] =
       }
     >
       <Connect(ComplianceRemediationButton)
-        allSystems={
-          Array [
-            Object {
-              "id": 1,
-            },
-          ]
-        }
+        allSystems={Array []}
         selectedRules={Array []}
       />
     </ToolbarItem>


### PR DESCRIPTION
![Screencast_2020年04月13日_11時11分33秒 webm](https://user-images.githubusercontent.com/598891/79109324-673fbf80-7d78-11ea-8be9-4fe990fdb12f.gif)

Before, we were passing literally all hosts, regardless of selections to the button (see the JIRA card)