### PR TITLE
RHICOMPL-604 - Add more warnings when no systems assigned

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -57,3 +57,7 @@ button.pf-c-button.pf-m-tertiary {
     --pf-c-button--BorderWidth: 2px;
   }
 }
+
+.ins-c-warning-text {
+    color: var(--pf-global--warning-color--200);
+}

--- a/src/PresentationalComponents/SystemsCountWarning/SystemsCountWarning.js
+++ b/src/PresentationalComponents/SystemsCountWarning/SystemsCountWarning.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import {
+    Tooltip,
+    TooltipPosition
+} from '@patternfly/react-core';
+import {
+    WarningText
+} from 'PresentationalComponents';
+
+const WARNING_TEXT = 'Policies without systems will not have reports.';
+
+const WithOptionalToolTip = ({ showTooltip, children }) => (
+    showTooltip ? <Tooltip
+        position={ TooltipPosition.bottom }
+        content={ WARNING_TEXT }>
+        { children }
+    </Tooltip> : children
+);
+
+WithOptionalToolTip.propTypes = {
+    showTooltip: propTypes.bool,
+    children: propTypes.node
+};
+
+const SystemsCountWarning = ({ count, variant }) => {
+    let text;
+
+    switch (variant) {
+        case 'count':
+            text = count;
+            break;
+        case 'compact':
+            text = 'No Systems';
+            break;
+        case 'full':
+            text = WARNING_TEXT;
+            break;
+        default:
+            text = count;
+    }
+
+    return <WithOptionalToolTip showTooltip={ variant === 'count' || variant === 'compact' }>
+        <WarningText>
+            { text }
+        </WarningText>
+    </WithOptionalToolTip>;
+};
+
+SystemsCountWarning.defaultProps = {
+    variant: 'compact'
+};
+
+SystemsCountWarning.propTypes = {
+    count: propTypes.number.isRequired,
+    variant: propTypes.string
+};
+
+export { WARNING_TEXT };
+export default SystemsCountWarning;

