### PR TITLE
Only try to clear selected when there are some

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -100,7 +100,10 @@ class SystemsTable extends React.Component {
     }
 
     componentDidMount = () => {
-        this.props.clearAll();
+        if (this.props.selectedEntities && this.props.selectedEntities.length > 0) {
+            this.props.clearAll();
+        }
+
         this.updateSystems().then(() => this.fetchInventory());
     }
 


### PR DESCRIPTION
Trying to clear selected entities when there are none will prevent
the table from loading properly.