### PR TITLE
Request only internal policies on Wizard

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
@@ -36,7 +36,7 @@ query benchmarksAndProfiles {
             complianceThreshold
         }
     }
-    profiles {
+    profiles(search: "external = false and canonical = false") {
         edges {
             node {
                 id


### PR DESCRIPTION
Currently, the wizard requests for all visible policies, and compares the intersection of that with the benchmark to remove them - since "all visible policies" include "canonical policies", then no policies are visible. We should get the intersection with "user created policies".