--- a/src/PresentationalComponents/SystemsCountWarning/SystemsCountWarning.test.js
+++ b/src/PresentationalComponents/SystemsCountWarning/SystemsCountWarning.test.js
@@ -1,0 +1,35 @@
+import SystemsCountWarning from './SystemsCountWarning';
+
+describe('SystemsCountWarning', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <SystemsCountWarning count={ 0 } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render compact without error', () => {
+        const wrapper = shallow(
+            <SystemsCountWarning count={ 10 } variant='compact' />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render count without error', () => {
+        const wrapper = shallow(
+            <SystemsCountWarning count={ 0 } variant='count' />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render full without error', () => {
+        const wrapper = shallow(
+            <SystemsCountWarning count={ 0 } variant='full' />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/SystemsCountWarning/__snapshots__/SystemsCountWarning.test.js.snap
+++ b/src/PresentationalComponents/SystemsCountWarning/__snapshots__/SystemsCountWarning.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SystemsCountWarning expect to render compact without error 1`] = `
+<WithOptionalToolTip
+  showTooltip={true}
+>
+  <WarningText>
+    No Systems
+  </WarningText>
+</WithOptionalToolTip>
+`;
+
+exports[`SystemsCountWarning expect to render count without error 1`] = `
+<WithOptionalToolTip
+  showTooltip={true}
+>
+  <WarningText>
+    0
+  </WarningText>
+</WithOptionalToolTip>
+`;
+
+exports[`SystemsCountWarning expect to render full without error 1`] = `
+<WithOptionalToolTip
+  showTooltip={false}
+>
+  <WarningText>
+    Policies without systems will not have reports.
+  </WarningText>
+</WithOptionalToolTip>
+`;
+
+exports[`SystemsCountWarning expect to render without error 1`] = `
+<WithOptionalToolTip
+  showTooltip={true}
+>
+  <WarningText>
+    No Systems
+  </WarningText>
+</WithOptionalToolTip>
+`;

--- a/src/PresentationalComponents/WarningText/WarningText.js
+++ b/src/PresentationalComponents/WarningText/WarningText.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import {
+    Text
+} from '@patternfly/react-core';
+import {
+    ExclamationTriangleIcon
+} from '@patternfly/react-icons';
+
+const WarningText = ({ children }) => (
+    <React.Fragment>
+        <ExclamationTriangleIcon className='ins-u-warning'/>
+        <Text component="span" className='ins-c-warning-text'>
+            &nbsp;{ children }
+        </Text>
+    </React.Fragment>
+);
+
+WarningText.propTypes = {
+    children: propTypes.node
+};
+
+export default WarningText;

--- a/src/PresentationalComponents/WarningText/WarningText.test.js
+++ b/src/PresentationalComponents/WarningText/WarningText.test.js
@@ -1,0 +1,13 @@
+import WarningText from './WarningText';
+
+describe('WarningText', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <WarningText>
+                Test Warning Text
+            </WarningText>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/WarningText/__snapshots__/WarningText.test.js.snap
+++ b/src/PresentationalComponents/WarningText/__snapshots__/WarningText.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WarningText expect to render without error 1`] = `
+<Fragment>
+  <ExclamationTriangleIcon
+    className="ins-u-warning"
+    color="currentColor"
+    noVerticalAlign={false}
+    size="sm"
+    title={null}
+  />
+  <Text
+    className="ins-c-warning-text"
+    component="span"
+  >
+     
+    Test Warning Text
+  </Text>
+</Fragment>
+`;

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -14,3 +14,5 @@ export { default as PolicyTabs } from './PolicyTabs/PolicyTabs';
 export { default as ProgressBar } from './ProgressBar/ProgressBar';
 export { default as TabSwitcher, Tab } from './TabSwitcher/TabSwitcher';
 export { StateView, StateViewWithError, StateViewPart } from './StateView/StateView';
+export { default as SystemsCountWarning, WARNING_TEXT } from './SystemsCountWarning/SystemsCountWarning';
+export { default as WarningText } from './WarningText/WarningText';

--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
@@ -6,19 +6,17 @@ import {
     TextList,
     TextListVariants,
     TextListItem,
-    TextListItemVariants,
-    Tooltip,
-    TooltipPosition
+    TextListItemVariants
 } from '@patternfly/react-core';
-import {
-    ExclamationTriangleIcon
-} from '@patternfly/react-icons';
 import { formValueSelector } from 'redux-form';
 import { connect } from 'react-redux';
 import gql from 'graphql-tag';
 import propTypes from 'prop-types';
 import { Spinner } from '@redhat-cloud-services/frontend-components';
 import { useQuery } from '@apollo/react-hooks';
+import {
+    SystemsCountWarning
+} from 'PresentationalComponents';
 
 const REVIEW = gql`
 query review($benchmarkId: String!) {
@@ -30,21 +28,6 @@ query review($benchmarkId: String!) {
     }
 }
 `;
-
-const SystemsCount = ({ count }) => (
-    count > 0 ? count : <Tooltip
-        position={TooltipPosition.bottom}
-        content="Policies without systems will not have reports.">
-        <ExclamationTriangleIcon className='ins-u-warning'/>
-        <Text component="span" className='ins-u-warning'>
-            &nbsp;No systems
-        </Text>
-    </Tooltip>
-);
-
-SystemsCount.propTypes = {
-    count: propTypes.number
-};
 
 const ReviewCreatedPolicy = ({ benchmarkId, name, refId, systemsCount, rulesCount, complianceThreshold, parentProfileName }) => {
     const { data, error, loading } = useQuery(REVIEW, { variables: { benchmarkId } });
@@ -83,7 +66,9 @@ const ReviewCreatedPolicy = ({ benchmarkId, name, refId, systemsCount, rulesCoun
                 <TextListItem component={TextListItemVariants.dt}>No. of rules</TextListItem>
                 <TextListItem component={TextListItemVariants.dd}>{ rulesCount }</TextListItem>
                 <TextListItem component={TextListItemVariants.dt}>No. of systems</TextListItem>
-                <TextListItem component={TextListItemVariants.dd}><SystemsCount count={ systemsCount } /></TextListItem>
+                <TextListItem component={TextListItemVariants.dd}>
+                    <SystemsCountWarning variant="compact" count={ systemsCount } />
+                </TextListItem>
             </TextList>
         </TextContent>
     );

--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
@@ -67,7 +67,7 @@ const ReviewCreatedPolicy = ({ benchmarkId, name, refId, systemsCount, rulesCoun
                 <TextListItem component={TextListItemVariants.dd}>{ rulesCount }</TextListItem>
                 <TextListItem component={TextListItemVariants.dt}>No. of systems</TextListItem>
                 <TextListItem component={TextListItemVariants.dd}>
-                    <SystemsCountWarning variant="compact" count={ systemsCount } />
+                    { systemsCount > 0 ? systemsCount : <SystemsCountWarning variant="compact" count={ systemsCount } /> }
                 </TextListItem>
             </TextList>
         </TextContent>

--- a/src/SmartComponents/CreatePolicy/__snapshots__/ReviewCreatedPolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/ReviewCreatedPolicy.test.js.snap
@@ -213,66 +213,23 @@ exports[`ReviewCreatedPolicy expect to render without error 1`] = `
                   className=""
                   data-pf-content={true}
                 >
-                  <SystemsCount
+                  <SystemsCountWarning
                     count={0}
+                    variant="compact"
                   >
-                    <Tooltip
-                      appendTo={[Function]}
-                      aria="describedby"
-                      boundary="window"
-                      className=""
-                      content="Policies without systems will not have reports."
-                      distance={15}
-                      enableFlip={true}
-                      entryDelay={500}
-                      exitDelay={500}
-                      flipBehavior={
-                        Array [
-                          "top",
-                          "right",
-                          "bottom",
-                          "left",
-                          "top",
-                          "right",
-                          "bottom",
-                        ]
-                      }
-                      id=""
-                      isAppLauncher={false}
-                      isContentLeftAligned={false}
-                      isVisible={false}
-                      maxWidth="18.75rem"
-                      position="bottom"
-                      tippyProps={Object {}}
-                      trigger="mouseenter focus"
-                      zIndex={9999}
+                    <WithOptionalToolTip
+                      showTooltip={true}
                     >
-                      <PopoverBase
+                      <Tooltip
                         appendTo={[Function]}
                         aria="describedby"
-                        arrow={true}
                         boundary="window"
-                        content={
-                          <div
-                            className=""
-                            id=""
-                            role="tooltip"
-                          >
-                            <TooltipContent
-                              isLeftAligned={false}
-                            >
-                              Policies without systems will not have reports.
-                            </TooltipContent>
-                          </div>
-                        }
-                        delay={
-                          Array [
-                            500,
-                            500,
-                          ]
-                        }
+                        className=""
+                        content="Policies without systems will not have reports."
                         distance={15}
-                        flip={true}
+                        enableFlip={true}
+                        entryDelay={500}
+                        exitDelay={500}
                         flipBehavior={
                           Array [
                             "top",
@@ -284,102 +241,153 @@ exports[`ReviewCreatedPolicy expect to render without error 1`] = `
                             "bottom",
                           ]
                         }
+                        id=""
+                        isAppLauncher={false}
+                        isContentLeftAligned={false}
                         isVisible={false}
-                        lazy={true}
                         maxWidth="18.75rem"
-                        onCreate={[Function]}
-                        placement="bottom"
-                        popperOptions={
-                          Object {
-                            "modifiers": Object {
-                              "hide": Object {
-                                "enabled": true,
-                              },
-                              "preventOverflow": Object {
-                                "enabled": true,
-                              },
-                            },
-                          }
-                        }
-                        theme="pf-tooltip"
+                        position="bottom"
+                        tippyProps={Object {}}
                         trigger="mouseenter focus"
                         zIndex={9999}
                       >
-                        <ExclamationTriangleIcon
-                          className="ins-u-warning"
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                          title={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            aria-labelledby={null}
-                            className="ins-u-warning"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style={
-                              Object {
-                                "verticalAlign": "-0.125em",
-                              }
+                        <PopoverBase
+                          appendTo={[Function]}
+                          aria="describedby"
+                          arrow={true}
+                          boundary="window"
+                          content={
+                            <div
+                              className=""
+                              id=""
+                              role="tooltip"
+                            >
+                              <TooltipContent
+                                isLeftAligned={false}
+                              >
+                                Policies without systems will not have reports.
+                              </TooltipContent>
+                            </div>
+                          }
+                          delay={
+                            Array [
+                              500,
+                              500,
+                            ]
+                          }
+                          distance={15}
+                          flip={true}
+                          flipBehavior={
+                            Array [
+                              "top",
+                              "right",
+                              "bottom",
+                              "left",
+                              "top",
+                              "right",
+                              "bottom",
+                            ]
+                          }
+                          isVisible={false}
+                          lazy={true}
+                          maxWidth="18.75rem"
+                          onCreate={[Function]}
+                          placement="bottom"
+                          popperOptions={
+                            Object {
+                              "modifiers": Object {
+                                "hide": Object {
+                                  "enabled": true,
+                                },
+                                "preventOverflow": Object {
+                                  "enabled": true,
+                                },
+                              },
                             }
-                            viewBox="0 0 576 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                              transform=""
-                            />
-                          </svg>
-                        </ExclamationTriangleIcon>
-                        <Text
-                          className="ins-u-warning"
-                          component="span"
+                          }
+                          theme="pf-tooltip"
+                          trigger="mouseenter focus"
+                          zIndex={9999}
                         >
-                          <span
-                            className="ins-u-warning"
-                            data-pf-content={true}
+                          <WarningText>
+                            <ExclamationTriangleIcon
+                              className="ins-u-warning"
+                              color="currentColor"
+                              noVerticalAlign={false}
+                              size="sm"
+                              title={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-labelledby={null}
+                                className="ins-u-warning"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.125em",
+                                  }
+                                }
+                                viewBox="0 0 576 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                  transform=""
+                                />
+                              </svg>
+                            </ExclamationTriangleIcon>
+                            <Text
+                              className="ins-c-warning-text"
+                              component="span"
+                            >
+                              <span
+                                className="ins-c-warning-text"
+                                data-pf-content={true}
+                              >
+                                 
+                                No Systems
+                              </span>
+                            </Text>
+                          </WarningText>
+                          <Portal
+                            containerInfo={
+                              <div>
+                                <div
+                                  class=""
+                                  id=""
+                                  role="tooltip"
+                                >
+                                  <div
+                                    class="pf-c-tooltip__content"
+                                  >
+                                    Policies without systems will not have reports.
+                                  </div>
+                                </div>
+                              </div>
+                            }
                           >
-                             No systems
-                          </span>
-                        </Text>
-                        <Portal
-                          containerInfo={
-                            <div>
-                              <div
-                                class=""
-                                id=""
-                                role="tooltip"
+                            <div
+                              className=""
+                              id=""
+                              role="tooltip"
+                            >
+                              <TooltipContent
+                                isLeftAligned={false}
                               >
                                 <div
-                                  class="pf-c-tooltip__content"
+                                  className="pf-c-tooltip__content"
                                 >
                                   Policies without systems will not have reports.
                                 </div>
-                              </div>
+                              </TooltipContent>
                             </div>
-                          }
-                        >
-                          <div
-                            className=""
-                            id=""
-                            role="tooltip"
-                          >
-                            <TooltipContent
-                              isLeftAligned={false}
-                            >
-                              <div
-                                className="pf-c-tooltip__content"
-                              >
-                                Policies without systems will not have reports.
-                              </div>
-                            </TooltipContent>
-                          </div>
-                        </Portal>
-                      </PopoverBase>
-                    </Tooltip>
-                  </SystemsCount>
+                          </Portal>
+                        </PopoverBase>
+                      </Tooltip>
+                    </WithOptionalToolTip>
+                  </SystemsCountWarning>
                 </dd>
               </TextListItem>
             </dl>

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -56,7 +56,7 @@ const policiesToRows = (policies) => (
                         </span>
                     </Tooltip>
                 },
-                { title: <SystemsCountWarning count={ policy.totalHostCount } variant='count' /> },
+                { title: policy.totalHostCount > 0 ? policy.totalHostCount : <SystemsCountWarning count={ policy.totalHostCount } variant='count' /> },
                 policy.businessObjective && policy.businessObjective.title || '--',
                 `${policy.complianceThreshold}%`
             ]

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -11,6 +11,9 @@ import { FilterConfigBuilder } from '@redhat-cloud-services/frontend-components-
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
 
+import {
+    SystemsCountWarning
+} from 'PresentationalComponents';
 import { CreatePolicy, DeletePolicy } from 'SmartComponents';
 
 const emptyRows = [{
@@ -53,7 +56,7 @@ const policiesToRows = (policies) => (
                         </span>
                     </Tooltip>
                 },
-                policy.totalHostCount,
+                { title: <SystemsCountWarning count={ policy.totalHostCount } variant='count' /> },
                 policy.businessObjective && policy.businessObjective.title || '--',
                 `${policy.complianceThreshold}%`
             ]

--- a/src/SmartComponents/PoliciesTable/PoliciesTable.js
+++ b/src/SmartComponents/PoliciesTable/PoliciesTable.js
@@ -56,7 +56,8 @@ const policiesToRows = (policies) => (
                         </span>
                     </Tooltip>
                 },
-                { title: policy.totalHostCount > 0 ? policy.totalHostCount : <SystemsCountWarning count={ policy.totalHostCount } variant='count' /> },
+                { title: policy.totalHostCount > 0 ? policy.totalHostCount :
+                    <SystemsCountWarning count={ policy.totalHostCount } variant='count' /> },
                 policy.businessObjective && policy.businessObjective.title || '--',
                 `${policy.complianceThreshold}%`
             ]

--- a/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -129,10 +129,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -198,10 +195,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -267,10 +261,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -434,10 +425,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -503,10 +491,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "67%",
@@ -572,10 +557,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -641,10 +623,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "69.5%",
@@ -710,10 +689,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -779,10 +755,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -848,10 +821,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -917,10 +887,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -986,10 +953,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -1055,10 +1019,7 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -1231,10 +1192,7 @@ exports[`PoliciesTable Pagination and search should show only matching results a
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -1524,10 +1482,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -1593,10 +1548,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "67%",
@@ -1662,10 +1614,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -1731,10 +1680,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "69.5%",
@@ -1800,10 +1746,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -1869,10 +1812,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -1938,10 +1878,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2007,10 +1944,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2076,10 +2010,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2145,10 +2076,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2335,10 +2263,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2404,10 +2329,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "67%",
@@ -2473,10 +2395,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2542,10 +2461,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "69.5%",
@@ -2611,10 +2527,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2680,10 +2593,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2749,10 +2659,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2818,10 +2725,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2887,10 +2791,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",
@@ -2956,10 +2857,7 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
               </Tooltip>,
             },
             Object {
-              "title": <SystemsCountWarning
-                count={10}
-                variant="count"
-              />,
+              "title": 10,
             },
             "--",
             "100%",

--- a/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/SmartComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -128,7 +128,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -192,7 +197,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -256,7 +266,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -418,7 +433,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -482,7 +502,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "67%",
           ],
@@ -546,7 +571,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -610,7 +640,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "69.5%",
           ],
@@ -674,7 +709,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -738,7 +778,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -802,7 +847,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -866,7 +916,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -930,7 +985,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -994,7 +1054,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -1165,7 +1230,12 @@ exports[`PoliciesTable Pagination and search should show only matching results a
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -1453,7 +1523,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -1517,7 +1592,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "67%",
           ],
@@ -1581,7 +1661,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -1645,7 +1730,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "69.5%",
           ],
@@ -1709,7 +1799,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -1773,7 +1868,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -1837,7 +1937,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -1901,7 +2006,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -1965,7 +2075,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2029,7 +2144,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2214,7 +2334,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2278,7 +2403,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "67%",
           ],
@@ -2342,7 +2472,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2406,7 +2541,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "69.5%",
           ],
@@ -2470,7 +2610,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2534,7 +2679,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2598,7 +2748,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2662,7 +2817,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2726,7 +2886,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],
@@ -2790,7 +2955,12 @@ exports[`PoliciesTable setAndDeletePolicy should set the policy in state and ope
                 </span>
               </Tooltip>,
             },
-            10,
+            Object {
+              "title": <SystemsCountWarning
+                count={10}
+                variant="count"
+              />,
+            },
             "--",
             "100%",
           ],

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -17,6 +17,10 @@ import registry from '@redhat-cloud-services/frontend-components-utilities/files
 import  {
     AssignPoliciesModal
 } from 'SmartComponents';
+import {
+    WARNING_TEXT
+} from 'PresentationalComponents';
+
 import { exportFromState, selectAll, clearSelection, SELECT_ENTITY } from 'Store/ActionTypes';
 import { systemsWithRuleObjectsFailed } from 'Utilities/ruleHelpers';
 import { FilterConfigBuilder } from '@redhat-cloud-services/frontend-components-inventory-compliance';
@@ -317,30 +321,37 @@ class SystemsTable extends React.Component {
             inventoryTableProps.variant = pfReactTable.TableVariant.compact;
         }
 
-        return <InventoryCmp { ...inventoryTableProps }>
-            { !showAllSystems && <reactCore.ToolbarGroup>
-                { remediationsEnabled &&
-                    <reactCore.ToolbarItem style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}>
-                        <ComplianceRemediationButton
-                            allSystems={ systemsWithRuleObjectsFailed(
-                                systems.filter(edge => selectedEntities.includes(edge.node.id)
-                                ).map(edge => edge.node))}
-                            selectedRules={ [] } />
-                    </reactCore.ToolbarItem>
-                }
-            </reactCore.ToolbarGroup> }
-            { selectedSystemId &&
-            <AssignPoliciesModal
-                isModalOpen={isAssignPoliciesModalOpen}
-                id={selectedSystemId}
-                fqdn={selectedSystemFqdn}
-                toggle={(closedOrCanceled) => {
-                    this.setState((prev) => (
-                        { isAssignPoliciesModalOpen: !prev.isAssignPoliciesModalOpen }
-                    ), !closedOrCanceled ? this.updateSystems : null);
-                }}
-            /> }
-        </InventoryCmp>;
+        return <React.Fragment>
+            { !showAllSystems && total === 0 &&
+                <reactCore.Alert variant="warning" isInline title={ WARNING_TEXT }>
+                    Add systems to this policy via the &quot;Edit Policy&quot; action, or by adding them from the systems page.
+                </reactCore.Alert>
+            }
+            <InventoryCmp { ...inventoryTableProps }>
+                { !showAllSystems && <reactCore.ToolbarGroup>
+                    { remediationsEnabled &&
+                        <reactCore.ToolbarItem style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}>
+                            <ComplianceRemediationButton
+                                allSystems={ systemsWithRuleObjectsFailed(
+                                    systems.filter(edge => selectedEntities.includes(edge.node.id)
+                                    ).map(edge => edge.node))}
+                                selectedRules={ [] } />
+                        </reactCore.ToolbarItem>
+                    }
+                </reactCore.ToolbarGroup> }
+                { selectedSystemId &&
+                <AssignPoliciesModal
+                    isModalOpen={isAssignPoliciesModalOpen}
+                    id={selectedSystemId}
+                    fqdn={selectedSystemFqdn}
+                    toggle={(closedOrCanceled) => {
+                        this.setState((prev) => (
+                            { isAssignPoliciesModalOpen: !prev.isAssignPoliciesModalOpen }
+                        ), !closedOrCanceled ? this.updateSystems : null);
+                    }}
+                /> }
+            </InventoryCmp>
+        </React.Fragment>;
     }
 }
 

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -323,9 +323,7 @@ class SystemsTable extends React.Component {
 
         return <React.Fragment>
             { !showAllSystems && total === 0 &&
-                <reactCore.Alert variant="warning" isInline title={ WARNING_TEXT }>
-                    Add systems to this policy via the &quot;Edit Policy&quot; action, or by adding them from the systems page.
-                </reactCore.Alert>
+                <reactCore.Alert variant="warning" isInline title={ WARNING_TEXT } />
             }
             <InventoryCmp { ...inventoryTableProps }>
                 { !showAllSystems && <reactCore.ToolbarGroup>

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -442,9 +442,7 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
     isInline={true}
     title="Policies without systems will not have reports."
     variant="warning"
-  >
-    Add systems to this policy via the "Edit Policy" action, or by adding them from the systems page.
-  </Component>
+  />
   <ForwardRef
     actions={
       Array [
@@ -540,9 +538,7 @@ exports[`SystemsTable expect to set isDisable on export config to true total is 
     isInline={true}
     title="Policies without systems will not have reports."
     variant="warning"
-  >
-    Add systems to this policy via the "Edit Policy" action, or by adding them from the systems page.
-  </Component>
+  />
   <ForwardRef
     actions={
       Array [

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -72,688 +72,718 @@ Object {
 `;
 
 exports[`SystemsTable expect to not render a loading state 1`] = `
-<ForwardRef
-  actions={
-    Array [
-      Object {
-        "onClick": [Function],
-        "title": "Edit policies for this system",
-      },
-      Object {
-        "onClick": [Function],
-        "title": "View in inventory",
-      },
-    ]
-  }
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  bulkSelect={
-    Object {
-      "checked": false,
-      "count": 0,
-      "label": undefined,
-      "onSelect": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": false,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
+<Fragment>
+  <ForwardRef
+    actions={
+      Array [
         Object {
-          "filterValues": Object {
-            "onChange": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
+          "onClick": [Function],
+          "title": "Edit policies for this system",
         },
-      ],
-    }
-  }
-  items={
-    Array [
-      1,
-    ]
-  }
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  tableProps={
-    Object {
-      "canSelectAll": false,
-    }
-  }
-  total={1}
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
         Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
+          "onClick": [Function],
+          "title": "View in inventory",
+        },
+      ]
+    }
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
       }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
+    }
+    bulkSelect={
+      Object {
+        "checked": false,
+        "count": 0,
+        "label": undefined,
+        "onSelect": [Function],
+      }
+    }
+    exportConfig={
+      Object {
+        "isDisabled": false,
+        "onSelect": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
+            },
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+      }
+    }
+    items={
+      Array [
+        1,
+      ]
+    }
+    onRefresh={[Function]}
+    page={1}
+    perPage={50}
+    tableProps={
+      Object {
+        "canSelectAll": false,
+      }
+    }
+    total={1}
+  >
+    <ToolbarGroup>
+      <ToolbarItem
+        style={
+          Object {
+            "marginLeft": "var(--pf-global--spacer--lg)",
+          }
+        }
+      >
+        <Connect(ComplianceRemediationButton)
+          allSystems={Array []}
+          selectedRules={Array []}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </ForwardRef>
+</Fragment>
 `;
 
 exports[`SystemsTable expect to not show actions if showActions is false 1`] = `
-<ForwardRef
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  bulkSelect={
-    Object {
-      "checked": false,
-      "count": 0,
-      "label": undefined,
-      "onSelect": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": false,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
-        Object {
-          "filterValues": Object {
-            "onChange": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
-        },
-      ],
-    }
-  }
-  items={
-    Array [
-      1,
-    ]
-  }
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  tableProps={
-    Object {
-      "canSelectAll": false,
-    }
-  }
-  total={1}
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
-        Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
+<Fragment>
+  <ForwardRef
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
       }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
