### PR TITLE
RHICOMPL-574 - Add OS to systems table when available

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -42,6 +42,8 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
             node {
                 id
                 name
+                osMajorVersion
+                osMinorVersion
                 profiles {
                     id
                     name
@@ -71,6 +73,8 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
             node {
                 id
                 name
+                osMajorVersion
+                osMinorVersion
                 profiles {
                     id
                     name

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -8,7 +8,12 @@ import {
     ComplianceScore as complianceScore,
     complianceScoreString
 } from 'PresentationalComponents';
-import { Tooltip, Text } from '@patternfly/react-core';
+import {
+    Tooltip,
+    Text,
+    TextContent,
+    TextVariants
+} from '@patternfly/react-core';
 import {
     profilesRulesPassed,
     profilesRulesFailed
@@ -77,9 +82,13 @@ export const policiesCell = (system) => {
 };
 
 const displayNameCell = (system, matchingSystem) =>  ({
-    title: <Link to={{ pathname: `/systems/${matchingSystem.id}` }}>
-        { system.display_name || matchingSystem.name }
-    </Link>,
+    title: <TextContent>
+        <Link to={{ pathname: `/systems/${matchingSystem.id}` }}>
+            { system.display_name || matchingSystem.name }
+        </Link>
+        { matchingSystem.osMajorVersion && matchingSystem.osMinorVersion &&
+            <Text component={TextVariants.small}>RHEL {matchingSystem.osMajorVersion}.{matchingSystem.osMinorVersion}</Text> }
+    </TextContent>,
     exportValue: system.display_name || matchingSystem.name
 });
 

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -332,15 +332,17 @@ Array [
         },
         "display_name": Object {
           "exportValue": "demo.lobatolan.home",
-          "title": <Link
-            to={
-              Object {
-                "pathname": "/systems/d5bc2459-21ce-4d11-bc0b-03ea7513dfa6",
+          "title": <TextContent>
+            <Link
+              to={
+                Object {
+                  "pathname": "/systems/d5bc2459-21ce-4d11-bc0b-03ea7513dfa6",
+                }
               }
-            }
-          >
-            demo.lobatolan.home
-          </Link>,
+            >
+              demo.lobatolan.home
+            </Link>
+          </TextContent>,
         },
         "last_scanned": Object {
           "title": <DateFormat


### PR DESCRIPTION
This takes the OS from compliance's DB and puts it as a subtitle under
the Host name as the mocks indicate.

![Screenshot from 2020-07-02 09-40-39](https://user-images.githubusercontent.com/598891/86330806-7e3fd080-bc48-11ea-86fd-8408d736b836.png)
