### PR TITLE
RHICOMPL-586 - Do not load rules if there's no remediation button

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -39,7 +39,7 @@ const ComplianceSystems = () => {
                 { !beta && <ComplianceTabs/> }
             </PageHeader>
             <Main>
-                <SystemsTable showAllSystems columns={columns} />
+                <SystemsTable showAllSystems remediationsEnabled={false} columns={columns} />
             </Main>
         </React.Fragment>
     );

--- a/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
+++ b/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
@@ -44,6 +44,7 @@ exports[`ComplianceSystems expect to render without error 1`] = `
           },
         ]
       }
+      remediationsEnabled={false}
       showAllSystems={true}
     />
   </Connect(Main)>

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -55,6 +55,29 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
 }
 `;
 
+export const GET_SYSTEMS_WITHOUT_FAILED_RULES = gql`
+query getSystems($filter: String!, $perPage: Int, $page: Int) {
+    systems(search: $filter, limit: $perPage, offset: $page) {
+        totalCount
+        edges {
+            node {
+                id
+                name
+                profiles {
+                    id
+                    name
+                    rulesPassed
+                    rulesFailed
+                    lastScanned
+                    compliant
+                    score
+                }
+            }
+        }
+    }
+}
+`;
+
 const loadingState = {
     loaded: false,
     items: [],
@@ -100,7 +123,7 @@ class SystemsTable extends React.Component {
     }
 
     systemFetch = () => {
-        const { client, showOnlySystemsWithTestResults } = this.props;
+        const { client, showOnlySystemsWithTestResults, remediationsEnabled } = this.props;
         const { policyId, perPage, page, activeFilters } = this.state;
         let filter = this.filterBuilder.buildFilterString(activeFilters);
 
@@ -113,7 +136,7 @@ class SystemsTable extends React.Component {
         }
 
         return client.query({
-            query: GET_SYSTEMS,
+            query: remediationsEnabled ? GET_SYSTEMS : GET_SYSTEMS_WITHOUT_FAILED_RULES,
             fetchResults: true,
             fetchPolicy: 'no-cache',
             variables: { filter, perPage, page, policyId }


### PR DESCRIPTION
This improves the performance on the Systems table (the one in beta with all systems) and the same table in the CreatePolicy wizard. It doesn't make sense to pull the rules, especially when that is an expensive operation, as they are useless in this context without the Remediation button. The table is slow when the Remediation button is used but I'm working on fixing that as well (likely on the backend).