### PR TITLE
RHICOMPL-534 - Update policy details to match mocks

### DIFF
--- a/src/SmartComponents/BusinessObjectiveField/BusinessObjectiveField.js
+++ b/src/SmartComponents/BusinessObjectiveField/BusinessObjectiveField.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { compose } from 'redux';
 import { Field, reduxForm } from 'redux-form';
-import { FormGroup, Title } from '@patternfly/react-core';
+import { FormGroup, Title, Popover, PopoverPosition } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import propTypes from 'prop-types';
 import { ReduxFormCreatableSelectInput } from 'PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers';
 import gql from 'graphql-tag';
@@ -65,19 +66,20 @@ export class BusinessObjectiveField extends React.Component {
 
     render() {
         const { selected } = this.state;
-        const { showTitle } = this.props;
         const titleId = 'business-objective-typeahead';
-        const title = <React.Fragment>
-            <Title headingLevel='h3' size='xl'>Business objective</Title>
-            This is an optional field that can be used to label policies that are related to
-            specific business objectives.
-        </React.Fragment>;
+        const popover = <Popover
+            position={PopoverPosition.top}
+            headerContent={<Title headingLevel='h3' size='xl'>Business objective</Title>}
+            bodyContent={<div>This is an optional field that can be used to label policies that are related to
+            specific business objectives.</div>}
+        >
+            <OutlinedQuestionCircleIcon />
+        </Popover>;
 
         return (
             <React.Fragment>
-                { showTitle && title }
                 <FormGroup fieldId='edit-policy-business-objective'
-                    label="Business objective"
+                    label={<React.Fragment>Business objective {popover}</React.Fragment>}
                     helperText='e.g Project Gemini'>
                     <Field name='businessObjective'
                         id='businessObjective'
@@ -100,12 +102,7 @@ export class BusinessObjectiveField extends React.Component {
 BusinessObjectiveField.propTypes = {
     businessObjective: propTypes.object,
     client: propTypes.object,
-    dispatch: propTypes.func,
-    showTitle: propTypes.bool
-};
-
-BusinessObjectiveField.defaultProps = {
-    showTitle: true
+    dispatch: propTypes.func
 };
 
 export default compose(

--- a/src/SmartComponents/BusinessObjectiveField/BusinessObjectiveField.js
+++ b/src/SmartComponents/BusinessObjectiveField/BusinessObjectiveField.js
@@ -66,20 +66,28 @@ export class BusinessObjectiveField extends React.Component {
 
     render() {
         const { selected } = this.state;
+        const { showTitle } = this.props;
         const titleId = 'business-objective-typeahead';
+        const titleHeader = <Title headingLevel='h3' size='xl'>Business objective</Title>;
+        const explanation = <React.Fragment>This is an optional field that can be used to label policies that are related to
+            specific business objectives.</React.Fragment>;
+        const title = <React.Fragment>
+            { titleHeader }
+            { explanation }
+        </React.Fragment>;
         const popover = <Popover
             position={PopoverPosition.top}
-            headerContent={<Title headingLevel='h3' size='xl'>Business objective</Title>}
-            bodyContent={<div>This is an optional field that can be used to label policies that are related to
-            specific business objectives.</div>}
+            headerContent={titleHeader}
+            bodyContent={explanation}
         >
             <OutlinedQuestionCircleIcon />
         </Popover>;
 
         return (
             <React.Fragment>
+                { showTitle && title }
                 <FormGroup fieldId='edit-policy-business-objective'
-                    label={<React.Fragment>Business objective {popover}</React.Fragment>}
+                    label={<React.Fragment>Business objective {!showTitle && popover}</React.Fragment>}
                     helperText='e.g Project Gemini'>
                     <Field name='businessObjective'
                         id='businessObjective'
@@ -102,7 +110,8 @@ export class BusinessObjectiveField extends React.Component {
 BusinessObjectiveField.propTypes = {
     businessObjective: propTypes.object,
     client: propTypes.object,
-    dispatch: propTypes.func
+    dispatch: propTypes.func,
+    showTitle: propTypes.bool
 };
 
 export default compose(

--- a/src/SmartComponents/BusinessObjectiveField/BusinessObjectiveField.test.js
+++ b/src/SmartComponents/BusinessObjectiveField/BusinessObjectiveField.test.js
@@ -30,9 +30,9 @@ describe('BusinessObjectiveField', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('expect to render without title', () => {
+    it('expect to render with title', () => {
         const wrapper = shallow(
-            <BusinessObjectiveField showTitle={false} { ...defaultProps }/>
+            <BusinessObjectiveField showTitle { ...defaultProps }/>
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/SmartComponents/BusinessObjectiveField/__snapshots__/BusinessObjectiveField.test.js.snap
+++ b/src/SmartComponents/BusinessObjectiveField/__snapshots__/BusinessObjectiveField.test.js.snap
@@ -1,66 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BusinessObjectiveField expect to render without error 1`] = `
+exports[`BusinessObjectiveField expect to render with title 1`] = `
 <Fragment>
+  <Title
+    headingLevel="h3"
+    size="xl"
+  >
+    Business objective
+  </Title>
+  This is an optional field that can be used to label policies that are related to specific business objectives.
   <FormGroup
     fieldId="edit-policy-business-objective"
     helperText="e.g Project Gemini"
     label={
       <React.Fragment>
         Business objective 
-        <Popover
-          appendTo={[Function]}
-          aria-label=""
-          bodyContent={
-            <div>
-              This is an optional field that can be used to label policies that are related to specific business objectives.
-            </div>
-          }
-          boundary="window"
-          className=""
-          closeBtnAriaLabel="Close"
-          distance={25}
-          enableFlip={true}
-          flipBehavior={
-            Array [
-              "top",
-              "right",
-              "bottom",
-              "left",
-              "top",
-              "right",
-              "bottom",
-            ]
-          }
-          footerContent={null}
-          headerContent={
-            <Title
-              headingLevel="h3"
-              size="xl"
-            >
-              Business objective
-            </Title>
-          }
-          hideOnOutsideClick={true}
-          isVisible={null}
-          maxWidth="calc(2rem + 18.75rem)"
-          onHidden={[Function]}
-          onHide={[Function]}
-          onMount={[Function]}
-          onShow={[Function]}
-          onShown={[Function]}
-          position="top"
-          shouldClose={[Function]}
-          tippyProps={Object {}}
-          zIndex={9999}
-        >
-          <OutlinedQuestionCircleIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-            title={null}
-          />
-        </Popover>
       </React.Fragment>
     }
   >
@@ -86,7 +40,7 @@ exports[`BusinessObjectiveField expect to render without error 1`] = `
 </Fragment>
 `;
 
-exports[`BusinessObjectiveField expect to render without title 1`] = `
+exports[`BusinessObjectiveField expect to render without error 1`] = `
 <Fragment>
   <FormGroup
     fieldId="edit-policy-business-objective"
@@ -98,9 +52,9 @@ exports[`BusinessObjectiveField expect to render without title 1`] = `
           appendTo={[Function]}
           aria-label=""
           bodyContent={
-            <div>
+            <React.Fragment>
               This is an optional field that can be used to label policies that are related to specific business objectives.
-            </div>
+            </React.Fragment>
           }
           boundary="window"
           className=""

--- a/src/SmartComponents/BusinessObjectiveField/__snapshots__/BusinessObjectiveField.test.js.snap
+++ b/src/SmartComponents/BusinessObjectiveField/__snapshots__/BusinessObjectiveField.test.js.snap
@@ -2,17 +2,67 @@
 
 exports[`BusinessObjectiveField expect to render without error 1`] = `
 <Fragment>
-  <Title
-    headingLevel="h3"
-    size="xl"
-  >
-    Business objective
-  </Title>
-  This is an optional field that can be used to label policies that are related to specific business objectives.
   <FormGroup
     fieldId="edit-policy-business-objective"
     helperText="e.g Project Gemini"
-    label="Business objective"
+    label={
+      <React.Fragment>
+        Business objective 
+        <Popover
+          appendTo={[Function]}
+          aria-label=""
+          bodyContent={
+            <div>
+              This is an optional field that can be used to label policies that are related to specific business objectives.
+            </div>
+          }
+          boundary="window"
+          className=""
+          closeBtnAriaLabel="Close"
+          distance={25}
+          enableFlip={true}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          footerContent={null}
+          headerContent={
+            <Title
+              headingLevel="h3"
+              size="xl"
+            >
+              Business objective
+            </Title>
+          }
+          hideOnOutsideClick={true}
+          isVisible={null}
+          maxWidth="calc(2rem + 18.75rem)"
+          onHidden={[Function]}
+          onHide={[Function]}
+          onMount={[Function]}
+          onShow={[Function]}
+          onShown={[Function]}
+          position="top"
+          shouldClose={[Function]}
+          tippyProps={Object {}}
+          zIndex={9999}
+        >
+          <OutlinedQuestionCircleIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+            title={null}
+          />
+        </Popover>
+      </React.Fragment>
+    }
   >
     <Field
       aria-label="Select a business objective"
@@ -41,7 +91,64 @@ exports[`BusinessObjectiveField expect to render without title 1`] = `
   <FormGroup
     fieldId="edit-policy-business-objective"
     helperText="e.g Project Gemini"
-    label="Business objective"
+    label={
+      <React.Fragment>
+        Business objective 
+        <Popover
+          appendTo={[Function]}
+          aria-label=""
+          bodyContent={
+            <div>
+              This is an optional field that can be used to label policies that are related to specific business objectives.
+            </div>
+          }
+          boundary="window"
+          className=""
+          closeBtnAriaLabel="Close"
+          distance={25}
+          enableFlip={true}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          footerContent={null}
+          headerContent={
+            <Title
+              headingLevel="h3"
+              size="xl"
+            >
+              Business objective
+            </Title>
+          }
+          hideOnOutsideClick={true}
+          isVisible={null}
+          maxWidth="calc(2rem + 18.75rem)"
+          onHidden={[Function]}
+          onHide={[Function]}
+          onMount={[Function]}
+          onShow={[Function]}
+          onShown={[Function]}
+          position="top"
+          shouldClose={[Function]}
+          tippyProps={Object {}}
+          zIndex={9999}
+        >
+          <OutlinedQuestionCircleIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+            title={null}
+          />
+        </Popover>
+      </React.Fragment>
+    }
   >
     <Field
       aria-label="Select a business objective"

--- a/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
@@ -19,6 +19,7 @@ const EditPolicyDetails = ({ profile, dispatch }) => {
                     Policy details
                 </Text>
             </TextContent>
+            <br/>
             <Form id='editpolicydetails'>
                 <FormGroup label="Policy name" isRequired fieldId="name">
                     <Field
@@ -49,12 +50,12 @@ const EditPolicyDetails = ({ profile, dispatch }) => {
                         aria-describedby="description"
                     />
                 </FormGroup>
-                <ProfileThresholdField previousThreshold={profile.complianceThreshold} />
                 <BusinessObjectiveField
                     businessObjective={{}}
                     policyId={profile.id}
                     dispatch={dispatch}
                 />
+                <ProfileThresholdField showTitle={false} previousThreshold={profile.complianceThreshold} />
             </Form>
         </React.Fragment>
     );

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyDetails.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyDetails.test.js.snap
@@ -163,9 +163,9 @@ exports[`EditPolicyDetails expect to render without error 1`] = `
                   appendTo={[Function]}
                   aria-label=""
                   bodyContent={
-                    <div>
+                    <React.Fragment>
                       The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
-                    </div>
+                    </React.Fragment>
                   }
                   boundary="window"
                   className=""
@@ -230,9 +230,9 @@ exports[`EditPolicyDetails expect to render without error 1`] = `
                     appendTo={[Function]}
                     aria-label=""
                     bodyContent={
-                      <div>
+                      <React.Fragment>
                         The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
-                      </div>
+                      </React.Fragment>
                     }
                     boundary="window"
                     className=""

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyDetails.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyDetails.test.js.snap
@@ -40,6 +40,7 @@ exports[`EditPolicyDetails expect to render without error 1`] = `
         </Text>
       </div>
     </TextContent>
+    <br />
     <Form
       id="editpolicydetails"
     >
@@ -142,27 +143,77 @@ exports[`EditPolicyDetails expect to render without error 1`] = `
             />
           </div>
         </FormGroup>
+        <withApollo(BusinessObjectiveField)
+          businessObjective={Object {}}
+          policyId="197eb783-7bca-45c5-978d-c1e89b0118da"
+        />
         <ProfileThresholdField
           previousThreshold={100}
-          showTitle={true}
+          showTitle={false}
         >
-          <Title
-            headingLevel="h3"
-            size="xl"
-          >
-            <h3
-              className="pf-c-title pf-m-xl"
-            >
-              Compliance threshold
-            </h3>
-          </Title>
-          The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
           <FormGroup
             fieldId="policy-threshold"
             helperText="A value of 95% or higher is recommended"
             helperTextInvalid="Threshold has to be a number between 0 and 100"
             isValid={true}
-            label="Compliance threshold (%)"
+            label={
+              <React.Fragment>
+                Compliance threshold (%) 
+                <Popover
+                  appendTo={[Function]}
+                  aria-label=""
+                  bodyContent={
+                    <div>
+                      The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
+                    </div>
+                  }
+                  boundary="window"
+                  className=""
+                  closeBtnAriaLabel="Close"
+                  distance={25}
+                  enableFlip={true}
+                  flipBehavior={
+                    Array [
+                      "top",
+                      "right",
+                      "bottom",
+                      "left",
+                      "top",
+                      "right",
+                      "bottom",
+                    ]
+                  }
+                  footerContent={null}
+                  headerContent={
+                    <Title
+                      headingLevel="h3"
+                      size="xl"
+                    >
+                      Compliance threshold
+                    </Title>
+                  }
+                  hideOnOutsideClick={true}
+                  isVisible={null}
+                  maxWidth="calc(2rem + 18.75rem)"
+                  onHidden={[Function]}
+                  onHide={[Function]}
+                  onMount={[Function]}
+                  onShow={[Function]}
+                  onShown={[Function]}
+                  position="top"
+                  shouldClose={[Function]}
+                  tippyProps={Object {}}
+                  zIndex={9999}
+                >
+                  <OutlinedQuestionCircleIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                    title={null}
+                  />
+                </Popover>
+              </React.Fragment>
+            }
           >
             <div
               className="pf-c-form__group"
@@ -174,7 +225,131 @@ exports[`EditPolicyDetails expect to render without error 1`] = `
                 <span
                   className="pf-c-form__label-text"
                 >
-                  Compliance threshold (%)
+                  Compliance threshold (%) 
+                  <Popover
+                    appendTo={[Function]}
+                    aria-label=""
+                    bodyContent={
+                      <div>
+                        The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
+                      </div>
+                    }
+                    boundary="window"
+                    className=""
+                    closeBtnAriaLabel="Close"
+                    distance={25}
+                    enableFlip={true}
+                    flipBehavior={
+                      Array [
+                        "top",
+                        "right",
+                        "bottom",
+                        "left",
+                        "top",
+                        "right",
+                        "bottom",
+                      ]
+                    }
+                    footerContent={null}
+                    headerContent={
+                      <Title
+                        headingLevel="h3"
+                        size="xl"
+                      >
+                        Compliance threshold
+                      </Title>
+                    }
+                    hideOnOutsideClick={true}
+                    isVisible={null}
+                    maxWidth="calc(2rem + 18.75rem)"
+                    onHidden={[Function]}
+                    onHide={[Function]}
+                    onMount={[Function]}
+                    onShow={[Function]}
+                    onShown={[Function]}
+                    position="top"
+                    shouldClose={[Function]}
+                    tippyProps={Object {}}
+                    zIndex={9999}
+                  >
+                    <PopoverBase
+                      appendTo={[Function]}
+                      arrow={true}
+                      boundary="window"
+                      content={<React.Fragment />}
+                      distance={25}
+                      flip={true}
+                      flipBehavior={
+                        Array [
+                          "top",
+                          "right",
+                          "bottom",
+                          "left",
+                          "top",
+                          "right",
+                          "bottom",
+                        ]
+                      }
+                      hideOnClick={true}
+                      interactive={true}
+                      interactiveBorder={0}
+                      isVisible={null}
+                      lazy={true}
+                      maxWidth="calc(2rem + 18.75rem)"
+                      onCreate={[Function]}
+                      onHidden={[Function]}
+                      onHide={[Function]}
+                      onMount={[Function]}
+                      onShow={[Function]}
+                      onShown={[Function]}
+                      placement="top"
+                      popperOptions={
+                        Object {
+                          "modifiers": Object {
+                            "hide": Object {
+                              "enabled": true,
+                            },
+                            "preventOverflow": Object {
+                              "enabled": true,
+                            },
+                          },
+                        }
+                      }
+                      theme="pf-popover"
+                      trigger="click"
+                      zIndex={9999}
+                    >
+                      <OutlinedQuestionCircleIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                        title={null}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                            transform=""
+                          />
+                        </svg>
+                      </OutlinedQuestionCircleIcon>
+                      <Portal
+                        containerInfo={<div />}
+                      />
+                    </PopoverBase>
+                  </Popover>
                 </span>
               </label>
               <Field
@@ -204,10 +379,6 @@ exports[`EditPolicyDetails expect to render without error 1`] = `
             </div>
           </FormGroup>
         </ProfileThresholdField>
-        <withApollo(BusinessObjectiveField)
-          businessObjective={Object {}}
-          policyId="197eb783-7bca-45c5-978d-c1e89b0118da"
-        />
       </form>
     </Form>
   </EditPolicyDetails>

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -69,8 +69,9 @@ export class EditPolicy extends Component {
                             businessObjective={businessObjective}
                             policyId={policyId}
                             dispatch={dispatch}
+                            showTitle
                         />
-                        <ProfileThresholdField previousThreshold={previousThreshold} />
+                        <ProfileThresholdField showTitle previousThreshold={previousThreshold} />
                     </Form>
                 </Modal>
             </React.Fragment>

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -52,6 +52,7 @@ exports[`EditPolicy expect to render without error 1`] = `
         }
         dispatch={[MockFunction]}
         policyId="POLICY_ID"
+        showTitle={true}
       />
       <ReduxForm
         destroyOnUnmount={false}
@@ -66,6 +67,7 @@ exports[`EditPolicy expect to render without error 1`] = `
         shouldError={[Function]}
         shouldValidate={[Function]}
         shouldWarn={[Function]}
+        showTitle={true}
         submitAsSideEffect={false}
         touchOnBlur={true}
         touchOnChange={false}

--- a/src/SmartComponents/ProfileThresholdField/ProfileThresholdField.js
+++ b/src/SmartComponents/ProfileThresholdField/ProfileThresholdField.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Field, reduxForm } from 'redux-form';
-import { FormGroup, Title } from '@patternfly/react-core';
+import { FormGroup, Title, Popover, PopoverPosition } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ReduxFormTextInput } from 'PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers';
 import propTypes from 'prop-types';
 import round from 'lodash/round';
@@ -24,21 +25,22 @@ export class ProfileThresholdField extends React.Component {
 
     render() {
         const { threshold, validThreshold } = this.state;
-        const { showTitle } = this.props;
-        const title = <React.Fragment>
-            <Title headingLevel="h3" size="xl">Compliance threshold</Title>
-            The compliance threshold defines what percentage of rules must be met in order for a system to
-            be determined &quot;compliant&quot;.
-        </React.Fragment>;
+        const popover = <Popover
+            position={PopoverPosition.top}
+            headerContent={<Title headingLevel="h3" size="xl">Compliance threshold</Title>}
+            bodyContent={<div>The compliance threshold defines what percentage of rules must be met in order for a system to
+            be determined &quot;compliant&quot;.</div>}
+        >
+            <OutlinedQuestionCircleIcon />
+        </Popover>;
 
         return (
             <React.Fragment>
-                { showTitle && title }
                 <FormGroup fieldId='policy-threshold'
                     isValid={validThreshold}
                     helperTextInvalid='Threshold has to be a number between 0 and 100'
                     helperText="A value of 95% or higher is recommended"
-                    label="Compliance threshold (%)">
+                    label={<React.Fragment>Compliance threshold (%) {popover}</React.Fragment>}>
                     <Field name='complianceThreshold' id='complianceThreshold' isRequired={true}
                         onChange={this.handleThresholdChange}
                         isValid={validThreshold}
@@ -53,12 +55,7 @@ export class ProfileThresholdField extends React.Component {
 }
 
 ProfileThresholdField.propTypes = {
-    previousThreshold: propTypes.number,
-    showTitle: propTypes.bool
-};
-
-ProfileThresholdField.defaultProps = {
-    showTitle: true
+    previousThreshold: propTypes.number
 };
 
 export default reduxForm({

--- a/src/SmartComponents/ProfileThresholdField/ProfileThresholdField.js
+++ b/src/SmartComponents/ProfileThresholdField/ProfileThresholdField.js
@@ -25,22 +25,30 @@ export class ProfileThresholdField extends React.Component {
 
     render() {
         const { threshold, validThreshold } = this.state;
+        const { showTitle } = this.props;
+        const explanation = <React.Fragment>The compliance threshold defines what percentage of rules
+            must be met in order for a system to be determined &quot;compliant&quot;.</React.Fragment>;
+        const titleHeader = <Title headingLevel="h3" size="xl">Compliance threshold</Title>;
+        const title = <React.Fragment>
+            { titleHeader }
+            { explanation }
+        </React.Fragment>;
         const popover = <Popover
             position={PopoverPosition.top}
-            headerContent={<Title headingLevel="h3" size="xl">Compliance threshold</Title>}
-            bodyContent={<div>The compliance threshold defines what percentage of rules must be met in order for a system to
-            be determined &quot;compliant&quot;.</div>}
+            headerContent={titleHeader}
+            bodyContent={explanation}
         >
             <OutlinedQuestionCircleIcon />
         </Popover>;
 
         return (
             <React.Fragment>
+                { showTitle && title }
                 <FormGroup fieldId='policy-threshold'
                     isValid={validThreshold}
                     helperTextInvalid='Threshold has to be a number between 0 and 100'
                     helperText="A value of 95% or higher is recommended"
-                    label={<React.Fragment>Compliance threshold (%) {popover}</React.Fragment>}>
+                    label={<React.Fragment>Compliance threshold (%) {!showTitle && popover}</React.Fragment>}>
                     <Field name='complianceThreshold' id='complianceThreshold' isRequired={true}
                         onChange={this.handleThresholdChange}
                         isValid={validThreshold}
@@ -55,7 +63,8 @@ export class ProfileThresholdField extends React.Component {
 }
 
 ProfileThresholdField.propTypes = {
-    previousThreshold: propTypes.number
+    previousThreshold: propTypes.number,
+    showTitle: propTypes.bool
 };
 
 export default reduxForm({

--- a/src/SmartComponents/ProfileThresholdField/ProfileThresholdField.test.js
+++ b/src/SmartComponents/ProfileThresholdField/ProfileThresholdField.test.js
@@ -13,9 +13,9 @@ describe('ProfileThresholdField', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('expect to render without title', () => {
+    it('expect to render with title', () => {
         const wrapper = shallow(
-            <ProfileThresholdField showTitle={false} { ...defaultProps }/>
+            <ProfileThresholdField showTitle { ...defaultProps }/>
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/SmartComponents/ProfileThresholdField/__snapshots__/ProfileThresholdField.test.js.snap
+++ b/src/SmartComponents/ProfileThresholdField/__snapshots__/ProfileThresholdField.test.js.snap
@@ -21,8 +21,15 @@ Object {
 }
 `;
 
-exports[`ProfileThresholdField expect to render without error 1`] = `
+exports[`ProfileThresholdField expect to render with title 1`] = `
 <Fragment>
+  <Title
+    headingLevel="h3"
+    size="xl"
+  >
+    Compliance threshold
+  </Title>
+  The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
   <FormGroup
     fieldId="policy-threshold"
     helperText="A value of 95% or higher is recommended"
@@ -31,59 +38,6 @@ exports[`ProfileThresholdField expect to render without error 1`] = `
     label={
       <React.Fragment>
         Compliance threshold (%) 
-        <Popover
-          appendTo={[Function]}
-          aria-label=""
-          bodyContent={
-            <div>
-              The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
-            </div>
-          }
-          boundary="window"
-          className=""
-          closeBtnAriaLabel="Close"
-          distance={25}
-          enableFlip={true}
-          flipBehavior={
-            Array [
-              "top",
-              "right",
-              "bottom",
-              "left",
-              "top",
-              "right",
-              "bottom",
-            ]
-          }
-          footerContent={null}
-          headerContent={
-            <Title
-              headingLevel="h3"
-              size="xl"
-            >
-              Compliance threshold
-            </Title>
-          }
-          hideOnOutsideClick={true}
-          isVisible={null}
-          maxWidth="calc(2rem + 18.75rem)"
-          onHidden={[Function]}
-          onHide={[Function]}
-          onMount={[Function]}
-          onShow={[Function]}
-          onShown={[Function]}
-          position="top"
-          shouldClose={[Function]}
-          tippyProps={Object {}}
-          zIndex={9999}
-        >
-          <OutlinedQuestionCircleIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-            title={null}
-          />
-        </Popover>
       </React.Fragment>
     }
   >
@@ -108,7 +62,7 @@ exports[`ProfileThresholdField expect to render without error 1`] = `
 </Fragment>
 `;
 
-exports[`ProfileThresholdField expect to render without title 1`] = `
+exports[`ProfileThresholdField expect to render without error 1`] = `
 <Fragment>
   <FormGroup
     fieldId="policy-threshold"
@@ -122,9 +76,9 @@ exports[`ProfileThresholdField expect to render without title 1`] = `
           appendTo={[Function]}
           aria-label=""
           bodyContent={
-            <div>
+            <React.Fragment>
               The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
-            </div>
+            </React.Fragment>
           }
           boundary="window"
           className=""

--- a/src/SmartComponents/ProfileThresholdField/__snapshots__/ProfileThresholdField.test.js.snap
+++ b/src/SmartComponents/ProfileThresholdField/__snapshots__/ProfileThresholdField.test.js.snap
@@ -23,19 +23,69 @@ Object {
 
 exports[`ProfileThresholdField expect to render without error 1`] = `
 <Fragment>
-  <Title
-    headingLevel="h3"
-    size="xl"
-  >
-    Compliance threshold
-  </Title>
-  The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
   <FormGroup
     fieldId="policy-threshold"
     helperText="A value of 95% or higher is recommended"
     helperTextInvalid="Threshold has to be a number between 0 and 100"
     isValid={true}
-    label="Compliance threshold (%)"
+    label={
+      <React.Fragment>
+        Compliance threshold (%) 
+        <Popover
+          appendTo={[Function]}
+          aria-label=""
+          bodyContent={
+            <div>
+              The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
+            </div>
+          }
+          boundary="window"
+          className=""
+          closeBtnAriaLabel="Close"
+          distance={25}
+          enableFlip={true}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          footerContent={null}
+          headerContent={
+            <Title
+              headingLevel="h3"
+              size="xl"
+            >
+              Compliance threshold
+            </Title>
+          }
+          hideOnOutsideClick={true}
+          isVisible={null}
+          maxWidth="calc(2rem + 18.75rem)"
+          onHidden={[Function]}
+          onHide={[Function]}
+          onMount={[Function]}
+          onShow={[Function]}
+          onShown={[Function]}
+          position="top"
+          shouldClose={[Function]}
+          tippyProps={Object {}}
+          zIndex={9999}
+        >
+          <OutlinedQuestionCircleIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+            title={null}
+          />
+        </Popover>
+      </React.Fragment>
+    }
   >
     <Field
       aria-label="compliance threshold"
@@ -65,7 +115,64 @@ exports[`ProfileThresholdField expect to render without title 1`] = `
     helperText="A value of 95% or higher is recommended"
     helperTextInvalid="Threshold has to be a number between 0 and 100"
     isValid={true}
-    label="Compliance threshold (%)"
+    label={
+      <React.Fragment>
+        Compliance threshold (%) 
+        <Popover
+          appendTo={[Function]}
+          aria-label=""
+          bodyContent={
+            <div>
+              The compliance threshold defines what percentage of rules must be met in order for a system to be determined "compliant".
+            </div>
+          }
+          boundary="window"
+          className=""
+          closeBtnAriaLabel="Close"
+          distance={25}
+          enableFlip={true}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          footerContent={null}
+          headerContent={
+            <Title
+              headingLevel="h3"
+              size="xl"
+            >
+              Compliance threshold
+            </Title>
+          }
+          hideOnOutsideClick={true}
+          isVisible={null}
+          maxWidth="calc(2rem + 18.75rem)"
+          onHidden={[Function]}
+          onHide={[Function]}
+          onMount={[Function]}
+          onShow={[Function]}
+          onShown={[Function]}
+          position="top"
+          shouldClose={[Function]}
+          tippyProps={Object {}}
+          zIndex={9999}
+        >
+          <OutlinedQuestionCircleIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+            title={null}
+          />
+        </Popover>
+      </React.Fragment>
+    }
   >
     <Field
       aria-label="compliance threshold"


### PR DESCRIPTION
This essentially moves the headers and descriptions to the tooltips, as the mocks indicate.

:warning: This also changes the Edit Policy menu. I am currently working on a PR to allow re-editing directly on the wizard as in the mocks, so the whole "Edit Policy" modal would go away. 

![Screenshot from 2020-06-24 10-08-26](https://user-images.githubusercontent.com/598891/85520419-30e9b080-b603-11ea-8e0f-43673a87e803.png)
![Screenshot from 2020-06-24 10-08-16](https://user-images.githubusercontent.com/598891/85520423-31824700-b603-11ea-849c-5c2799fd3075.png)
![Screenshot from 2020-06-24 10-08-04](https://user-images.githubusercontent.com/598891/85520425-321add80-b603-11ea-8ab9-45bf325e41c2.png)
