### PR TITLE
RHICOMPL-606 - Add policy id to rowdata and use for deletion

### DIFF
--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -38,6 +38,7 @@ const emptyRows = [{
 const policiesToRows = (policies) => (
     policies.map((policy) => (
         {
+            policyId: policy.id,
             cells: [
                 { title: <Link to={'/scappolicies/' + policy.id}>{policy.name}</Link>, original: policy.name },
                 {
@@ -148,16 +149,14 @@ export class PoliciesTable extends React.Component {
 
     actionResolver = (rowData) => {
         const { policies } = this.props;
-        const { itemsPerPage, page } = this.state;
-
-        const currentRowIndex = rowData.id + (page - 1) * itemsPerPage;
+        const policy = policies.find((p) => p.id === rowData.policyId);
 
         return [
             {
                 title: 'Delete policy',
                 onClick: () => {
                     this.setState((prev) => ({
-                        policyToDelete: policies[currentRowIndex],
+                        policyToDelete: policy,
                         isDeleteModalOpen: !prev.isDeleteModalOpen
                     }));
                 }

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -147,19 +147,22 @@ export class PoliciesTable extends React.Component {
         clearAll ? this.clearAllFilter() : this.deleteFilter(chips[0])
     )
 
-    actionResolver = (rowData) => {
-        const { policies } = this.props;
-        const policy = policies.find((p) => p.id === rowData.policyId);
+    setAndDeletePolicy = (policyId) => (
+        this.setState((prev) => ({
+            policyToDelete: this.props.policies.find((policy) => (
+                policy.id === policyId
+            )),
+            isDeleteModalOpen: !prev.isDeleteModalOpen
+        }))
+    )
 
+    actionResolver = () => {
         return [
             {
                 title: 'Delete policy',
-                onClick: () => {
-                    this.setState((prev) => ({
-                        policyToDelete: policy,
-                        isDeleteModalOpen: !prev.isDeleteModalOpen
-                    }));
-                }
+                onClick: (_event, _index, { policyId }) => (
+                    this.setAndDeletePolicy(policyId)
+                )
             }
         ];
     }
@@ -208,7 +211,7 @@ export class PoliciesTable extends React.Component {
                 aria-label='policies'
                 className='compliance-policies-table'
                 cells={ this.columns }
-                actionResolver={ rows.length > 0 && this.actionResolver}
+                actionResolver={ rows.length > 0 && this.actionResolver }
                 rows={ (rows.length === 0) ? emptyRows : rows }>
                 <TableHeader />
                 <TableBody />

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.test.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.test.js
@@ -1,5 +1,5 @@
 import toJson from 'enzyme-to-json';
-import { policies } from './fixtures.js';
+import { policies as rawPolicies } from './fixtures.js';
 import debounce from 'lodash/debounce';
 
 jest.mock('react-router-dom', () => (
@@ -14,18 +14,22 @@ jest.mock('lodash/debounce');
 debounce.mockImplementation(fn => fn);
 
 import { PoliciesTable } from './PoliciesTable.js';
+const policies = rawPolicies.edges.map(profile => profile.node);
 
 describe('PoliciesTable', () => {
+    let wrapper;
+    let instance;
+
     it('expect to render without error', () => {
-        const wrapper = shallow(
-            <PoliciesTable policies={policies.edges.map(profile => profile.node)} />
+        wrapper = shallow(
+            <PoliciesTable policies={ policies } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('expect to render emptystate', () => {
-        const wrapper = shallow(
+        wrapper = shallow(
             <PoliciesTable policies={[]} />
         );
 
@@ -33,28 +37,40 @@ describe('PoliciesTable', () => {
     });
 
     describe('Pagination and search', () => {
-        let wrapper;
-
         beforeEach(() => {
             wrapper = shallow(
                 <PoliciesTable
-                    policies={policies.edges.map(profile => profile.node)}
+                    policies={ policies }
                 />);
+            instance = wrapper.instance();
         });
 
         it('should show only matching results after searching', async () => {
-            const instance = wrapper.instance();
             await instance.onFilterUpdate('name', 'CCP');
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
         it('should be able to move to next and previous pages', async () => {
-            const instance = wrapper.instance();
             await instance.changePage(2, 10);
             expect(toJson(wrapper)).toMatchSnapshot();
             await instance.changePage(1, 10);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
+    });
 
+    describe('setAndDeletePolicy', () => {
+        beforeEach(() => {
+            wrapper = shallow(
+                <PoliciesTable
+                    policies={ policies }
+                />);
+            instance = wrapper.instance();
+        });
+
+        it('should set the policy in state and open modal', async () => {
+            await instance.setAndDeletePolicy(policies[0].id);
+            expect(wrapper.state()).toMatchSnapshot();
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
     });
 });

--- a/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -132,6 +132,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "4c27fe09-9a7f-437c-b38b-e42272d9ccf0",
         },
         Object {
           "cells": Array [
@@ -195,6 +196,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "9b034440-e3dd-4c19-8f2c-ca75e813d57d",
         },
         Object {
           "cells": Array [
@@ -258,6 +260,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "19921ca4-8526-4651-8876-3c8587e8e125",
         },
       ]
     }
@@ -419,6 +422,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "b71376fd-015e-4209-99af-4543e82e5dc5",
         },
         Object {
           "cells": Array [
@@ -482,6 +486,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "67%",
           ],
+          "policyId": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
         },
         Object {
           "cells": Array [
@@ -545,6 +550,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "dae0487d-3201-4ee0-af5f-b94cde2af818",
         },
         Object {
           "cells": Array [
@@ -608,6 +614,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "69.5%",
           ],
+          "policyId": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
         },
         Object {
           "cells": Array [
@@ -671,6 +678,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
         },
         Object {
           "cells": Array [
@@ -734,6 +742,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
         },
         Object {
           "cells": Array [
@@ -797,6 +806,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
         },
         Object {
           "cells": Array [
@@ -860,6 +870,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
         },
         Object {
           "cells": Array [
@@ -923,6 +934,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
         },
         Object {
           "cells": Array [
@@ -986,6 +998,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
             "--",
             "100%",
           ],
+          "policyId": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
         },
       ]
     }
@@ -1156,6 +1169,7 @@ exports[`PoliciesTable Pagination and search should show only matching results a
             "--",
             "100%",
           ],
+          "policyId": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
         },
       ]
     }
@@ -1443,6 +1457,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "100%",
           ],
+          "policyId": "b71376fd-015e-4209-99af-4543e82e5dc5",
         },
         Object {
           "cells": Array [
@@ -1506,6 +1521,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "67%",
           ],
+          "policyId": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
         },
         Object {
           "cells": Array [
@@ -1569,6 +1585,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "100%",
           ],
+          "policyId": "dae0487d-3201-4ee0-af5f-b94cde2af818",
         },
         Object {
           "cells": Array [
@@ -1632,6 +1649,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "69.5%",
           ],
+          "policyId": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
         },
         Object {
           "cells": Array [
@@ -1695,6 +1713,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "100%",
           ],
+          "policyId": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
         },
         Object {
           "cells": Array [
@@ -1758,6 +1777,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "100%",
           ],
+          "policyId": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
         },
         Object {
           "cells": Array [
@@ -1821,6 +1841,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "100%",
           ],
+          "policyId": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
         },
         Object {
           "cells": Array [
@@ -1884,6 +1905,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "100%",
           ],
+          "policyId": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
         },
         Object {
           "cells": Array [
@@ -1947,6 +1969,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "100%",
           ],
+          "policyId": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
         },
         Object {
           "cells": Array [
@@ -2010,6 +2033,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "--",
             "100%",
           ],
+          "policyId": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
         },
       ]
     }

--- a/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -2062,3 +2062,779 @@ exports[`PoliciesTable expect to render without error 1`] = `
   />
 </Fragment>
 `;
+
+exports[`PoliciesTable setAndDeletePolicy should set the policy in state and open modal 1`] = `
+Object {
+  "activeFilters": Object {},
+  "isDeleteModalOpen": true,
+  "itemsPerPage": 10,
+  "page": 1,
+  "policyToDelete": Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
+    "majorOsVersion": 7,
+    "name": "United States Government Configuration Baseline23",
+    "refId": "xccdf_org.ssgproject.content_profile_ospp23",
+    "totalHostCount": 10,
+  },
+}
+`;
+
+exports[`PoliciesTable setAndDeletePolicy should set the policy in state and open modal 2`] = `
+<Fragment>
+  <PrimaryToolbar
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": undefined,
+            },
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+      }
+    }
+    pagination={
+      Object {
+        "dropDirection": "down",
+        "itemCount": 13,
+        "onPerPageSelect": [Function],
+        "onSetPage": [Function],
+        "page": 1,
+        "perPage": 10,
+      }
+    }
+    toggleIsExpanded={[Function]}
+  >
+    <DataToolbarItem>
+      <Connect(CreatePolicy) />
+    </DataToolbarItem>
+    <DataToolbarItem>
+      13
+       results
+    </DataToolbarItem>
+  </PrimaryToolbar>
+  <Component
+    actionResolver={[Function]}
+    aria-label="policies"
+    cells={
+      Array [
+        Object {
+          "title": "Policy name",
+        },
+        Object {
+          "title": "Operating system",
+        },
+        Object {
+          "title": "Systems",
+        },
+        Object {
+          "title": "Business objective",
+        },
+        Object {
+          "title": "Compliance threshold",
+        },
+      ]
+    }
+    className="compliance-policies-table"
+    rows={
+      Array [
+        Object {
+          "cells": Array [
+            Object {
+              "original": "United States Government Configuration Baseline23",
+              "title": <UNDEFINED
+                to="/scappolicies/b71376fd-015e-4209-99af-4543e82e5dc5"
+              >
+                United States Government Configuration Baseline23
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "100%",
+          ],
+          "policyId": "b71376fd-015e-4209-99af-4543e82e5dc5",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+              "title": <UNDEFINED
+                to="/scappolicies/719999b6-d230-4ba5-8dba-7ab3dc6561e0"
+              >
+                PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "67%",
+          ],
+          "policyId": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "United States Government Configuration Baseline2",
+              "title": <UNDEFINED
+                to="/scappolicies/dae0487d-3201-4ee0-af5f-b94cde2af818"
+              >
+                United States Government Configuration Baseline2
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "100%",
+          ],
+          "policyId": "dae0487d-3201-4ee0-af5f-b94cde2af818",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "C2S for Red Hat Enterprise Linux 7",
+              "title": <UNDEFINED
+                to="/scappolicies/20a9d997-62a6-40cc-a5f3-19d466eb975e"
+              >
+                C2S for Red Hat Enterprise Linux 7
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "69.5%",
+          ],
+          "policyId": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "Criminal Justice Information Services (CJIS) Security Policy",
+              "title": <UNDEFINED
+                to="/scappolicies/6d345bd2-d597-4df8-9bcf-71c41155b42c"
+              >
+                Criminal Justice Information Services (CJIS) Security Policy
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "100%",
+          ],
+          "policyId": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
+              "title": <UNDEFINED
+                to="/scappolicies/c8e15347-9c2b-495d-8e54-503c2f9582b6"
+              >
+                Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "100%",
+          ],
+          "policyId": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+              "title": <UNDEFINED
+                to="/scappolicies/3c4823a1-2c16-46ae-b2fe-0cebf5a03931"
+              >
+                PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "100%",
+          ],
+          "policyId": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
+              "title": <UNDEFINED
+                to="/scappolicies/f7b7977a-403b-4cd1-ab90-20b6f9a5a359"
+              >
+                Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "100%",
+          ],
+          "policyId": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "Health Insurance Portability and Accountability Act (HIPAA)",
+              "title": <UNDEFINED
+                to="/scappolicies/36abc364-6dc3-4e35-94f4-d10fa77e866e"
+              >
+                Health Insurance Portability and Accountability Act (HIPAA)
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "100%",
+          ],
+          "policyId": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "original": "United States Government Configuration Baseline",
+              "title": <UNDEFINED
+                to="/scappolicies/d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220"
+              >
+                United States Government Configuration Baseline
+              </UNDEFINED>,
+            },
+            Object {
+              "title": <Tooltip
+                appendTo={[Function]}
+                aria="describedby"
+                boundary="window"
+                className=""
+                content={
+                  <span>
+                    SCAP Security Guide (SSG): 
+                    Guide to the Secure Configuration of RHEL 7
+                     - 
+                    0.1.49
+                  </span>
+                }
+                distance={15}
+                enableFlip={true}
+                entryDelay={500}
+                exitDelay={500}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                id=""
+                isAppLauncher={false}
+                isContentLeftAligned={false}
+                isVisible={false}
+                maxWidth="18.75rem"
+                position="right"
+                tippyProps={Object {}}
+                trigger="mouseenter focus"
+                zIndex={9999}
+              >
+                <span>
+                  RHEL 
+                  7
+                   (SSG 
+                  0.1.49
+                  )
+                </span>
+              </Tooltip>,
+            },
+            10,
+            "--",
+            "100%",
+          ],
+          "policyId": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
+        },
+      ]
+    }
+  >
+    <TableHeader />
+    <TableBody />
+  </Component>
+  <TableToolbar
+    className="ins-c-inventory__table--toolbar"
+    isFooter={true}
+  >
+    <Component
+      dropDirection="up"
+      itemCount={13}
+      onPerPageSelect={[Function]}
+      onSetPage={[Function]}
+      page={1}
+      perPage={10}
+      variant="bottom"
+    />
+  </TableToolbar>
+  <DeletePolicy
+    isModalOpen={true}
+    policy={
+      Object {
+        "__typename": "Profile",
+        "benchmark": Object {
+          "title": "Guide to the Secure Configuration of RHEL 7",
+          "version": "0.1.49",
+        },
+        "businessObjective": null,
+        "complianceThreshold": 100,
+        "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
+        "majorOsVersion": 7,
+        "name": "United States Government Configuration Baseline23",
+        "refId": "xccdf_org.ssgproject.content_profile_ospp23",
+        "totalHostCount": 10,
+      }
+    }
+    toggle={[Function]}
+  />
+</Fragment>
+`;


### PR DESCRIPTION
When filtering looking up the policy with per page, index, etc. returns the wrong policy to delete.
This adds the policy id to the rowdata to later use it to find the correct policy to delete.