+    }
+    bulkSelect={
+      Object {
+        "checked": false,
+        "count": 0,
+        "label": undefined,
+        "onSelect": [Function],
+      }
+    }
+    exportConfig={
+      Object {
+        "isDisabled": false,
+        "onSelect": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
+            },
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+      }
+    }
+    items={
+      Array [
+        1,
+      ]
+    }
+    onRefresh={[Function]}
+    page={1}
+    perPage={50}
+    tableProps={
+      Object {
+        "canSelectAll": false,
+      }
+    }
+    total={1}
+  >
+    <ToolbarGroup>
+      <ToolbarItem
+        style={
+          Object {
+            "marginLeft": "var(--pf-global--spacer--lg)",
+          }
+        }
+      >
+        <Connect(ComplianceRemediationButton)
+          allSystems={Array []}
+          selectedRules={Array []}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </ForwardRef>
+</Fragment>
 `;
 
 exports[`SystemsTable expect to render a loading state 1`] = `
-<ForwardRef
-  actions={
-    Array [
-      Object {
-        "onClick": [Function],
-        "title": "Edit policies for this system",
-      },
-      Object {
-        "onClick": [Function],
-        "title": "View in inventory",
-      },
-    ]
-  }
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  bulkSelect={
-    Object {
-      "checked": false,
-      "count": 0,
-      "label": undefined,
-      "onSelect": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": true,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
+<Fragment>
+  <ForwardRef
+    actions={
+      Array [
         Object {
-          "filterValues": Object {
-            "onChange": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
+          "onClick": [Function],
+          "title": "Edit policies for this system",
         },
-      ],
-    }
-  }
-  items={Array []}
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  tableProps={
-    Object {
-      "canSelectAll": false,
-    }
-  }
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
         Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
+          "onClick": [Function],
+          "title": "View in inventory",
+        },
+      ]
+    }
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
       }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
