### PR TITLE
RHICOMPL-597 - Clear inventory filters when loading systems

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -210,7 +210,7 @@ class SystemsTable extends React.Component {
     }, 500)
 
     async fetchInventory() {
-        const { columns, policyId, showAllSystems } = this.props;
+        const { columns, policyId, showAllSystems, clearInventoryFilter } = this.props;
         const {
             inventoryConnector,
             INVENTORY_ACTION_TYPES,
@@ -223,7 +223,7 @@ class SystemsTable extends React.Component {
             pfReactTable
         });
 
-        this.props.clearInventoryFilter();
+        clearInventoryFilter();
 
         this.getRegistry().register({
             ...mergeWithEntities(

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -223,6 +223,8 @@ class SystemsTable extends React.Component {
             pfReactTable
         });
 
+        this.props.clearInventoryFilter();
+
         this.getRegistry().register({
             ...mergeWithEntities(
                 entitiesReducer(
@@ -332,7 +334,8 @@ SystemsTable.propTypes = {
     complianceThreshold: propTypes.number,
     showOnlySystemsWithTestResults: propTypes.bool,
     showActions: propTypes.bool,
-    compliantFilter: propTypes.bool
+    compliantFilter: propTypes.bool,
+    clearInventoryFilter: propTypes.func
 };
 
 SystemsTable.defaultProps = {
@@ -362,6 +365,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
     return {
+        clearInventoryFilter: () => dispatch({ type: 'CLEAR_FILTERS' }),
         exportToCSV: event => dispatch(exportToCSV(event))
     };
 };

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -366,7 +366,7 @@ exports[`SystemsTable expect to set compliant filters when enabled 1`] = `
 `;
 
 exports[`SystemsTable expect to set loading state correctly on systemfetch 1`] = `
-<mockConstructor
+<ForwardRef
   actions={
     Array [
       Object {
@@ -431,7 +431,7 @@ exports[`SystemsTable expect to set loading state correctly on systemfetch 1`] =
       />
     </ToolbarItem>
   </ToolbarGroup>
-</mockConstructor>
+</ForwardRef>
 `;
 
 exports[`SystemsTable expect to show actions if showActions is true or by default 1`] = `


### PR DESCRIPTION
This will prevent Inventory filters to persist throughout navigating to other pages.