### PR TITLE
RHICOMPL-604 - Add warning when no systems assigned

### DIFF
--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
@@ -6,8 +6,13 @@ import {
     TextList,
     TextListVariants,
     TextListItem,
-    TextListItemVariants
+    TextListItemVariants,
+    Tooltip,
+    TooltipPosition
 } from '@patternfly/react-core';
+import {
+    ExclamationTriangleIcon
+} from '@patternfly/react-icons';
 import { formValueSelector } from 'redux-form';
 import { connect } from 'react-redux';
 import gql from 'graphql-tag';
@@ -25,6 +30,21 @@ query review($benchmarkId: String!) {
     }
 }
 `;
+
+const SystemsCount = ({ count }) => (
+    count > 0 ? count : <Tooltip
+        position={TooltipPosition.bottom}
+        content="Policies without systems will not have reports.">
+        <ExclamationTriangleIcon className='ins-u-warning'/>
+        <Text component="span" className='ins-u-warning'>
+            &nbsp;No systems
+        </Text>
+    </Tooltip>
+);
+
+SystemsCount.propTypes = {
+    count: propTypes.number
+};
 
 const ReviewCreatedPolicy = ({ benchmarkId, name, refId, systemsCount, rulesCount, complianceThreshold, parentProfileName }) => {
     const { data, error, loading } = useQuery(REVIEW, { variables: { benchmarkId } });
@@ -63,7 +83,7 @@ const ReviewCreatedPolicy = ({ benchmarkId, name, refId, systemsCount, rulesCoun
                 <TextListItem component={TextListItemVariants.dt}>No. of rules</TextListItem>
                 <TextListItem component={TextListItemVariants.dd}>{ rulesCount }</TextListItem>
                 <TextListItem component={TextListItemVariants.dt}>No. of systems</TextListItem>
-                <TextListItem component={TextListItemVariants.dd}>{ systemsCount }</TextListItem>
+                <TextListItem component={TextListItemVariants.dd}><SystemsCount count={ systemsCount } /></TextListItem>
             </TextList>
         </TextContent>
     );

--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.test.js
@@ -1,7 +1,6 @@
 import ReviewCreatedPolicy from './ReviewCreatedPolicy.js';
 import configureStore from 'redux-mock-store';
 import { policyFormValues } from '@/__fixtures__/benchmarks_rules.js';
-import renderer from 'react-test-renderer';
 import { Provider } from 'react-redux';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -23,21 +22,21 @@ describe('ReviewCreatedPolicy', () => {
                 refId: 'xccdf_org.ssgproject.content_benchmark_RHEL-7',
                 version: '0.1.40'  }
         }, error: false, loading: false }));
-        component = renderer.create(
+        component = mount(
             <Provider store={store}>
                 <ReviewCreatedPolicy />
             </Provider>
         );
-        expect(component.toJSON()).toMatchSnapshot();
+        expect(toJson(component)).toMatchSnapshot();
     });
 
     it('should render a spinner while loading', () => {
         useQuery.mockImplementation(() => ({ data: {}, error: false, loading: true }));
-        component = renderer.create(
+        component = mount(
             <Provider store={store}>
                 <ReviewCreatedPolicy />
             </Provider>
         );
-        expect(component.toJSON()).toMatchSnapshot();
+        expect(toJson(component)).toMatchSnapshot();
     });
 });

--- a/src/SmartComponents/CreatePolicy/__snapshots__/ReviewCreatedPolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/ReviewCreatedPolicy.test.js.snap
@@ -1,135 +1,433 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReviewCreatedPolicy expect to render without error 1`] = `
-<div
-  className="pf-c-content"
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
 >
-  <h1
-    className=""
-    data-pf-content={true}
-  >
-    Review
-  </h1>
-  <h4
-    className=""
-    data-pf-content={true}
-  >
-    Review your policy before finishing.
-  </h4>
-  <dl
-    className=""
-    data-pf-content={true}
-  >
-    <dt
-      className=""
-      data-pf-content={true}
+  <Connect(ReviewCreatedPolicy)>
+    <ReviewCreatedPolicy
+      benchmarkId="a5e7f1ea-e63c-40be-a17a-c2a247c11e10"
+      complianceThreshold={100}
+      dispatch={[Function]}
+      name="C2S for Red Hat Enterprise Linux 6"
+      parentProfileName="C2S for Red Hat Enterprise Linux 6"
+      refId="xccdf_org.ssgproject.content_profile_C2S"
+      rulesCount={1}
+      systemsCount={0}
     >
-      Operating system
-    </dt>
-    <dd
-      className=""
-      data-pf-content={true}
-    >
-      RHEL 7
-    </dd>
-    <dt
-      className=""
-      data-pf-content={true}
-    >
-      Security guide
-    </dt>
-    <dd
-      className=""
-      data-pf-content={true}
-    >
-       SCAP security guide for RHEL7 - 0.1.40
-    </dd>
-    <dt
-      className=""
-      data-pf-content={true}
-    >
-      Policy type
-    </dt>
-    <dd
-      className=""
-      data-pf-content={true}
-    >
-      C2S for Red Hat Enterprise Linux 6
-    </dd>
-    <dt
-      className=""
-      data-pf-content={true}
-    >
-      Policy name
-    </dt>
-    <dd
-      className=""
-      data-pf-content={true}
-    >
-      C2S for Red Hat Enterprise Linux 6
-    </dd>
-    <dt
-      className=""
-      data-pf-content={true}
-    >
-      Reference ID
-    </dt>
-    <dd
-      className=""
-      data-pf-content={true}
-    >
-      xccdf_org.ssgproject.content_profile_C2S
-    </dd>
-    <dt
-      className=""
-      data-pf-content={true}
-    >
-      Compliance threshold
-    </dt>
-    <dd
-      className=""
-      data-pf-content={true}
-    >
-      100
-      %
-    </dd>
-    <dt
-      className=""
-      data-pf-content={true}
-    >
-      No. of rules
-    </dt>
-    <dd
-      className=""
-      data-pf-content={true}
-    >
-      1
-    </dd>
-    <dt
-      className=""
-      data-pf-content={true}
-    >
-      No. of systems
-    </dt>
-    <dd
-      className=""
-      data-pf-content={true}
-    >
-      0
-    </dd>
-  </dl>
-</div>
+      <TextContent>
+        <div
+          className="pf-c-content"
+        >
+          <Text
+            component="h1"
+          >
+            <h1
+              className=""
+              data-pf-content={true}
+            >
+              Review
+            </h1>
+          </Text>
+          <Text
+            component="h4"
+          >
+            <h4
+              className=""
+              data-pf-content={true}
+            >
+              Review your policy before finishing.
+            </h4>
+          </Text>
+          <TextList
+            component="dl"
+          >
+            <dl
+              className=""
+              data-pf-content={true}
+            >
+              <TextListItem
+                component="dt"
+              >
+                <dt
+                  className=""
+                  data-pf-content={true}
+                >
+                  Operating system
+                </dt>
+              </TextListItem>
+              <TextListItem
+                component="dd"
+              >
+                <dd
+                  className=""
+                  data-pf-content={true}
+                >
+                  RHEL 7
+                </dd>
+              </TextListItem>
+              <TextListItem
+                component="dt"
+              >
+                <dt
+                  className=""
+                  data-pf-content={true}
+                >
+                  Security guide
+                </dt>
+              </TextListItem>
+              <TextListItem
+                component="dd"
+              >
+                <dd
+                  className=""
+                  data-pf-content={true}
+                >
+                   SCAP security guide for RHEL7 - 0.1.40
+                </dd>
+              </TextListItem>
+              <TextListItem
+                component="dt"
+              >
+                <dt
+                  className=""
+                  data-pf-content={true}
+                >
+                  Policy type
+                </dt>
+              </TextListItem>
+              <TextListItem
+                component="dd"
+              >
+                <dd
+                  className=""
+                  data-pf-content={true}
+                >
+                  C2S for Red Hat Enterprise Linux 6
+                </dd>
+              </TextListItem>
+              <TextListItem
+                component="dt"
+              >
+                <dt
+                  className=""
+                  data-pf-content={true}
+                >
+                  Policy name
+                </dt>
+              </TextListItem>
+              <TextListItem
+                component="dd"
+              >
+                <dd
+                  className=""
+                  data-pf-content={true}
+                >
+                  C2S for Red Hat Enterprise Linux 6
+                </dd>
+              </TextListItem>
+              <TextListItem
+                component="dt"
+              >
+                <dt
+                  className=""
+                  data-pf-content={true}
+                >
+                  Reference ID
+                </dt>
+              </TextListItem>
+              <TextListItem
+                component="dd"
+              >
+                <dd
+                  className=""
+                  data-pf-content={true}
+                >
+                  xccdf_org.ssgproject.content_profile_C2S
+                </dd>
+              </TextListItem>
+              <TextListItem
+                component="dt"
+              >
+                <dt
+                  className=""
+                  data-pf-content={true}
+                >
+                  Compliance threshold
+                </dt>
+              </TextListItem>
+              <TextListItem
+                component="dd"
+              >
+                <dd
+                  className=""
+                  data-pf-content={true}
+                >
+                  100
+                  %
+                </dd>
+              </TextListItem>
+              <TextListItem
+                component="dt"
+              >
+                <dt
+                  className=""
+                  data-pf-content={true}
+                >
+                  No. of rules
+                </dt>
+              </TextListItem>
+              <TextListItem
+                component="dd"
+              >
+                <dd
+                  className=""
+                  data-pf-content={true}
+                >
+                  1
+                </dd>
+              </TextListItem>
+              <TextListItem
+                component="dt"
+              >
+                <dt
+                  className=""
+                  data-pf-content={true}
+                >
+                  No. of systems
+                </dt>
+              </TextListItem>
+              <TextListItem
+                component="dd"
+              >
+                <dd
+                  className=""
+                  data-pf-content={true}
+                >
+                  <SystemsCount
+                    count={0}
+                  >
+                    <Tooltip
+                      appendTo={[Function]}
+                      aria="describedby"
+                      boundary="window"
+                      className=""
+                      content="Policies without systems will not have reports."
+                      distance={15}
+                      enableFlip={true}
+                      entryDelay={500}
+                      exitDelay={500}
+                      flipBehavior={
+                        Array [
+                          "top",
+                          "right",
+                          "bottom",
+                          "left",
+                          "top",
+                          "right",
+                          "bottom",
+                        ]
+                      }
+                      id=""
+                      isAppLauncher={false}
+                      isContentLeftAligned={false}
+                      isVisible={false}
+                      maxWidth="18.75rem"
+                      position="bottom"
+                      tippyProps={Object {}}
+                      trigger="mouseenter focus"
+                      zIndex={9999}
+                    >
+                      <PopoverBase
+                        appendTo={[Function]}
+                        aria="describedby"
+                        arrow={true}
+                        boundary="window"
+                        content={
+                          <div
+                            className=""
+                            id=""
+                            role="tooltip"
+                          >
+                            <TooltipContent
+                              isLeftAligned={false}
+                            >
+                              Policies without systems will not have reports.
+                            </TooltipContent>
+                          </div>
+                        }
+                        delay={
+                          Array [
+                            500,
+                            500,
+                          ]
+                        }
+                        distance={15}
+                        flip={true}
+                        flipBehavior={
+                          Array [
+                            "top",
+                            "right",
+                            "bottom",
+                            "left",
+                            "top",
+                            "right",
+                            "bottom",
+                          ]
+                        }
+                        isVisible={false}
+                        lazy={true}
+                        maxWidth="18.75rem"
+                        onCreate={[Function]}
+                        placement="bottom"
+                        popperOptions={
+                          Object {
+                            "modifiers": Object {
+                              "hide": Object {
+                                "enabled": true,
+                              },
+                              "preventOverflow": Object {
+                                "enabled": true,
+                              },
+                            },
+                          }
+                        }
+                        theme="pf-tooltip"
+                        trigger="mouseenter focus"
+                        zIndex={9999}
+                      >
+                        <ExclamationTriangleIcon
+                          className="ins-u-warning"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                          title={null}
+                        >
+                          <svg
+                            aria-hidden={true}
+                            aria-labelledby={null}
+                            className="ins-u-warning"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 576 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                              transform=""
+                            />
+                          </svg>
+                        </ExclamationTriangleIcon>
+                        <Text
+                          className="ins-u-warning"
+                          component="span"
+                        >
+                          <span
+                            className="ins-u-warning"
+                            data-pf-content={true}
+                          >
+                             No systems
+                          </span>
+                        </Text>
+                        <Portal
+                          containerInfo={
+                            <div>
+                              <div
+                                class=""
+                                id=""
+                                role="tooltip"
+                              >
+                                <div
+                                  class="pf-c-tooltip__content"
+                                >
+                                  Policies without systems will not have reports.
+                                </div>
+                              </div>
+                            </div>
+                          }
+                        >
+                          <div
+                            className=""
+                            id=""
+                            role="tooltip"
+                          >
+                            <TooltipContent
+                              isLeftAligned={false}
+                            >
+                              <div
+                                className="pf-c-tooltip__content"
+                              >
+                                Policies without systems will not have reports.
+                              </div>
+                            </TooltipContent>
+                          </div>
+                        </Portal>
+                      </PopoverBase>
+                    </Tooltip>
+                  </SystemsCount>
+                </dd>
+              </TextListItem>
+            </dl>
+          </TextList>
+        </div>
+      </TextContent>
+    </ReviewCreatedPolicy>
+  </Connect(ReviewCreatedPolicy)>
+</Provider>
 `;
 
 exports[`ReviewCreatedPolicy should render a spinner while loading 1`] = `
-<div
-  className="ins-c-spinner"
-  role="status"
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
 >
-  <span
-    className="pf-u-screen-reader"
-  >
-    Loading...
-  </span>
-</div>
+  <Connect(ReviewCreatedPolicy)>
+    <ReviewCreatedPolicy
+      benchmarkId="a5e7f1ea-e63c-40be-a17a-c2a247c11e10"
+      complianceThreshold={100}
+      dispatch={[Function]}
+      name="C2S for Red Hat Enterprise Linux 6"
+      parentProfileName="C2S for Red Hat Enterprise Linux 6"
+      refId="xccdf_org.ssgproject.content_profile_C2S"
+      rulesCount={1}
+      systemsCount={0}
+    >
+      <Spinner>
+        <div
+          className="ins-c-spinner"
+          role="status"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Loading...
+          </span>
+        </div>
+      </Spinner>
+    </ReviewCreatedPolicy>
+  </Connect(ReviewCreatedPolicy)>
+</Provider>
 `;


### PR DESCRIPTION
This adds a warning to the policy creation wizard when no systems are assigned:

![Screenshot 2020-05-13 at 13 51 27](https://user-images.githubusercontent.com/7757/81808978-def03e00-9520-11ea-8b5c-8f0c84ec6660.png)

@katierik Could you confirm the text colour? In the mocks it is darker, but I'm unable to find a matching colour. 