### PR TITLE
Fix tabs-top-border

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -5,7 +5,7 @@
 
 
 .pf-c-page__main .pf-c-page-header.pf-c-page__main-section {
-  &.page-header {
+  &.page-header-tabs {
       padding-bottom: 0px !important;
   }
 

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -84,7 +84,7 @@ export const PolicyDetailsQuery = ({ policyId, onNavigateWithProps }) => {
             <Main><Spinner/></Main>
         </StateViewPart>
         <StateViewPart stateKey='data'>
-            <PageHeader className='page-header'>
+            <PageHeader className='page-header-tabs'>
                 <Breadcrumb>
                     <BreadcrumbItem to={`${ beta ? '/beta/insights' : '/rhel' }/compliance/scappolicies`}
                         onClick={ (event) => onNavigateWithProps(event) }>

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -3,7 +3,7 @@
 exports[`PolicyDetails expect to render without error 1`] = `
 <div>
   <section
-    class="page-header pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+    class="page-header-tabs pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -279,7 +279,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
 exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
 <div>
   <section
-    class="page-header pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+    class="page-header-tabs pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -555,7 +555,7 @@ exports[`PolicyDetailsQuery expect to render even without policyId 1`] = `
 exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
 <div>
   <section
-    class="page-header pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+    class="page-header-tabs pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -831,7 +831,7 @@ exports[`PolicyDetailsQuery expect to render with policyId 1`] = `
 exports[`PolicyDetailsQuery renders without error 1`] = `
 <div>
   <section
-    class="page-header pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+    class="page-header-tabs pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -1107,7 +1107,7 @@ exports[`PolicyDetailsQuery renders without error 1`] = `
 exports[`PolicyDetailsQuery renders without error 2`] = `
 <div>
   <section
-    class="page-header pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+    class="page-header-tabs pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
     widget-type="InsightsPageHeader"
   >
     <nav

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -58,7 +58,7 @@ export const Reports = () => {
         const profiles = data.profiles.edges.map(profile => profile.node).filter((profile) => profile.totalHostCount > 0);
 
         if (profiles.length) {
-            pageHeader = <PageHeader className='page-header'>
+            pageHeader = <PageHeader className='page-header-tabs'>
                 <PageHeaderTitle title="Compliance reports" />
                 <ReportTabs/>
             </PageHeader>;

--- a/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
+++ b/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
@@ -165,7 +165,7 @@ exports[`Reports expect to render without error 1`] = `
     stateKey="data"
   >
     <PageHeader
-      className="page-header"
+      className="page-header-tabs"
     >
       <PageHeaderTitle
         title="Compliance reports"

--- a/src/SmartComponents/ReportsSystems/ReportsSystems.js
+++ b/src/SmartComponents/ReportsSystems/ReportsSystems.js
@@ -32,7 +32,7 @@ const ReportsSystems = () => {
 
     return (
         <React.Fragment>
-            <PageHeader className='page-header'>
+            <PageHeader className='page-header-tabs'>
                 <PageHeaderTitle title="Compliance reports" />
                 <ReportTabs/>
             </PageHeader>

--- a/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
+++ b/src/SmartComponents/ReportsSystems/__snapshots__/ReportsSystems.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ReportsSystems expect to render without error in beta 1`] = `
 <Fragment>
   <PageHeader
-    className="page-header"
+    className="page-header-tabs"
   >
     <PageHeaderTitle
       title="Compliance reports"
@@ -54,7 +54,7 @@ exports[`ReportsSystems expect to render without error in beta 1`] = `
 exports[`ReportsSystems expect to render without error in stable 1`] = `
 <Fragment>
   <PageHeader
-    className="page-header"
+    className="page-header-tabs"
   >
     <PageHeaderTitle
       title="Compliance reports"


### PR DESCRIPTION
![Screencast_2020年04月23日_11時23分49秒 webm](https://user-images.githubusercontent.com/598891/80082749-1472be80-8555-11ea-8620-6c79e30dd2c1.gif)

This should fix the problem we have with different top borders in pages with tabs and without tabs. The end result is what you can see in the gif. 