### PR TITLE
RHICOMPL-647 - Disable sorting on systems table

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -17,13 +17,13 @@ const EditPolicySystems = ({ change, selectedSystemIds }) => {
         key: 'facts.compliance.display_name',
         title: 'System name',
         props: {
-            width: 40
+            width: 40, isStatic: true
         }
     }, {
         key: 'facts.compliance.profiles',
         title: 'Policies',
         props: {
-            width: 40
+            width: 40, isStatic: true
         }
     }];
 

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -9,7 +9,7 @@ const PolicySystemsTab = ({ policy, complianceThreshold }) => (
             key: 'facts.compliance.display_name',
             title: 'System name',
             props: {
-                width: 40
+                width: 40, isStatic: true
             }
         }]}
         complianceThreshold={ complianceThreshold }


### PR DESCRIPTION
These sorting buttons are not expected to work without x-join integration, if anyone clicks on them it breaks the table, so I'm disabling them for now. 