### PR TITLE
Name is displayed even if host is not in the inventory

### DIFF
--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -81,7 +81,7 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, pr
             account: entity.account,
             bios_uuid: entity.bios_uuid,
             created: entity.created,
-            display_name: entity.display_name,
+            display_name: entity.display_name || matchingSystem.name,
             fqdn: entity.fqdn,
             insights_id: entity.insights_id,
             ip_addresses: entity.ip_addresses,
@@ -105,7 +105,7 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, pr
                 },
                 compliance: {
                     display_name: { title: <Link to={{ pathname: `/systems/${matchingSystem.id}` }}>
-                        { entity.display_name }
+                        { entity.display_name || matchingSystem.name }
                     </Link> },
                     policies: matchingSystem.profileNames,
                     rules_passed: matchingSystem.rulesPassed,

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -6,7 +6,7 @@ Array [
     "account": undefined,
     "bios_uuid": undefined,
     "created": undefined,
-    "display_name": undefined,
+    "display_name": "demo.lobatolan.home",
     "facts": Object {
       "compliance": Object {
         "compliance_score": <React.Fragment>
@@ -66,7 +66,9 @@ Array [
                 "pathname": "/systems/d5bc2459-21ce-4d11-bc0b-03ea7513dfa6",
               }
             }
-          />,
+          >
+            demo.lobatolan.home
+          </Link>,
         },
         "last_scanned": Object {
           "title": <DateFormat


### PR DESCRIPTION
Just a minor change we could implement if the hostname is not found in the inventory. Currently the system details page is resilient enough to make it pretty clear that the system is not in the inventory, but it doesn't break anything.

This fixes all of the "empty names" around the app if a host is missing in the inventory. I'd prioritize https://github.com/RedHatInsights/compliance-backend/pull/384 over this, but it's nice in dev environments (or if you had imported a prod dump to test the data). 

![Screencast_2020年04月16日_22時19分50秒 webm](https://user-images.githubusercontent.com/598891/79503105-e7904a00-8030-11ea-99db-6172cf549a47.gif)