+    }
+    bulkSelect={
+      Object {
+        "checked": false,
+        "count": 0,
+        "label": undefined,
+        "onSelect": [Function],
+      }
+    }
+    exportConfig={
+      Object {
+        "isDisabled": true,
+        "onSelect": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
+            },
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+      }
+    }
+    items={Array []}
+    onRefresh={[Function]}
+    page={1}
+    perPage={50}
+    tableProps={
+      Object {
+        "canSelectAll": false,
+      }
+    }
+  >
+    <ToolbarGroup>
+      <ToolbarItem
+        style={
+          Object {
+            "marginLeft": "var(--pf-global--spacer--lg)",
+          }
+        }
+      >
+        <Connect(ComplianceRemediationButton)
+          allSystems={Array []}
+          selectedRules={Array []}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </ForwardRef>
+</Fragment>
 `;
 
 exports[`SystemsTable expect to set compliant filters when enabled 1`] = `
-<ForwardRef
-  actions={
-    Array [
+<Fragment>
+  <ForwardRef
+    actions={
+      Array [
+        Object {
+          "onClick": [Function],
+          "title": "Edit policies for this system",
+        },
+        Object {
+          "onClick": [Function],
+          "title": "View in inventory",
+        },
+      ]
+    }
+    activeFiltersConfig={
       Object {
-        "onClick": [Function],
-        "title": "Edit policies for this system",
-      },
-      Object {
-        "onClick": [Function],
-        "title": "View in inventory",
-      },
-    ]
-  }
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  bulkSelect={
-    Object {
-      "checked": false,
-      "count": 0,
-      "label": undefined,
-      "onSelect": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": false,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
-        Object {
-          "filterValues": Object {
-            "onChange": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
-        },
-        Object {
-          "filterValues": Object {
-            "items": Array [
-              Object {
-                "label": "Compliant",
-                "value": "true",
-              },
-              Object {
-                "label": "Non-compliant",
-                "value": "false",
-              },
-            ],
-            "onChange": [Function],
-            "value": Array [],
-          },
-          "id": "compliant",
-          "label": "Compliant",
-          "type": "checkbox",
-        },
-        Object {
-          "filterValues": Object {
-            "items": Array [
-              Object {
-                "label": "90 - 100%",
-                "value": "90-100",
-              },
-              Object {
-                "label": "70 - 89%",
-                "value": "70-89",
-              },
-              Object {
-                "label": "50 - 69%",
-                "value": "50-69",
-              },
-              Object {
-                "label": "Less than 50%",
-                "value": "0-49",
-              },
-            ],
-            "onChange": [Function],
-            "value": Array [],
-          },
-          "id": "compliancescore",
-          "label": "Compliance score",
-          "type": "checkbox",
-        },
-      ],
-    }
-  }
-  items={
-    Array [
-      1,
-    ]
-  }
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  tableProps={
-    Object {
-      "canSelectAll": false,
-    }
-  }
-  total={1}
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
-        Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
+        "filters": Array [],
+        "onDelete": [Function],
       }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
