### PR TITLE
RHICOMPL-524 - Match Reports by system table names in mocks

### DIFF
--- a/src/SmartComponents/ReportsSystems/ReportsSystems.js
+++ b/src/SmartComponents/ReportsSystems/ReportsSystems.js
@@ -6,7 +6,7 @@ import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/fronte
 const ReportsSystems = () => {
     const columns = [{
         key: 'facts.compliance.display_name',
-        title: 'System name',
+        title: 'Name',
         props: {
             width: 40
         }
@@ -24,7 +24,7 @@ const ReportsSystems = () => {
         }
     }, {
         key: 'facts.compliance.last_scanned',
-        title: 'Last scanned',
+        title: 'Scan date',
         props: {
             width: 10
         }

--- a/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
+++ b/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
@@ -19,7 +19,7 @@ exports[`ReportsSystems expect to render without error in beta 1`] = `
             "props": Object {
               "width": 40,
             },
-            "title": "System name",
+            "title": "Name",
           },
           Object {
             "key": "facts.compliance.policies",
@@ -40,7 +40,7 @@ exports[`ReportsSystems expect to render without error in beta 1`] = `
             "props": Object {
               "width": 10,
             },
-            "title": "Last scanned",
+            "title": "Scan date",
           },
         ]
       }
@@ -69,7 +69,7 @@ exports[`ReportsSystems expect to render without error in stable 1`] = `
             "props": Object {
               "width": 40,
             },
-            "title": "System name",
+            "title": "Name",
           },
           Object {
             "key": "facts.compliance.policies",
@@ -90,7 +90,7 @@ exports[`ReportsSystems expect to render without error in stable 1`] = `
             "props": Object {
               "width": 10,
             },
-            "title": "Last scanned",
+            "title": "Scan date",
           },
         ]
       }


### PR DESCRIPTION
This doesn't make the table sortable as I'm not sure how can we do this with the SystemsTable and the inventory component, but it fixes the mismatch in title names with the mocks. 