### PR TITLE
RHICOMPL-604 - Update "no systems" warning on systems tab

### DIFF
--- a/src/PresentationalComponents/NoSystemsTableBody/NoSystemsTableBody.js
+++ b/src/PresentationalComponents/NoSystemsTableBody/NoSystemsTableBody.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+    EmptyStateBody, EmptyState, EmptyStateVariant, Text, TextContent, TextVariants, Title, Bullseye
+} from '@patternfly/react-core';
+import {
+    ExclamationTriangleIcon
+} from '@patternfly/react-icons';
+import {
+    WARNING_TEXT
+} from 'PresentationalComponents';
+
+const NoSystemsTableBody = () => (
+    <Bullseye>
+        <EmptyState variant={ EmptyStateVariant.full }>
+            <Title headingLevel="h2" size='lg' style={ { fontWeight: 'bold' }}>
+                No systems on this policy
+            </Title>
+            <EmptyStateBody>
+                <TextContent>
+                    <Text component={ TextVariants.p }>
+                        Add systems to this policy from the systems page
+                    </Text>
+                    <Text style={ { color: 'var(--pf-global--warning-color--100)' }}>
+                        <ExclamationTriangleIcon /> { WARNING_TEXT }
+                    </Text>
+                </TextContent>
+            </EmptyStateBody>
+        </EmptyState>
+    </Bullseye>
+);
+
+export default NoSystemsTableBody;

--- a/src/PresentationalComponents/NoSystemsTableBody/NoSystemsTableBody.test.js
+++ b/src/PresentationalComponents/NoSystemsTableBody/NoSystemsTableBody.test.js
@@ -1,0 +1,11 @@
+import NoSystemsTableBody from './NoSystemsTableBody';
+
+describe('NoSystemsTableBody', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <NoSystemsTableBody />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/NoSystemsTableBody/__snapshots__/NoSystemsTableBody.test.js.snap
+++ b/src/PresentationalComponents/NoSystemsTableBody/__snapshots__/NoSystemsTableBody.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoSystemsTableBody expect to render without error 1`] = `
+<Bullseye>
+  <EmptyState
+    variant="full"
+  >
+    <Title
+      headingLevel="h2"
+      size="lg"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      No systems on this policy
+    </Title>
+    <EmptyStateBody>
+      <TextContent>
+        <Text
+          component="p"
+        >
+          Add systems to this policy from the systems page
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "var(--pf-global--warning-color--100)",
+            }
+          }
+        >
+          <ExclamationTriangleIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+           
+          Policies without systems will not have reports.
+        </Text>
+      </TextContent>
+    </EmptyStateBody>
+  </EmptyState>
+</Bullseye>
+`;

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -16,3 +16,4 @@ export { default as TabSwitcher, Tab } from './TabSwitcher/TabSwitcher';
 export { StateView, StateViewWithError, StateViewPart } from './StateView/StateView';
 export { default as SystemsCountWarning, WARNING_TEXT } from './SystemsCountWarning/SystemsCountWarning';
 export { default as WarningText } from './WarningText/WarningText';
+export { default as NoSystemsTableBody } from './NoSystemsTableBody/NoSystemsTableBody';

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -19,7 +19,7 @@ import  {
     AssignPoliciesModal
 } from 'SmartComponents';
 import {
-    WARNING_TEXT
+    NoSystemsTableBody
 } from 'PresentationalComponents';
 
 import { exportFromState, selectAll, clearSelection, SELECT_ENTITY } from 'Store/ActionTypes';
@@ -345,15 +345,19 @@ class SystemsTable extends React.Component {
             noError = true;
         }
 
+        if (!showAllSystems && total === 0) {
+            inventoryTableProps.tableProps.rows = [{ cells: [{ title: <NoSystemsTableBody /> }] }];
+            inventoryTableProps.tableProps.columns = [];
+            inventoryTableProps.hasItems = false;
+            inventoryTableProps.hasCheckbox = false;
+        }
+
         return <React.Fragment>
             <StateView stateValues={{ error, noError }}>
                 <StateViewPart stateKey='error'>
                     <ErrorPage error={error}/>
                 </StateViewPart>
                 <StateViewPart stateKey='noError'>
-                    { !showAllSystems && total === 0 &&
-                        <reactCore.Alert variant="warning" isInline title={ WARNING_TEXT } />
-                    }
                     <InventoryCmp { ...inventoryTableProps }>
                         { !showAllSystems && <reactCore.ToolbarGroup>
                             { remediationsEnabled &&

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -526,11 +526,6 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
     <StateViewPart
       stateKey="noError"
     >
-      <Alert
-        isInline={true}
-        title="Policies without systems will not have reports."
-        variant="warning"
-      />
       <ForwardRef
         actions={
           Array [
@@ -580,6 +575,8 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
             ],
           }
         }
+        hasCheckbox={false}
+        hasItems={false}
         items={
           Array [
             1,
@@ -591,6 +588,16 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
         tableProps={
           Object {
             "canSelectAll": false,
+            "columns": Array [],
+            "rows": Array [
+              Object {
+                "cells": Array [
+                  Object {
+                    "title": <NoSystemsTableBody />,
+                  },
+                ],
+              },
+            ],
           }
         }
         total={0}
@@ -640,11 +647,6 @@ exports[`SystemsTable expect to set isDisable on export config to true total is 
     <StateViewPart
       stateKey="noError"
     >
-      <Alert
-        isInline={true}
-        title="Policies without systems will not have reports."
-        variant="warning"
-      />
       <ForwardRef
         actions={
           Array [
@@ -694,6 +696,8 @@ exports[`SystemsTable expect to set isDisable on export config to true total is 
             ],
           }
         }
+        hasCheckbox={false}
+        hasItems={false}
         items={
           Array [
             1,
@@ -705,6 +709,16 @@ exports[`SystemsTable expect to set isDisable on export config to true total is 
         tableProps={
           Object {
             "canSelectAll": false,
+            "columns": Array [],
+            "rows": Array [
+              Object {
+                "cells": Array [
+                  Object {
+                    "title": <NoSystemsTableBody />,
+                  },
+                ],
+              },
+            ],
           }
         }
         total={0}

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -236,7 +236,7 @@ export const entitiesReducer = (INVENTORY_ACTION, columns, showAllSystems, profi
                 state.selectedEntities
             ),
             total: !showAllSystems ? state.systemsCount : state.total,
-            columns
+            columns: state.total > 0 ? columns : [{ title: '' }]
         }),
         [EXPORT]: (state, { payload: { format } }) => {
             exportFromState(state, format);


### PR DESCRIPTION
This updates the warning for policies with no systems on the systems tab in the details according to the mockups:
![Screenshot 2020-07-23 at 17 53 34](https://user-images.githubusercontent.com/7757/88308605-89e55b00-cd0d-11ea-8b1a-09fd2ad6f394.png)

**Note:** The mockups mention another way to add systems, which is not yet available. Once that changes the copy in this table will be updated as well.