+    }
+    bulkSelect={
+      Object {
+        "checked": false,
+        "count": 0,
+        "label": undefined,
+        "onSelect": [Function],
+      }
+    }
+    exportConfig={
+      Object {
+        "isDisabled": false,
+        "onSelect": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
+            },
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+          Object {
+            "filterValues": Object {
+              "items": Array [
+                Object {
+                  "label": "Compliant",
+                  "value": "true",
+                },
+                Object {
+                  "label": "Non-compliant",
+                  "value": "false",
+                },
+              ],
+              "onChange": [Function],
+              "value": Array [],
+            },
+            "id": "compliant",
+            "label": "Compliant",
+            "type": "checkbox",
+          },
+          Object {
+            "filterValues": Object {
+              "items": Array [
+                Object {
+                  "label": "90 - 100%",
+                  "value": "90-100",
+                },
+                Object {
+                  "label": "70 - 89%",
+                  "value": "70-89",
+                },
+                Object {
+                  "label": "50 - 69%",
+                  "value": "50-69",
+                },
+                Object {
+                  "label": "Less than 50%",
+                  "value": "0-49",
+                },
+              ],
+              "onChange": [Function],
+              "value": Array [],
+            },
+            "id": "compliancescore",
+            "label": "Compliance score",
+            "type": "checkbox",
+          },
+        ],
+      }
+    }
+    items={
+      Array [
+        1,
+      ]
+    }
+    onRefresh={[Function]}
+    page={1}
+    perPage={50}
+    tableProps={
+      Object {
+        "canSelectAll": false,
+      }
+    }
+    total={1}
+  >
+    <ToolbarGroup>
+      <ToolbarItem
+        style={
+          Object {
+            "marginLeft": "var(--pf-global--spacer--lg)",
+          }
+        }
+      >
+        <Connect(ComplianceRemediationButton)
+          allSystems={Array []}
+          selectedRules={Array []}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </ForwardRef>
+</Fragment>
 `;
 
 exports[`SystemsTable expect to set isDisable on export config to false total is 0 but selected is not 1`] = `
