### PR TITLE
Changes to report card to display SSG from policy

### DIFF
--- a/src/PresentationalComponents/ReportCard/PolicyPopover.js
+++ b/src/PresentationalComponents/ReportCard/PolicyPopover.js
@@ -13,7 +13,7 @@ import {
 import propTypes from 'prop-types';
 
 const PolicyPopover = ({ profile }) => {
-    const { policy, complianceThreshold, majorOsVersion, businessObjective } = profile;
+    const { name, policy, complianceThreshold, majorOsVersion, businessObjective } = profile;
     return (
         <Popover
             headerContent={name}
@@ -34,7 +34,7 @@ const PolicyPopover = ({ profile }) => {
                         Policy SSG version
                     </TextListItem>
                     <TextListItem component={TextListItemVariants.dd}>
-                        { policy.benchmark.version }
+                        { policy && policy.benchmark && policy.benchmark.version }
                     </TextListItem>
                     <TextListItem component={TextListItemVariants.dt}>
                         Compliance threshold

--- a/src/PresentationalComponents/ReportCard/PolicyPopover.js
+++ b/src/PresentationalComponents/ReportCard/PolicyPopover.js
@@ -12,13 +12,13 @@ import {
 } from 'react-router-dom';
 import propTypes from 'prop-types';
 
-const PolicyPopover = ({ policy }) => {
-    const { name, id, complianceThreshold, majorOsVersion, businessObjective } = policy;
+const PolicyPopover = ({ profile }) => {
+    const { policy, complianceThreshold, majorOsVersion, businessObjective } = profile;
     return (
         <Popover
             headerContent={name}
             footerContent={
-                <Link to={'/scappolicies/' + id} >
+                <Link to={'/scappolicies/' + policy.id} >
                     View policy
                 </Link>
             }
@@ -29,6 +29,12 @@ const PolicyPopover = ({ policy }) => {
                     </TextListItem>
                     <TextListItem component={TextListItemVariants.dd}>
                         RHEL { majorOsVersion }
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dt}>
+                        Policy SSG version
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>
+                        { policy.benchmark.version }
                     </TextListItem>
                     <TextListItem component={TextListItemVariants.dt}>
                         Compliance threshold
@@ -54,7 +60,7 @@ const PolicyPopover = ({ policy }) => {
 };
 
 PolicyPopover.propTypes = {
-    policy: propTypes.object
+    profile: propTypes.object
 };
 
 export default PolicyPopover;

--- a/src/PresentationalComponents/ReportCard/ReportCard.js
+++ b/src/PresentationalComponents/ReportCard/ReportCard.js
@@ -62,10 +62,10 @@ class ReportCard extends React.Component {
                         <Text onMouseEnter={this.onMouseover.bind(this)} onMouseLeave={this.onMouseout.bind(this)}
                             style={{ fontWeight: '500' }} component={TextVariants.h2}>
                             { cardTitleTruncated ? <Truncate lines={1}>{name}&nbsp;
-                                { policy && <PolicyPopover profile={this.props.profile} />}</Truncate> :
-                                <React.Fragment>{name}&nbsp;
-                                    { policy && <PolicyPopover profile={this.props.profile} />}
-                                </React.Fragment> }
+                                { policy && <PolicyPopover profile={this.props.profile} />}
+                            </Truncate> : <React.Fragment>{name}&nbsp;
+                                { policy && <PolicyPopover profile={this.props.profile} />}
+                            </React.Fragment> }
                         </Text>
                         <Grid>
                             <GridItem span={12}>

--- a/src/PresentationalComponents/ReportCard/ReportCard.js
+++ b/src/PresentationalComponents/ReportCard/ReportCard.js
@@ -27,7 +27,6 @@ import '../../Charts.scss';
 import { fixedPercentage } from '../../Utilities/TextHelper';
 
 class ReportCard extends React.Component {
-    policy = this.props.policy;
     state = {
         cardTitleTruncated: true
     }
@@ -47,8 +46,8 @@ class ReportCard extends React.Component {
     render() {
         const { cardTitleTruncated } = this.state;
         const {
-            benchmark, external, majorOsVersion, compliantHostCount, totalHostCount, refId, name, id
-        } = this.policy;
+            policy, benchmark, majorOsVersion, compliantHostCount, totalHostCount, refId, name, id
+        } = this.props.profile;
         let donutValues = [
             { x: 'Compliant', y: compliantHostCount },
             { x: 'Non-compliant', y: totalHostCount - compliantHostCount }
@@ -63,15 +62,20 @@ class ReportCard extends React.Component {
                         <Text onMouseEnter={this.onMouseover.bind(this)} onMouseLeave={this.onMouseout.bind(this)}
                             style={{ fontWeight: '500' }} component={TextVariants.h2}>
                             { cardTitleTruncated ? <Truncate lines={1}>{name}&nbsp;
-                                { !external && <PolicyPopover policy={this.policy} />}</Truncate> :
+                                { policy && <PolicyPopover profile={this.props.profile} />}</Truncate> :
                                 <React.Fragment>{name}&nbsp;
-                                    { !external && <PolicyPopover policy={this.policy} />}
+                                    { policy && <PolicyPopover profile={this.props.profile} />}
                                 </React.Fragment> }
                         </Text>
                         <Grid>
                             <GridItem span={12}>
                                 <Text>
-                                    Operating system: RHEL { majorOsVersion } (SSG { benchmark.version })
+                                    Operating system: RHEL { majorOsVersion }
+                                </Text>
+                            </GridItem>
+                            <GridItem span={12}>
+                                <Text>
+                                    SSG version: { benchmark.version }
                                 </Text>
                             </GridItem>
                             <GridItem className='pf-u-m-sm'/>
@@ -126,7 +130,7 @@ class ReportCard extends React.Component {
                                     </Link>
                                 </Text>
                                 <Text component={TextVariants.small} style={{ fontSize: '16px' }} >
-                                    { external ? <Tooltip position='bottom' content={
+                                    { !policy ? <Tooltip position='bottom' content={
                                         <span>This policy report was uploaded into the Compliance application.
                                         If you would like to manage your policy inside the Compliance application,
                                         use the &quot;Create a policy&quot; wizard to create one and associate systems.</span>
@@ -135,7 +139,7 @@ class ReportCard extends React.Component {
                                             External SCAP policy <OutlinedQuestionCircleIcon className='grey-icon'/>
                                         </span>
                                     </Tooltip> :
-                                        <Link to={'/scappolicies/' + id} >
+                                        <Link to={'/scappolicies/' + policy.id} >
                                             View policy
                                         </Link>
                                     }
@@ -150,7 +154,7 @@ class ReportCard extends React.Component {
 };
 
 ReportCard.propTypes = {
-    policy: propTypes.object
+    profile: propTypes.object
 };
 
 export default ReportCard;

--- a/src/PresentationalComponents/ReportCard/ReportCard.test.js
+++ b/src/PresentationalComponents/ReportCard/ReportCard.test.js
@@ -3,12 +3,18 @@ import toJson from 'enzyme-to-json';
 import ReportCard from './ReportCard';
 
 const defaultProps = {
-    policy: {
+    profile: {
         id: 'ID',
         refId: 'REF_ID',
         name: 'Test Policy',
         compliantHostCount: 10,
         totalHostCount: 15,
+        policy: {
+            id: 'policyid',
+            benchmark: {
+                version: '0.1.4'
+            }
+        },
         businessObjective: {
             title: 'BO'
         },

--- a/src/PresentationalComponents/ReportCard/__snapshots__/ReportCard.test.js.snap
+++ b/src/PresentationalComponents/ReportCard/__snapshots__/ReportCard.test.js.snap
@@ -25,7 +25,7 @@ exports[`ReportCard expect to render without error 1`] = `
           Test Policy
            
           <PolicyPopover
-            policy={
+            profile={
               Object {
                 "benchmark": Object {
                   "version": "0.1.5",
@@ -36,6 +36,12 @@ exports[`ReportCard expect to render without error 1`] = `
                 "compliantHostCount": 10,
                 "id": "ID",
                 "name": "Test Policy",
+                "policy": Object {
+                  "benchmark": Object {
+                    "version": "0.1.4",
+                  },
+                  "id": "policyid",
+                },
                 "refId": "REF_ID",
                 "totalHostCount": 15,
               }
@@ -49,9 +55,14 @@ exports[`ReportCard expect to render without error 1`] = `
         >
           <Text>
             Operating system: RHEL 
-             (SSG 
+          </Text>
+        </GridItem>
+        <GridItem
+          span={12}
+        >
+          <Text>
+            SSG version: 
             0.1.5
-            )
           </Text>
         </GridItem>
         <GridItem
@@ -181,7 +192,7 @@ exports[`ReportCard expect to render without error 1`] = `
             }
           >
             <Link
-              to="/scappolicies/ID"
+              to="/scappolicies/policyid"
             >
               View policy
             </Link>

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -28,7 +28,6 @@ const QUERY = gql`
                 description
                 totalHostCount
                 compliantHostCount
-                external
                 majorOsVersion
                 complianceThreshold
                 businessObjective {

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -35,6 +35,12 @@ const QUERY = gql`
                     id
                     title
                 }
+                policy {
+                    id
+                    benchmark {
+                        version
+                    }
+                }
                 benchmark {
                     version
                 }
@@ -51,21 +57,21 @@ export const Reports = () => {
     let pageHeader;
 
     if (!loading && data) {
-        const policies = data.profiles.edges.map(profile => profile.node).filter((profile) => profile.totalHostCount > 0);
+        const profiles = data.profiles.edges.map(profile => profile.node).filter((profile) => profile.totalHostCount > 0);
         const beta = window.location.pathname.split('/')[1] === 'beta';
 
-        if (policies.length) {
+        if (profiles.length) {
             pageHeader = <PageHeader className={ beta ? 'beta-page-header' : 'stable-page-header' }>
                 <PageHeaderTitle title="Compliance reports" />
                 { beta ? <ReportTabs/> : <ComplianceTabs/> }
 
             </PageHeader>;
-            reportCards = policies.map(
-                (policy, i) =>
+            reportCards = profiles.map(
+                (profile, i) =>
                     <GridItem sm={12} md={12} lg={6} xl={4} key={i}>
                         <ReportCard
                             key={i}
-                            policy={policy}
+                            profile={profile}
                         />
                     </GridItem>
             );

--- a/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
+++ b/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
@@ -188,7 +188,7 @@ exports[`Reports expect to render without error 1`] = `
           >
             <ReportCard
               key="0"
-              policy={
+              profile={
                 Object {
                   "businessObjective": Object {
                     "id": "1",


### PR DESCRIPTION
This commit changes the Report card to:

 - display SSG on a separate line
 - show the policy info on the popover
 - link to the policy ID on view policy if availabble