### PR TITLE
RHICOMPL-561 - Set loading and error to undefined on data

### DIFF
--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -1,16 +1,19 @@
 import React from 'react';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+import {
+    Grid
+} from '@patternfly/react-core';
+import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/frontend-components';
+import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import {
     CompliancePoliciesEmptyState,
     ErrorPage,
     LoadingPoliciesTable,
     StateView,
-    StateViewPart
+    StateViewPart,
+    PoliciesTable
 } from 'PresentationalComponents';
-import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/frontend-components';
-import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
-import { useQuery } from '@apollo/react-hooks';
-import gql from 'graphql-tag';
-import PoliciesTable from '../PoliciesTable/PoliciesTable';
 
 const QUERY = gql`
 {
@@ -65,7 +68,7 @@ export const CompliancePolicies = () => {
             </PageHeader>
             <Main>
                 { policies && policies.length === 0 ?
-                    <CompliancePoliciesEmptyState /> :
+                    <Grid gutter='md'><CompliancePoliciesEmptyState /></Grid> :
                     <PoliciesTable onWizardFinish={() => refetch()} policies={ policies } />
                 }
             </Main>

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -11,9 +11,12 @@ import {
     ErrorPage,
     LoadingPoliciesTable,
     StateView,
-    StateViewPart,
-    PoliciesTable
+    StateViewPart
 } from 'PresentationalComponents';
+
+import {
+    PoliciesTable
+} from 'SmartComponents';
 
 const QUERY = gql`
 {

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -39,10 +39,11 @@ const QUERY = gql`
 `;
 
 export const CompliancePolicies = () => {
-    const { data, error, loading, refetch } = useQuery(QUERY, { fetchPolicy: 'cache-and-network' });
+    let { data, error, loading, refetch } = useQuery(QUERY, { fetchPolicy: 'cache-and-network' });
     let policies;
 
     if (data) {
+        error = undefined; loading = undefined;
         policies = data.profiles.edges.map(profile => profile.node);
     }
 

--- a/src/SmartComponents/CompliancePolicies/__snapshots__/CompliancePolicies.test.js.snap
+++ b/src/SmartComponents/CompliancePolicies/__snapshots__/CompliancePolicies.test.js.snap
@@ -255,7 +255,7 @@ exports[`CompliancePolicies expect to render a policies table 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <withRouter(Connect(RouterParams))
+      <Component
         onWizardFinish={[Function]}
         policies={
           Array [
@@ -473,7 +473,7 @@ exports[`CompliancePolicies expect to render an error 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <withRouter(Connect(RouterParams))
+      <Component
         onWizardFinish={[Function]}
       />
     </Connect(Main)>
@@ -525,9 +525,13 @@ exports[`CompliancePolicies expect to render emptystate 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <CompliancePoliciesEmptyState
-        title="No policies"
-      />
+      <Grid
+        gutter="md"
+      >
+        <CompliancePoliciesEmptyState
+          title="No policies"
+        />
+      </Grid>
     </Connect(Main)>
   </StateViewPart>
 </StateView>
@@ -573,7 +577,7 @@ exports[`CompliancePolicies expect to render loading 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <withRouter(Connect(RouterParams))
+      <Component
         onWizardFinish={[Function]}
       />
     </Connect(Main)>
@@ -636,7 +640,7 @@ exports[`CompliancePolicies expect to render without error 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <withRouter(Connect(RouterParams))
+      <Component
         onWizardFinish={[Function]}
         policies={
           Array [

--- a/src/SmartComponents/CompliancePolicies/__snapshots__/CompliancePolicies.test.js.snap
+++ b/src/SmartComponents/CompliancePolicies/__snapshots__/CompliancePolicies.test.js.snap
@@ -255,7 +255,7 @@ exports[`CompliancePolicies expect to render a policies table 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <Component
+      <withRouter(Connect(RouterParams))
         onWizardFinish={[Function]}
         policies={
           Array [
@@ -473,7 +473,7 @@ exports[`CompliancePolicies expect to render an error 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <Component
+      <withRouter(Connect(RouterParams))
         onWizardFinish={[Function]}
       />
     </Connect(Main)>
@@ -577,7 +577,7 @@ exports[`CompliancePolicies expect to render loading 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <Component
+      <withRouter(Connect(RouterParams))
         onWizardFinish={[Function]}
       />
     </Connect(Main)>
@@ -640,7 +640,7 @@ exports[`CompliancePolicies expect to render without error 1`] = `
       />
     </PageHeader>
     <Connect(Main)>
-      <Component
+      <withRouter(Connect(RouterParams))
         onWizardFinish={[Function]}
         policies={
           Array [

--- a/src/SmartComponents/index.js
+++ b/src/SmartComponents/index.js
@@ -4,3 +4,4 @@ export { default as ComplianceSystems } from './ComplianceSystems/ComplianceSyst
 export { default as AssignPoliciesModal } from './AssignPoliciesModal/AssignPoliciesModal';
 export { default } from './InventoryDetails/InventoryDetails';
 export { default as SystemsTable } from './SystemsTable/SystemsTable';
+export { default as PoliciesTable } from './PoliciesTable/PoliciesTable';


### PR DESCRIPTION
This fixes the "clunky" loading of SCAP Policies.

Before:

![Kapture 2020-05-01 at 13 16 36](https://user-images.githubusercontent.com/7757/80801943-2d5f1d80-8bae-11ea-9ebc-1e058679be67.gif)

After:

![Kapture 2020-05-01 at 13 19 47](https://user-images.githubusercontent.com/7757/80802082-8fb81e00-8bae-11ea-8c2c-97d73c23b42d.gif)

And also the empty state spacing to the top:

![Screenshot 2020-05-01 at 16 57 47](https://user-images.githubusercontent.com/7757/80814875-f77d6180-8bcc-11ea-8927-82cee32da259.png)