-<ForwardRef
-  actions={
-    Array [
-      Object {
-        "onClick": [Function],
-        "title": "Edit policies for this system",
-      },
-      Object {
-        "onClick": [Function],
-        "title": "View in inventory",
-      },
-    ]
-  }
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  bulkSelect={
-    Object {
-      "checked": null,
-      "count": 1,
-      "label": "1 Selected",
-      "onSelect": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": false,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
+<Fragment>
+  <Component
+    isInline={true}
+    title="Policies without systems will not have reports."
+    variant="warning"
+  >
+    Add systems to this policy via the "Edit Policy" action, or by adding them from the systems page.
+  </Component>
+  <ForwardRef
+    actions={
+      Array [
         Object {
-          "filterValues": Object {
-            "onChange": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
+          "onClick": [Function],
+          "title": "Edit policies for this system",
         },
-      ],
-    }
-  }
-  items={
-    Array [
-      1,
-    ]
-  }
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  tableProps={
-    Object {
-      "canSelectAll": false,
-    }
-  }
-  total={0}
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
         Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
+          "onClick": [Function],
+          "title": "View in inventory",
+        },
+      ]
+    }
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
       }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={
-          Array [
-            Object {
-              "id": 1,
-              "ruleObjectsFailed": Array [],
+    }
+    bulkSelect={
+      Object {
+        "checked": null,
+        "count": 1,
+        "label": "1 Selected",
+        "onSelect": [Function],
+      }
+    }
+    exportConfig={
+      Object {
+        "isDisabled": false,
+        "onSelect": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
             },
-          ]
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+      }
+    }
+    items={
+      Array [
+        1,
+      ]
+    }
+    onRefresh={[Function]}
+    page={1}
+    perPage={50}
+    tableProps={
+      Object {
+        "canSelectAll": false,
+      }
+    }
+    total={0}
+  >
+    <ToolbarGroup>
+      <ToolbarItem
+        style={
+          Object {
+            "marginLeft": "var(--pf-global--spacer--lg)",
+          }
         }
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
+      >
+        <Connect(ComplianceRemediationButton)
+          allSystems={
+            Array [
+              Object {
+                "id": 1,
+                "ruleObjectsFailed": Array [],
+              },
+            ]
+          }
+          selectedRules={Array []}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </ForwardRef>
+</Fragment>
 `;
 
 exports[`SystemsTable expect to set isDisable on export config to true total is 0 1`] = `
