### PR TITLE
Remove extra fields from EditPolicyRules

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicyRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyRules.js
@@ -26,13 +26,7 @@ query benchmarkAndProfile($benchmarkId: String!, $profileId: String!){
         name
         refId
         rules {
-            title
-            severity
-            rationale
             refId
-            description
-            remediationAvailable
-            identifier
         }
     }
 }


### PR DESCRIPTION
The EditPolicyRules file is querying some extra info for the selected
rules. However, we only use the Ref ID to check which rules are
selected, and this info is used from the Benchmark Rules GQL call.