### PR TITLE
RHICOMPL-578 - Disable exporting when no items

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -242,7 +242,10 @@ class SystemsTable extends React.Component {
             { hideLabel: true }
         );
         const filterChips = this.chipBuilder.chipsFor(this.state.activeFilters);
-        const exportConfig = enableExport ? { onSelect: this.onExportSelect } : {};
+        const exportConfig = enableExport ? {
+            isDisabled: items.length === 0,
+            onSelect: this.onExportSelect
+        } : {};
         const inventoryTableProps = {
             onRefresh: this.onRefresh,
             ref: this.inventory,

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -101,6 +101,7 @@ exports[`SystemsTable expect to not render a loading state 1`] = `
   }
   exportConfig={
     Object {
+      "isDisabled": true,
       "onSelect": [Function],
     }
   }
@@ -199,6 +200,7 @@ exports[`SystemsTable expect to not show actions if showActions is false 1`] = `
   }
   exportConfig={
     Object {
+      "isDisabled": true,
       "onSelect": [Function],
     }
   }
@@ -309,6 +311,7 @@ exports[`SystemsTable expect to render a loading state 1`] = `
   }
   exportConfig={
     Object {
+      "isDisabled": true,
       "onSelect": [Function],
     }
   }
@@ -419,6 +422,7 @@ exports[`SystemsTable expect to set loading state correctly on systemfetch 1`] =
   }
   exportConfig={
     Object {
+      "isDisabled": false,
       "onSelect": [Function],
     }
   }
@@ -533,6 +537,7 @@ exports[`SystemsTable expect to show actions if showActions is true or by defaul
   }
   exportConfig={
     Object {
+      "isDisabled": true,
       "onSelect": [Function],
     }
   }


### PR DESCRIPTION
With results:

![Screenshot 2020-04-22 at 13 13 00](https://user-images.githubusercontent.com/7757/79975346-1f691880-849b-11ea-84a4-1a6de3984308.png)

Without results:

![Screenshot 2020-04-22 at 13 12 38](https://user-images.githubusercontent.com/7757/79975350-2001af00-849b-11ea-99c1-22f7f1797035.png)

Note: The option are disabled, but the dropdown-button remains the same.