-<ForwardRef
-  actions={
-    Array [
-      Object {
-        "onClick": [Function],
-        "title": "Edit policies for this system",
-      },
-      Object {
-        "onClick": [Function],
-        "title": "View in inventory",
-      },
-    ]
-  }
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  bulkSelect={
-    Object {
-      "checked": false,
-      "count": 0,
-      "label": undefined,
-      "onSelect": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": true,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
+<Fragment>
+  <Component
+    isInline={true}
+    title="Policies without systems will not have reports."
+    variant="warning"
+  >
+    Add systems to this policy via the "Edit Policy" action, or by adding them from the systems page.
+  </Component>
+  <ForwardRef
+    actions={
+      Array [
         Object {
-          "filterValues": Object {
-            "onChange": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
+          "onClick": [Function],
+          "title": "Edit policies for this system",
         },
-      ],
-    }
-  }
-  items={
-    Array [
-      1,
-    ]
-  }
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  tableProps={
-    Object {
-      "canSelectAll": false,
-    }
-  }
-  total={0}
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
         Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
+          "onClick": [Function],
+          "title": "View in inventory",
+        },
+      ]
+    }
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
       }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
+    }
+    bulkSelect={
+      Object {
+        "checked": false,
+        "count": 0,
+        "label": undefined,
+        "onSelect": [Function],
+      }
+    }
+    exportConfig={
+      Object {
+        "isDisabled": true,
+        "onSelect": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
+            },
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+      }
+    }
+    items={
+      Array [
+        1,
+      ]
+    }
+    onRefresh={[Function]}
+    page={1}
+    perPage={50}
+    tableProps={
+      Object {
+        "canSelectAll": false,
+      }
+    }
+    total={0}
+  >
+    <ToolbarGroup>
+      <ToolbarItem
+        style={
+          Object {
+            "marginLeft": "var(--pf-global--spacer--lg)",
+          }
+        }
+      >
+        <Connect(ComplianceRemediationButton)
+          allSystems={Array []}
+          selectedRules={Array []}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </ForwardRef>
+</Fragment>
 `;
 
 exports[`SystemsTable expect to set loading state correctly on updateSystems 1`] = `
