### PR TITLE
RHICOMPL-521 - Keep popover in ReportCard always visible

### DIFF
--- a/src/PresentationalComponents/ReportCard/ReportCard.js
+++ b/src/PresentationalComponents/ReportCard/ReportCard.js
@@ -59,14 +59,20 @@ class ReportCard extends React.Component {
             <Card widget-id={refId}>
                 <CardHeader>
                     <TextContent>
-                        <Text onMouseEnter={this.onMouseover.bind(this)} onMouseLeave={this.onMouseout.bind(this)}
-                            style={{ fontWeight: '500' }} component={TextVariants.h2}>
-                            { cardTitleTruncated ? <Truncate lines={1}>{name}&nbsp;
-                                { policy && <PolicyPopover profile={this.props.profile} />}
-                            </Truncate> : <React.Fragment>{name}&nbsp;
-                                { policy && <PolicyPopover profile={this.props.profile} />}
-                            </React.Fragment> }
-                        </Text>
+                        <Grid>
+                            <GridItem span={11}>
+                                <Text onMouseEnter={this.onMouseover.bind(this)} onMouseLeave={this.onMouseout.bind(this)}
+                                    style={{ fontWeight: '500' }} component={TextVariants.h2}>
+                                    { cardTitleTruncated ? <Truncate lines={1}>{name}&nbsp;</Truncate> :
+                                        <React.Fragment>{name}&nbsp;</React.Fragment> }
+                                </Text>
+                            </GridItem>
+                            <GridItem span={1}>
+                                <Text style={{ fontWeight: '500' }} component={TextVariants.h2}>
+                                    { policy && <PolicyPopover profile={this.props.profile} />}
+                                </Text>
+                            </GridItem>
+                        </Grid>
                         <Grid>
                             <GridItem span={12}>
                                 <Text>

--- a/src/PresentationalComponents/ReportCard/__snapshots__/ReportCard.test.js.snap
+++ b/src/PresentationalComponents/ReportCard/__snapshots__/ReportCard.test.js.snap
@@ -6,49 +6,68 @@ exports[`ReportCard expect to render without error 1`] = `
 >
   <CardHeader>
     <TextContent>
-      <Text
-        component="h2"
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        style={
-          Object {
-            "fontWeight": "500",
-          }
-        }
-      >
-        <Truncate
-          ellipsis="…"
-          lines={1}
-          trimWhitespace={false}
-          width={0}
+      <Grid>
+        <GridItem
+          span={11}
         >
-          Test Policy
-           
-          <PolicyPopover
-            profile={
+          <Text
+            component="h2"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
               Object {
-                "benchmark": Object {
-                  "version": "0.1.5",
-                },
-                "businessObjective": Object {
-                  "title": "BO",
-                },
-                "compliantHostCount": 10,
-                "id": "ID",
-                "name": "Test Policy",
-                "policy": Object {
-                  "benchmark": Object {
-                    "version": "0.1.4",
-                  },
-                  "id": "policyid",
-                },
-                "refId": "REF_ID",
-                "totalHostCount": 15,
+                "fontWeight": "500",
               }
             }
-          />
-        </Truncate>
-      </Text>
+          >
+            <Truncate
+              ellipsis="…"
+              lines={1}
+              trimWhitespace={false}
+              width={0}
+            >
+              Test Policy
+               
+            </Truncate>
+          </Text>
+        </GridItem>
+        <GridItem
+          span={1}
+        >
+          <Text
+            component="h2"
+            style={
+              Object {
+                "fontWeight": "500",
+              }
+            }
+          >
+            <PolicyPopover
+              profile={
+                Object {
+                  "benchmark": Object {
+                    "version": "0.1.5",
+                  },
+                  "businessObjective": Object {
+                    "title": "BO",
+                  },
+                  "compliantHostCount": 10,
+                  "id": "ID",
+                  "name": "Test Policy",
+                  "policy": Object {
+                    "benchmark": Object {
+                      "version": "0.1.4",
+                    },
+                    "id": "policyid",
+                  },
+                  "refId": "REF_ID",
+                  "totalHostCount": 15,
+                }
+              }
+            />
+          </Text>
+        </GridItem>
+      </Grid>
       <Grid>
         <GridItem
           span={12}


### PR DESCRIPTION
This allows us to keep the popover in the ReportCard always visible so that even with the truncated text, the user can just click on it. It is very frustrating otherwise to aim for it and have it show up on the 2nd line. 