### PR TITLE
Edit systems

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -6,7 +6,7 @@ import { compose } from 'redux';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-const EditPolicySystems = ({ change, selectedSystemIds }) => {
+const EditPolicySystems = ({ showHeader, change, selectedSystemIds }) => {
     const columns = [{
         composed: ['facts.os_release', 'display_name'],
         key: 'facts.compliance.display_name',
@@ -30,14 +30,16 @@ const EditPolicySystems = ({ change, selectedSystemIds }) => {
 
     return (
         <React.Fragment>
-            <TextContent>
-                <Text component={TextVariants.h1}>
-                    Systems
-                </Text>
-                <Text component={TextVariants.h4}>
-                    Choose systems to scan with this policy. You can add and remove systems later.
-                </Text>
-            </TextContent>
+            { showHeader &&
+                <TextContent>
+                    <Text component={TextVariants.h1}>
+                        Systems
+                    </Text>
+                    <Text component={TextVariants.h4}>
+                        Choose systems to scan with this policy. You can add and remove systems later.
+                    </Text>
+                </TextContent>
+            }
             <Form>
                 <SystemsTable
                     columns={columns}
@@ -53,11 +55,13 @@ const EditPolicySystems = ({ change, selectedSystemIds }) => {
 
 EditPolicySystems.propTypes = {
     selectedSystemIds: propTypes.array,
-    change: reduxFormPropTypes.change
+    change: reduxFormPropTypes.change,
+    showHeader: propTypes.bool
 };
 
 EditPolicySystems.defaultProps = {
-    selectedSystemIds: []
+    selectedSystemIds: [],
+    showHeader: true
 };
 
 const mapStateToProps = ({ entities }) => ({

--- a/src/SmartComponents/EditSystems/EditSystems.js
+++ b/src/SmartComponents/EditSystems/EditSystems.js
@@ -42,6 +42,7 @@ class EditSystems extends React.Component {
                         <SubmitEditSystemsButton key='save'
                             aria-label='save'
                             policyId={policyId}
+                            onComplete={this.toggleOpen}
                             systemIds={selectedSystemIds}
                             variant='primary'/>,
                         <Button key="cancel" variant="secondary" onClick={this.toggleOpen}>

--- a/src/SmartComponents/EditSystems/EditSystems.js
+++ b/src/SmartComponents/EditSystems/EditSystems.js
@@ -4,6 +4,10 @@ import {
     Modal
 } from '@patternfly/react-core';
 import EditPolicySystems from '../CreatePolicy/EditPolicySystems';
+import { SubmitEditSystemsButton } from './SubmitEditSystemsButton';
+import { reduxForm, formValueSelector } from 'redux-form';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
 import propTypes from 'prop-types';
 
 class EditSystems extends React.Component {
@@ -22,6 +26,7 @@ class EditSystems extends React.Component {
 
     render() {
         const { isOpen } = this.state;
+        const { policyId, selectedSystemIds } = this.props;
 
         return (
             <React.Fragment>
@@ -30,13 +35,15 @@ class EditSystems extends React.Component {
                 </Button>
                 <Modal
                     title={`Edit systems`}
-                    width={'50%'}
+                    width={'75%'}
                     isOpen={isOpen}
                     isFooterLeftAligned
                     actions={[
-                        <Button key="submit" onClick={this.toggleOpen}>
-                            Submit
-                        </Button>,
+                        <SubmitEditSystemsButton key='save'
+                            aria-label='save'
+                            policyId={policyId}
+                            systemIds={selectedSystemIds}
+                            variant='primary'/>,
                         <Button key="cancel" variant="secondary" onClick={this.toggleOpen}>
                             Cancel
                         </Button>
@@ -51,11 +58,24 @@ class EditSystems extends React.Component {
 
 EditSystems.propTypes = {
     isOpen: propTypes.bool,
-    onClose: propTypes.func
+    onClose: propTypes.func,
+    policyId: propTypes.number.isRequired,
+    selectedSystemIds: propTypes.arrayOf(propTypes.string).isRequired
 };
 
 EditSystems.defaultProps = {
     isOpen: false
 };
 
-export default EditSystems;
+const selector = formValueSelector('policyForm');
+
+export default compose(
+    connect(
+        state => ({
+            selectedSystemIds: selector(state, 'systems')
+        })
+    ),
+    reduxForm({
+        form: 'policyForm'
+    })
+)(EditSystems);

--- a/src/SmartComponents/EditSystems/EditSystems.js
+++ b/src/SmartComponents/EditSystems/EditSystems.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import {
+    Button,
+    Modal
+} from '@patternfly/react-core';
+import EditPolicySystems from '../CreatePolicy/EditPolicySystems';
+import propTypes from 'prop-types';
+
+class EditSystems extends React.Component {
+    state = {
+        isOpen: this.props.isOpen
+    };
+
+    toggleOpen = () => {
+        const { isOpen } = this.state;
+        const { onClose } = this.props;
+
+        this.setState({
+            isOpen: !isOpen
+        }, onClose);
+    };
+
+    render() {
+        const { isOpen } = this.state;
+
+        return (
+            <React.Fragment>
+                <Button onClick={this.toggleOpen}>
+                    Edit systems
+                </Button>
+                <Modal
+                    title={`Edit systems`}
+                    width={'50%'}
+                    isOpen={isOpen}
+                    isFooterLeftAligned
+                    actions={[
+                        <Button key="submit" onClick={this.toggleOpen}>
+                            Submit
+                        </Button>,
+                        <Button key="cancel" variant="secondary" onClick={this.toggleOpen}>
+                            Cancel
+                        </Button>
+                    ]}
+                >
+                    <EditPolicySystems showHeader={false} />
+                </Modal>
+            </React.Fragment>
+        );
+    }
+}
+
+EditSystems.propTypes = {
+    isOpen: propTypes.bool,
+    onClose: propTypes.func
+};
+
+EditSystems.defaultProps = {
+    isOpen: false
+};
+
+export default EditSystems;

--- a/src/SmartComponents/EditSystems/SubmitEditSystemsButton.js
+++ b/src/SmartComponents/EditSystems/SubmitEditSystemsButton.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { useMutation } from '@apollo/react-hooks';
+import { Button } from '@patternfly/react-core';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
+import { dispatchAction } from 'Utilities/Dispatcher';
+import { ASSOCIATE_SYSTEMS_TO_PROFILES } from 'Utilities/graphql/mutations';
+
+export const completedMessage = (profile) => {
+    const systems = profile.systems.map(system => system.name);
+    let message;
+    if (systems.length > 0) {
+        message = `Associated ${systems} to ${profile.name}`;
+    } else {
+        message = `${profile.name} is no longer associated to any policies`;
+    }
+
+    return message;
+};
+
+export const SubmitEditSystemsButton = ({ systemIds, policyId }) => {
+    const [associateSystemsToProfile] = useMutation(ASSOCIATE_SYSTEMS_TO_PROFILES, {
+        onCompleted: (data) => {
+            dispatchAction(addNotification({
+                variant: 'success',
+                title: completedMessage(data.associateSystems.profile)
+            }));
+        },
+        onError: (error) => {
+            dispatchAction(addNotification({
+                variant: 'danger',
+                title: 'Error associating systems',
+                description: error.message
+            }));
+        }
+    });
+
+    return <Button type='submit' aria-label='save'
+        onClick={() => associateSystemsToProfile({ variables: { input: { systemIds, id: policyId } } })}
+        variant='primary'>Save</Button>;
+};
+
+SubmitEditSystemsButton.propTypes = {
+    systemIds: propTypes.arrayOf(propTypes.string).isRequired,
+    policyId: propTypes.string.isRequired
+};
+
+SubmitEditSystemsButton.defaultProps = {
+    systemIds: []
+};

--- a/src/SmartComponents/EditSystems/SubmitEditSystemsButton.js
+++ b/src/SmartComponents/EditSystems/SubmitEditSystemsButton.js
@@ -6,25 +6,14 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import { dispatchAction } from 'Utilities/Dispatcher';
 import { ASSOCIATE_SYSTEMS_TO_PROFILES } from 'Utilities/graphql/mutations';
 
-export const completedMessage = (profile) => {
-    const systems = profile.systems.map(system => system.name);
-    let message;
-    if (systems.length > 0) {
-        message = `Associated ${systems} to ${profile.name}`;
-    } else {
-        message = `${profile.name} is no longer associated to any policies`;
-    }
-
-    return message;
-};
-
-export const SubmitEditSystemsButton = ({ systemIds, policyId }) => {
+export const SubmitEditSystemsButton = ({ systemIds, policyId, onComplete }) => {
     const [associateSystemsToProfile] = useMutation(ASSOCIATE_SYSTEMS_TO_PROFILES, {
-        onCompleted: (data) => {
+        onCompleted: () => {
             dispatchAction(addNotification({
                 variant: 'success',
-                title: completedMessage(data.associateSystems.profile)
+                title: 'Success associating systems to profile'
             }));
+            onComplete();
         },
         onError: (error) => {
             dispatchAction(addNotification({
@@ -42,7 +31,8 @@ export const SubmitEditSystemsButton = ({ systemIds, policyId }) => {
 
 SubmitEditSystemsButton.propTypes = {
     systemIds: propTypes.arrayOf(propTypes.string).isRequired,
-    policyId: propTypes.string.isRequired
+    policyId: propTypes.string.isRequired,
+    onComplete: propTypes.func
 };
 
 SubmitEditSystemsButton.defaultProps = {

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -6,6 +6,7 @@ import { SystemsTable } from 'SmartComponents';
 const PolicySystemsTab = ({ policy, complianceThreshold }) => (
     <SystemsTable policyId={policy.id}
         remediationsEnabled={false}
+        editSystemsEnabled
         columns={[{
             key: 'facts.compliance.display_name',
             title: 'System name',

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -259,7 +259,7 @@ class SystemsTable extends React.Component {
     render() {
         const {
             editSystemsEnabled, remediationsEnabled, compact, enableExport, showAllSystems, showActions,
-            selectedEntities, systems, total
+            selectedEntities, systems, total, policyId
         } = this.props;
         const {
             page, perPage, InventoryCmp, selectedSystemId,
@@ -356,7 +356,7 @@ class SystemsTable extends React.Component {
                             }
                             { editSystemsEnabled &&
                                 <reactCore.ToolbarItem style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}>
-                                    <EditSystems />
+                                    <EditSystems policyId={policyId} />
                                 </reactCore.ToolbarItem>
                             }
                         </reactCore.ToolbarGroup> }

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -15,7 +15,8 @@ import {
 } from '@redhat-cloud-services/frontend-components-inventory-compliance';
 import registry from '@redhat-cloud-services/frontend-components-utilities/files/Registry';
 import  {
-    AssignPoliciesModal
+    AssignPoliciesModal,
+    EditSystems
 } from 'SmartComponents';
 import {
     WARNING_TEXT
@@ -257,7 +258,7 @@ class SystemsTable extends React.Component {
 
     render() {
         const {
-            remediationsEnabled, compact, enableExport, showAllSystems, showActions,
+            editSystemsEnabled, remediationsEnabled, compact, enableExport, showAllSystems, showActions,
             selectedEntities, systems, total
         } = this.props;
         const {
@@ -353,6 +354,11 @@ class SystemsTable extends React.Component {
                                         selectedRules={ [] } />
                                 </reactCore.ToolbarItem>
                             }
+                            { editSystemsEnabled &&
+                                <reactCore.ToolbarItem style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}>
+                                    <EditSystems />
+                                </reactCore.ToolbarItem>
+                            }
                         </reactCore.ToolbarGroup> }
                         { selectedSystemId &&
                         <AssignPoliciesModal
@@ -377,6 +383,7 @@ SystemsTable.propTypes = {
     policyId: propTypes.string,
     columns: propTypes.array,
     remediationsEnabled: propTypes.bool,
+    editSystemsEnabled: propTypes.bool,
     compact: propTypes.bool,
     selectedEntities: propTypes.array,
     exportFromState: propTypes.func,
@@ -401,6 +408,7 @@ SystemsTable.propTypes = {
 SystemsTable.defaultProps = {
     policyId: '',
     remediationsEnabled: true,
+    editSystemsEnabled: false,
     compact: false,
     enableExport: true,
     showAllSystems: false,

--- a/src/SmartComponents/index.js
+++ b/src/SmartComponents/index.js
@@ -9,4 +9,4 @@ export { default as CreatePolicy } from './CreatePolicy/CreatePolicy';
 export { default as DeleteReport } from './DeleteReport/DeleteReport';
 export { default as EditPolicy } from './EditPolicy/EditPolicy';
 export { default as DeletePolicy } from './DeletePolicy/DeletePolicy';
-
+export { default as EditSystems } from './EditSystems/EditSystems';


### PR DESCRIPTION
A draft for now. Missing features:

- [ ] Preloading the systems table modal with checked items for systems in the policy
- [ ] Refetching the systems table after the modal has been submitted.
- [ ] Allowing to dissociate systems from a policy. Right now the mutation can only add new systems to a policy but not remove any. 