### PR TITLE
RHICOMPL-603 - Restore compliant filters on Reports by System

### DIFF
--- a/src/SmartComponents/ReportsSystems/ReportsSystems.js
+++ b/src/SmartComponents/ReportsSystems/ReportsSystems.js
@@ -37,7 +37,10 @@ const ReportsSystems = () => {
                 <ReportTabs/>
             </PageHeader>
             <Main>
-                <SystemsTable showOnlySystemsWithTestResults columns={columns} />
+                <SystemsTable
+                    compliantFilter
+                    showOnlySystemsWithTestResults
+                    columns={columns} />
             </Main>
         </React.Fragment>
     );

--- a/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
+++ b/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
@@ -44,6 +44,7 @@ exports[`ReportsSystems expect to render without error in beta 1`] = `
           },
         ]
       }
+      compliantFilter={true}
       showOnlySystemsWithTestResults={true}
     />
   </Connect(Main)>
@@ -94,6 +95,7 @@ exports[`ReportsSystems expect to render without error in stable 1`] = `
           },
         ]
       }
+      compliantFilter={true}
       showOnlySystemsWithTestResults={true}
     />
   </Connect(Main)>


### PR DESCRIPTION
The SystemsTable onb the "By Systems" page under Reports still shows a compliance score and should also have the filters for it.