### PR TITLE
Pass react redux to inventory loader as well

### DIFF
--- a/src/SmartComponents/InventoryDetails/InventoryDetails.js
+++ b/src/SmartComponents/InventoryDetails/InventoryDetails.js
@@ -2,6 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import * as reactRouterDom from 'react-router-dom';
 import * as reactCore from '@patternfly/react-core';
+import * as ReactRedux from 'react-redux';
 import * as reactIcons from '@patternfly/react-icons';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components';
 import registryDecorator from '@redhat-cloud-services/frontend-components-utilities/files/Registry';
@@ -23,6 +24,7 @@ class InventoryDetails extends React.Component {
             inventoryConnector,
             mergeWithDetail
         } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             reactCore,

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -4,6 +4,7 @@ import * as reactRouterDom from 'react-router-dom';
 import * as reactCore from '@patternfly/react-core';
 import * as reactIcons from '@patternfly/react-icons';
 import * as pfReactTable from '@patternfly/react-table';
+import * as ReactRedux from 'react-redux';
 import { withApollo } from '@apollo/react-hoc';
 import { connect } from 'react-redux';
 import gql from 'graphql-tag';
@@ -238,6 +239,7 @@ class SystemsTable extends React.Component {
             INVENTORY_ACTION_TYPES,
             mergeWithEntities
         } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             reactCore,


### PR DESCRIPTION
We are working on inventory refactoring, since we'd like to fully use hooks and such we have to use App's react dependency. With this being used react-redux needs to be passed from application as well. If you are cautious about the size of your bundle I can pick only the functions really required by inventory.