### PR TITLE
Increase ESI socket timeout to 5 seconds

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,5 +1,8 @@
 /*global module*/
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const goodGuyLib = require('good-guy-http');
+
 const envWithDefault = function (envVar, defaultVar) {
     return process.env[envVar] ? process.env[envVar] : defaultVar;
 };
@@ -49,4 +52,12 @@ if (LOCAL_INVENTORY) {
     routes[`/api/inventory/v1/hosts`] = { host: `http://${INVENTORY_HOST}:${INVENTORY_PORT}` };
 }
 
-module.exports = { routes };
+const esi = {
+    // Increases the default (2s) timeout which can be a pain sometimes.
+    // https://github.com/Schibsted-Tech-Polska/good-guy-http/blob/master/lib/index.js#L55
+    httpClient: goodGuyLib({
+        timeout: 5000
+    })
+};
+
+module.exports = { routes, esi };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2195,6 +2195,12 @@
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.6.tgz",
       "integrity": "sha512-y4+DuXrAd1W5UIY3zTcsosi/1GyYT8k5jGnZ/wG7UUHVrU+MHlH4Mp87KK2/lvMW4+H7HVcdB+aJhqywgXksjA=="
     },
+    "@schibstedpl/circuit-breaker-js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@schibstedpl/circuit-breaker-js/-/circuit-breaker-js-0.0.2.tgz",
+      "integrity": "sha512-82fEbDRVsEAO/XlaFsGb5GKoAMvlfOd/hiNxyPWMvd1ZYJxxHs8hAu4i5Jrlcgpf1sUhhgV53oJSHNwyThsVFQ==",
+      "dev": true
+    },
     "@sentry/browser": {
       "version": "5.18.1",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.18.1.tgz",
@@ -4043,6 +4049,12 @@
       "integrity": "sha512-QzPRKDCyp7RhjczTPZaqK3CjPA5Ht2UnXhZhCI4f7QiB5JK6KEuZBxIzyWnB3wO4hgAj4GMRxAhuiacfw0Psjg==",
       "dev": true
     },
+    "capitalize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-1.0.0.tgz",
+      "integrity": "sha1-3IAsWAruEBkpAg0soUtMqKCuRL4=",
+      "dev": true
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -4336,6 +4348,12 @@
           }
         }
       }
+    },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -7169,6 +7187,104 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "good-guy-http": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/good-guy-http/-/good-guy-http-1.13.0.tgz",
+      "integrity": "sha512-fpDn6FWJbgzZZD1LIow/dUNCDGGCVP6rIGloRmSZAuR2mVv7qXHcKbBsdc3DXac6jb4eqf53glo7I91oPfPneg==",
+      "dev": true,
+      "requires": {
+        "@schibstedpl/circuit-breaker-js": "0.0.2",
+        "capitalize": "^1.0.0",
+        "clone": "2.1.1",
+        "request": "2.87.0",
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -15515,6 +15631,12 @@
           "dev": true
         }
       }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
     },
     "unherit": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "eslint-plugin-react": "^7.19.0",
     "file-loader": "^1.1.11",
     "git-revision-webpack-plugin": "^3.0.6",
+    "good-guy-http": "^1.13.0",
     "html-replace-webpack-plugin": "^2.5.3",
     "html-webpack-plugin": "^3.2.0",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
@bastilian Over a satellite connection, 2 seconds is too short to accommodate the latency (~1200ms round trip). If the ESIs time out, then `window.insights` is undefined, like we've seen in my environment.

Signed-off-by: Andrew Kofink <akofink@redhat.com>