### PR TITLE
RHICOMPL-638 - Fix SystemsTable loading behaviour

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -6,7 +6,7 @@ import {
     TextContent,
     TextVariants
 } from '@patternfly/react-core';
-import { SystemsTableWithApollo as SystemsTable } from '../SystemsTable/SystemsTable';
+import SystemsTable from '../SystemsTable/SystemsTable';
 import { compose } from 'redux';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.test.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.test.js
@@ -2,6 +2,7 @@ import { policyFormValues } from './fixtures.js';
 import configureStore from 'redux-mock-store';
 import renderer from 'react-test-renderer';
 import { MockedProvider } from '@apollo/react-testing';
+import { Provider as ReduxProvider } from 'react-redux';
 
 const mockStore = configureStore();
 
@@ -17,9 +18,11 @@ describe('EditPolicySystems', () => {
 
     it('expect to render without error', () => {
         component = renderer.create(
-            <MockedProvider>
-                <EditPolicySystems store={store} />
-            </MockedProvider>
+            <ReduxProvider store={store}>
+                <MockedProvider>
+                    <EditPolicySystems />
+                </MockedProvider>
+            </ReduxProvider>
         );
         expect(component.toJSON()).toMatchSnapshot();
     });

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.test.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.test.js
@@ -1,6 +1,5 @@
 import toJson from 'enzyme-to-json';
 import { policies as rawPolicies } from './fixtures.js';
-import debounce from 'lodash/debounce';
 
 jest.mock('react-router-dom', () => (
     {
@@ -10,8 +9,6 @@ jest.mock('react-router-dom', () => (
         withRouter: jest.fn()
     }
 ));
-jest.mock('lodash/debounce');
-debounce.mockImplementation(fn => fn);
 
 import { PoliciesTable } from './PoliciesTable.js';
 const policies = rawPolicies.edges.map(profile => profile.node);

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -170,7 +170,7 @@ class SystemsTable extends React.Component {
         this.props.updateSystems({
             systems: [],
             systemsCount: 0
-        })
+        });
         this.setState({
             ...initialState,
             activeFilters: {

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -167,6 +167,10 @@ class SystemsTable extends React.Component {
     }
 
     onFilterUpdate = (filter, selectedValues) => {
+        this.props.updateSystems({
+            systems: [],
+            systemsCount: 0
+        })
         this.setState({
             ...initialState,
             activeFilters: {

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -113,11 +113,15 @@ exports[`SystemsTable expect to not render a loading state 1`] = `
       ],
     }
   }
-  items={Array []}
+  items={
+    Array [
+      1,
+    ]
+  }
   onRefresh={[Function]}
   page={1}
   perPage={50}
-  total={0}
+  total={1}
 >
   <ToolbarGroup>
     <ToolbarItem
@@ -166,11 +170,15 @@ exports[`SystemsTable expect to not show actions if showActions is false 1`] = `
       ],
     }
   }
-  items={Array []}
+  items={
+    Array [
+      1,
+    ]
+  }
   onRefresh={[Function]}
   page={1}
   perPage={50}
-  total={0}
+  total={1}
 >
   <ToolbarGroup>
     <ToolbarItem
@@ -235,7 +243,6 @@ exports[`SystemsTable expect to render a loading state 1`] = `
   onRefresh={[Function]}
   page={1}
   perPage={50}
-  total={0}
 >
   <ToolbarGroup>
     <ToolbarItem
@@ -342,11 +349,15 @@ exports[`SystemsTable expect to set compliant filters when enabled 1`] = `
       ],
     }
   }
-  items={Array []}
+  items={
+    Array [
+      1,
+    ]
+  }
   onRefresh={[Function]}
   page={1}
   perPage={50}
-  total={0}
+  total={1}
 >
   <ToolbarGroup>
     <ToolbarItem
@@ -365,7 +376,7 @@ exports[`SystemsTable expect to set compliant filters when enabled 1`] = `
 </ForwardRef>
 `;
 
-exports[`SystemsTable expect to set isDisable on export config to false entityCount is 0 but selected is not 1`] = `
+exports[`SystemsTable expect to set isDisable on export config to false total is 0 but selected is not 1`] = `
 <ForwardRef
   actions={
     Array [
@@ -407,72 +418,11 @@ exports[`SystemsTable expect to set isDisable on export config to false entityCo
       ],
     }
   }
-  items={Array []}
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  total={0}
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
-        Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
-      }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
-`;
-
-exports[`SystemsTable expect to set isDisable on export config to true entityCount is 0 1`] = `
-<ForwardRef
-  actions={
+  items={
     Array [
-      Object {
-        "onClick": [Function],
-        "title": "Edit policies for this system",
-      },
-      Object {
-        "onClick": [Function],
-        "title": "View in inventory",
-      },
+      1,
     ]
   }
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": true,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
-        Object {
-          "filterValues": Object {
-            "onSubmit": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
-        },
-      ],
-    }
-  }
-  items={Array []}
   onRefresh={[Function]}
   page={1}
   perPage={50}
@@ -487,7 +437,14 @@ exports[`SystemsTable expect to set isDisable on export config to true entityCou
       }
     >
       <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
+        allSystems={
+          Array [
+            Object {
+              "id": 1,
+              "ruleObjectsFailed": Array [],
+            },
+          ]
+        }
         selectedRules={Array []}
       />
     </ToolbarItem>
@@ -495,7 +452,7 @@ exports[`SystemsTable expect to set isDisable on export config to true entityCou
 </ForwardRef>
 `;
 
-exports[`SystemsTable expect to set loading state correctly on systemfetch 1`] = `
+exports[`SystemsTable expect to set isDisable on export config to true total is 0 1`] = `
 <ForwardRef
   actions={
     Array [
@@ -545,7 +502,71 @@ exports[`SystemsTable expect to set loading state correctly on systemfetch 1`] =
   onRefresh={[Function]}
   page={1}
   perPage={50}
-  total={1}
+  total={0}
+>
+  <ToolbarGroup>
+    <ToolbarItem
+      style={
+        Object {
+          "marginLeft": "var(--pf-global--spacer--lg)",
+        }
+      }
+    >
+      <Connect(ComplianceRemediationButton)
+        allSystems={Array []}
+        selectedRules={Array []}
+      />
+    </ToolbarItem>
+  </ToolbarGroup>
+</ForwardRef>
+`;
+
+exports[`SystemsTable expect to set loading state correctly on updateSystems 1`] = `
+<ForwardRef
+  actions={
+    Array [
+      Object {
+        "onClick": [Function],
+        "title": "Edit policies for this system",
+      },
+      Object {
+        "onClick": [Function],
+        "title": "View in inventory",
+      },
+    ]
+  }
+  activeFiltersConfig={
+    Object {
+      "filters": Array [],
+      "onDelete": [Function],
+    }
+  }
+  exportConfig={
+    Object {
+      "isDisabled": true,
+      "onSelect": [Function],
+    }
+  }
+  filterConfig={
+    Object {
+      "hideLabel": true,
+      "items": Array [
+        Object {
+          "filterValues": Object {
+            "onSubmit": [Function],
+            "value": "",
+          },
+          "id": "name",
+          "label": "Name",
+          "type": "text",
+        },
+      ],
+    }
+  }
+  items={Array []}
+  onRefresh={[Function]}
+  page={1}
+  perPage={50}
 >
   <ToolbarGroup>
     <ToolbarItem
@@ -606,11 +627,15 @@ exports[`SystemsTable expect to show actions if showActions is true or by defaul
       ],
     }
   }
-  items={Array []}
+  items={
+    Array [
+      1,
+    ]
+  }
   onRefresh={[Function]}
   page={1}
   perPage={50}
-  total={0}
+  total={1}
 >
   <ToolbarGroup>
     <ToolbarItem

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -103,7 +103,7 @@ exports[`SystemsTable expect to not render a loading state 1`] = `
       "items": Array [
         Object {
           "filterValues": Object {
-            "onSubmit": [Function],
+            "onChange": [Function],
             "value": "",
           },
           "id": "name",
@@ -160,7 +160,7 @@ exports[`SystemsTable expect to not show actions if showActions is false 1`] = `
       "items": Array [
         Object {
           "filterValues": Object {
-            "onSubmit": [Function],
+            "onChange": [Function],
             "value": "",
           },
           "id": "name",
@@ -229,7 +229,7 @@ exports[`SystemsTable expect to render a loading state 1`] = `
       "items": Array [
         Object {
           "filterValues": Object {
-            "onSubmit": [Function],
+            "onChange": [Function],
             "value": "",
           },
           "id": "name",
@@ -293,7 +293,7 @@ exports[`SystemsTable expect to set compliant filters when enabled 1`] = `
       "items": Array [
         Object {
           "filterValues": Object {
-            "onSubmit": [Function],
+            "onChange": [Function],
             "value": "",
           },
           "id": "name",
@@ -408,7 +408,7 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
       "items": Array [
         Object {
           "filterValues": Object {
-            "onSubmit": [Function],
+            "onChange": [Function],
             "value": "",
           },
           "id": "name",
@@ -484,7 +484,7 @@ exports[`SystemsTable expect to set isDisable on export config to true total is 
       "items": Array [
         Object {
           "filterValues": Object {
-            "onSubmit": [Function],
+            "onChange": [Function],
             "value": "",
           },
           "id": "name",
@@ -553,7 +553,7 @@ exports[`SystemsTable expect to set loading state correctly on updateSystems 1`]
       "items": Array [
         Object {
           "filterValues": Object {
-            "onSubmit": [Function],
+            "onChange": [Function],
             "value": "",
           },
           "id": "name",
@@ -617,7 +617,7 @@ exports[`SystemsTable expect to show actions if showActions is true or by defaul
       "items": Array [
         Object {
           "filterValues": Object {
-            "onSubmit": [Function],
+            "onChange": [Function],
             "value": "",
           },
           "id": "name",

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,7 +18,6 @@ export const DEFAULT_SYSTEMS_FILTER_CONFIGURATION = [
     {
         type: conditionalFilterType.text,
         label: 'Name',
-        event: 'onSubmit',
         filterString: (value) => (`name ~ ${value}`)
     }
 ];

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -153,28 +153,34 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, pr
         };
     }).filter(value => value !== undefined);
 
-export const entitiesReducer = (INVENTORY_ACTION, systems, columns, isGraphqlFinished, showAllSystems,
-    profileId) => applyReducerHash(
+export const entitiesReducer = (INVENTORY_ACTION, columns, showAllSystems, profileId) => applyReducerHash(
     {
-        [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => {
-            if (!isGraphqlFinished()) {
-                return { ...state, loaded: false };
-            }
-
-            state.rows = systemsToInventoryEntities(systems(), state.rows, showAllSystems, profileId);
-
-            if (!showAllSystems) {
-                state.count = state.rows.length;
-                state.total = state.rows.length;
-            }
-
-            state.columns = [];
-            for (const column of columns) {
-                state.columns.push(column);
-            }
-
-            return { ...state };
-        },
+        ['UPDATE_SYSTEMS']: (state, { systems, systemsCount }) => ({
+            ...state,
+            systems,
+            systemsCount
+        }),
+        ['UPDATE_ROWS']: (state) => ({
+            ...state,
+            loaded: true,
+            rows: systemsToInventoryEntities(
+                state.systems || [],
+                state.rows || [],
+                showAllSystems,
+                profileId
+            )
+        }),
+        [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => ({
+            ...state,
+            rows: systemsToInventoryEntities(
+                state.systems || [],
+                state.rows,
+                showAllSystems,
+                profileId
+            ),
+            total: !showAllSystems ? state.systemsCount : state.total,
+            columns
+        }),
         [EXPORT_TO_CSV]: (state) => {
             downloadCsv(state);
             return state;


### PR DESCRIPTION
This puts systems into the inventory store, that is updated with fetching systems.
It is also ensured that systems are fetched and updated prior to `fetchInventory` and is called when filters or paginating changes.

To ensure the table is up to date even when items stay the same there is now an `UPDATE_ROWS` action that will get dispatched and recalculate the rows without triggering a inventory refresh.

It also removes debouncing certain calls, which could lead to states being out of sync. 

The primary objective is to fix the policy creation step to assign systems, but since the `SystemsTable` is used in other places here's a list where to click through:

**On each use of the SystemsTable test:**

  * Filter
    * by Name
      * [Known bug] Subsequent name filter, without clearing filters, won't work
    * by Compliance/Score
  * Paginate
    * and filter
    * change per Page
    * click on same per Page count
  * Edit Policies of a system (where enabled)
    * [Known (UX) Bug] Policies previously assigned will be deselected on selecting any policy
  * View in inventory

**Test on:**
  * SCAP Policies -> Create Policy -> Step 4: Systems
  * Reports -> By policy -> View Report
  * Reports -> By policy -> View policy -> Systems | SCAP Policies -> View Policy -> Systems
  * Reports -> By system
  * Systems
