### PR TITLE
Fetch benchmark for Report details description

### DIFF
--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -44,6 +44,9 @@ query Profile($policyId: String!){
         complianceThreshold
         majorOsVersion
         lastScanned
+        benchmark {
+            version
+        }
         businessObjective {
             id
             title


### PR DESCRIPTION
In the Report Details page, currently loading the description fails as it tries to populate the description of the OS with the SSG version, which is not queried.  