-<ForwardRef
-  actions={
-    Array [
-      Object {
-        "onClick": [Function],
-        "title": "Edit policies for this system",
-      },
-      Object {
-        "onClick": [Function],
-        "title": "View in inventory",
-      },
-    ]
-  }
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  bulkSelect={
-    Object {
-      "checked": false,
-      "count": 0,
-      "label": undefined,
-      "onSelect": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": true,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
+<Fragment>
+  <ForwardRef
+    actions={
+      Array [
         Object {
-          "filterValues": Object {
-            "onChange": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
+          "onClick": [Function],
+          "title": "Edit policies for this system",
         },
-      ],
-    }
-  }
-  items={Array []}
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  tableProps={
-    Object {
-      "canSelectAll": false,
-    }
-  }
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
         Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
+          "onClick": [Function],
+          "title": "View in inventory",
+        },
+      ]
+    }
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
       }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
+    }
+    bulkSelect={
+      Object {
+        "checked": false,
+        "count": 0,
+        "label": undefined,
+        "onSelect": [Function],
+      }
+    }
+    exportConfig={
+      Object {
+        "isDisabled": true,
+        "onSelect": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
+            },
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+      }
+    }
+    items={Array []}
+    onRefresh={[Function]}
+    page={1}
+    perPage={50}
+    tableProps={
+      Object {
+        "canSelectAll": false,
+      }
+    }
+  >
+    <ToolbarGroup>
+      <ToolbarItem
+        style={
+          Object {
+            "marginLeft": "var(--pf-global--spacer--lg)",
+          }
+        }
+      >
+        <Connect(ComplianceRemediationButton)
+          allSystems={Array []}
+          selectedRules={Array []}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </ForwardRef>
+</Fragment>
 `;
 
 exports[`SystemsTable expect to show actions if showActions is true or by default 1`] = `
-<ForwardRef
-  actions={
-    Array [
-      Object {
-        "onClick": [Function],
-        "title": "Edit policies for this system",
-      },
-      Object {
-        "onClick": [Function],
-        "title": "View in inventory",
-      },
-    ]
-  }
-  activeFiltersConfig={
-    Object {
-      "filters": Array [],
-      "onDelete": [Function],
-    }
-  }
-  bulkSelect={
-    Object {
-      "checked": false,
-      "count": 0,
-      "label": undefined,
-      "onSelect": [Function],
-    }
-  }
-  exportConfig={
-    Object {
-      "isDisabled": false,
-      "onSelect": [Function],
-    }
-  }
-  filterConfig={
-    Object {
-      "hideLabel": true,
-      "items": Array [
+<Fragment>
+  <ForwardRef
+    actions={
+      Array [
         Object {
-          "filterValues": Object {
-            "onChange": [Function],
-            "value": "",
-          },
-          "id": "name",
-          "label": "Name",
-          "type": "text",
+          "onClick": [Function],
+          "title": "Edit policies for this system",
         },
-      ],
-    }
-  }
-  items={
-    Array [
-      1,
-    ]
-  }
-  onRefresh={[Function]}
-  page={1}
-  perPage={50}
-  tableProps={
-    Object {
-      "canSelectAll": false,
-    }
-  }
-  total={1}
->
-  <ToolbarGroup>
-    <ToolbarItem
-      style={
         Object {
-          "marginLeft": "var(--pf-global--spacer--lg)",
-        }
+          "onClick": [Function],
+          "title": "View in inventory",
+        },
+      ]
+    }
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
       }
-    >
-      <Connect(ComplianceRemediationButton)
-        allSystems={Array []}
-        selectedRules={Array []}
-      />
-    </ToolbarItem>
-  </ToolbarGroup>
-</ForwardRef>
+    }
+    bulkSelect={
+      Object {
+        "checked": false,
+        "count": 0,
+        "label": undefined,
+        "onSelect": [Function],
+      }
+    }
+    exportConfig={
+      Object {
+        "isDisabled": false,
+        "onSelect": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "hideLabel": true,
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
+            },
+            "id": "name",
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+      }
+    }
+    items={
+      Array [
+        1,
+      ]
+    }
+    onRefresh={[Function]}
+    page={1}
+    perPage={50}
+    tableProps={
+      Object {
+        "canSelectAll": false,
+      }
+    }
+    total={1}
+  >
+    <ToolbarGroup>
+      <ToolbarItem
+        style={
+          Object {
+            "marginLeft": "var(--pf-global--spacer--lg)",
+          }
+        }
+      >
+        <Connect(ComplianceRemediationButton)
+          allSystems={Array []}
+          selectedRules={Array []}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </ForwardRef>
+</Fragment>
 `;


### PR DESCRIPTION
Corrects the colour of the warning text in the wizard:
![Screenshot 2020-05-19 at 14 10 02](https://user-images.githubusercontent.com/7757/82324908-b497f800-99da-11ea-978b-06e4f00c34e4.png)

Adds a wardning to the policies table:

![Screenshot 2020-05-19 at 13 55 44](https://user-images.githubusercontent.com/7757/82324936-bcf03300-99da-11ea-869f-f12b5f11dc30.png)

And adds a warning to the systems table in the policy details (Difference to mock approved by PM, see ticket):

![Screenshot 2020-05-19 at 15 31 27](https://user-images.githubusercontent.com/7757/82332751-14e06700-99e6-11ea-9a07-f9da8408b28a.png)
