### PR TITLE
Add config for local chrome

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 DEFAULT_HOST=ci.foo.redhat.com
 HOT_RELOAD='false'
 
+# Enable/uncomment this to run chrome locally
+# CHROME_DIR=../insights-chrome
+# LOCAL_CHROME=true
+
 LOCAL_API='true'
 # API_PORT=''
 # API_HOST=''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,25 @@ services:
     frontend:
         env_file: .env
         build: .
+        image: compliance-frontend_frontend
         ports:
             - 8002:8002
         volumes:
             - .:/frontend:z
             - /frontend/node_modules
+
+    # Enable/uncomment this if you want to run chrome locally
+    # chrome:
+    #     env_file: .env
+    #     image: compliance-frontend_frontend
+    #     working_dir: /insights-chrome
+    #     entrypoint: /bin/sh
+    #     command: -c '
+    #         npm ci;
+    #         npm run start'
+    #     volumes:
+    #         - ${CHROME_DIR}:/insights-chrome:z
+    #         - /insights-chrome/node_modules
 
     proxy:
         env_file: .env
@@ -15,3 +29,4 @@ services:
         network_mode: host
         volumes:
           - ./config/spandx.config.js:/config/spandx.config.js:z
+          # - ${CHROME_DIR}/build:/chrome:z # local chrome


### PR DESCRIPTION
Chrome uses the same image with npm installed as the frontend; we just run `npm ci` to clear out the node_modules and install chrome's.