### PR TITLE
RHICOMPL-556 - Run onWizardFinish only when button is clicked

### DIFF
--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -73,7 +73,7 @@ export const CompliancePolicies = () => {
             <Main>
                 { policies && policies.length === 0 ?
                     <Grid gutter='md'><ComplianceEmptyState title='No policies'
-                        mainButton={<CreatePolicy onWizardFinish={() => { location.reload(); }} />} /></Grid> :
+                        mainButton={<CreatePolicy onWizardFinish={() => refetch()} />} /></Grid> :
                     <PoliciesTable onWizardFinish={() => refetch()} policies={ policies } />
                 }
             </Main>

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
@@ -45,7 +45,7 @@ class FinishedCreatePolicy extends React.Component {
     }
 
     associateSystems = () => {
-        const { systemIds, client, onWizardFinish } = this.props;
+        const { systemIds, client } = this.props;
         const { profileId: id } = this.state;
         return client.mutate({
             mutation: ASSOCIATE_SYSTEMS_TO_PROFILES,
@@ -56,7 +56,7 @@ class FinishedCreatePolicy extends React.Component {
             this.setState(prevState => ({
                 percent: prevState.percent + 50,
                 message: ''
-            }), onWizardFinish);
+            }));
         }).catch((error) => {
             this.setState({
                 message: error.networkError.message,
@@ -67,6 +67,7 @@ class FinishedCreatePolicy extends React.Component {
 
     render() {
         const { percent, message, failed } = this.state;
+        const { onClose, onWizardFinish } = this.props;
         return (
             <Bullseye>
                 <EmptyState variant={EmptyStateVariant.full}>
@@ -83,7 +84,12 @@ class FinishedCreatePolicy extends React.Component {
                     </EmptyStateBody>
                     <EmptyStateSecondaryActions>
                         { percent === 100 ?
-                            <Button variant={'primary'} onClick={this.props.onClose}>Return to application</Button> :
+                            <Button
+                                variant={'primary'}
+                                onClick={() => { onWizardFinish(); onClose(); }}
+                            >
+                                Return to application
+                            </Button> :
                             '' }
                     </EmptyStateSecondaryActions>
                 </EmptyState>


### PR DESCRIPTION
Currently onWizardFinish runs automatically when the systems have been
assigned to the policy. This function is used mainly to reload the table
of SCAP policies.

Instead, we should only run it when the button is clicked - this allows
us to NOT automatically reload the page when the wizard finishes and we
have just created our **first** policy or a Policy through the Reports
page empty state.