### PR TITLE
RHICOMPL-729 - Use cache-and-network policy for AssignPoliciesModal

### DIFF
--- a/src/SmartComponents/AssignPoliciesModal/AssignPoliciesModal.js
+++ b/src/SmartComponents/AssignPoliciesModal/AssignPoliciesModal.js
@@ -59,7 +59,7 @@ const AssignPoliciesModal = ({ isModalOpen, toggle, fqdn, id, selectedPolicyIds,
         });
     }, [id]);
 
-    const { data, error, loading } = useQuery(QUERY, { variables: { search: 'id=' + id } });
+    const { data, error, loading } = useQuery(QUERY, { variables: { search: 'id=' + id }, fetchPolicy: 'cache-and-network' });
 
     if (error || errorSystemOs) { return <ErrorPage error={error}/>; }
 


### PR DESCRIPTION
Without this, if:

 - you create a policy and then immediately go to the systems table
   without a hard refresh, the policy will not show up on the list

 - you go from systems -> scap policies, delete a policy -> back to
   systems, the policy will still show up as assignable and this will
   cause an error if you even attempt it