### PR TITLE
RHICOMPL-618 - Get 'external' attr on SystemsTable GQL

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -40,6 +40,7 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
                     refId
                     lastScanned
                     compliant
+                    external
                     score
                     rules {
                         refId
@@ -66,6 +67,7 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
                     id
                     name
                     lastScanned
+                    external
                     compliant
                     score
                 }


### PR DESCRIPTION
Before, we were not getting the attribute from GQL at all, therefore the "(External)" note in the Policies column could not show. It looks like this now:

![Screenshot from 2020-05-07 10-35-48](https://user-images.githubusercontent.com/598891/81273121-bd89e080-904e-11ea-93af-ac2e01eacfb7.png)
