### PR TITLE
Fix endless loading SystemsTable

### DIFF
--- a/src/Utilities/ruleHelpers.js
+++ b/src/Utilities/ruleHelpers.js
@@ -1,9 +1,9 @@
 export const profilesRulesFailed = (profiles) => (
-    profiles.flatMap(profile => profile.rules.filter(rule => !rule.compliant))
+    profiles.flatMap(profile => profile.rules && profile.rules.filter(rule => !rule.compliant))
 );
 
 export const profilesRulesPassed = (profiles) => (
-    profiles.flatMap(profile => profile.rules.filter(rule => rule.compliant))
+    profiles.flatMap(profile => profile.rules && profile.rules.filter(rule => rule.compliant))
 );
 
 export const systemRulesPassed = (system) => (


### PR DESCRIPTION
On the SCAP policy details view, systems table - the table is endlessly
loading because it's tries to get the rules passed (the reducer does
this automatically) - but the rules passed just can't be computed based
on the GQL query we make there - since there's no remediation button, we
don't fetch that info.