### PR TITLE
RHICOMPL-604 - Only show warning for no systems on details page

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -8,6 +8,7 @@ import * as ReactRedux from 'react-redux';
 import { withApollo } from '@apollo/react-hoc';
 import { connect } from 'react-redux';
 import gql from 'graphql-tag';
+import { pickBy } from 'lodash';
 import {
     SkeletonTable
 } from '@redhat-cloud-services/frontend-components';
@@ -90,6 +91,10 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
 }
 `;
 
+const initFilterState = (filterConfig) => (
+    pickBy(filterConfig.initialDefaultState(), (value) => (!!value))
+);
+
 const initialState = {
     page: 1
 };
@@ -110,7 +115,7 @@ class SystemsTable extends React.Component {
         policyId: this.props.policyId,
         perPage: 50,
         totalCount: 0,
-        activeFilters: this.filterConfig.initialDefaultState()
+        activeFilters: initFilterState(this.filterConfig)
     }
 
     componentDidMount = () => {
@@ -214,7 +219,7 @@ class SystemsTable extends React.Component {
     clearAllFilter = () => {
         this.setState({
             ...initialState,
-            activeFilters: this.filterConfig.initialDefaultState()
+            activeFilters: initFilterState(this.filterConfig)
         }, this.updateSystems);
     }
 
@@ -273,13 +278,13 @@ class SystemsTable extends React.Component {
             selectedEntities, systems, total, policyId
         } = this.props;
         const {
-            page, perPage, InventoryCmp, selectedSystemId,
+            page, perPage, InventoryCmp, selectedSystemId, activeFilters,
             selectedSystemFqdn, isAssignPoliciesModalOpen, error
         } = this.state;
         let noError;
         const filterConfig = this.filterConfig.buildConfiguration(
             this.onFilterUpdate,
-            this.state.activeFilters,
+            activeFilters,
             { hideLabel: true }
         );
         const filterChips = this.chipBuilder.chipsFor(this.state.activeFilters);
@@ -345,7 +350,7 @@ class SystemsTable extends React.Component {
             noError = true;
         }
 
-        if (policyId && total === 0) {
+        if (policyId && total === 0 && Object.keys(activeFilters).length === 0) {
             inventoryTableProps.tableProps.rows = [{ cells: [{ title: <NoSystemsTableBody /> }] }];
             inventoryTableProps.tableProps.columns = [];
             inventoryTableProps.hasItems = false;

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -270,7 +270,7 @@ class SystemsTable extends React.Component {
     render() {
         const {
             remediationsEnabled, compact, enableExport, showAllSystems, showActions,
-            selectedEntities, systems, total
+            selectedEntities, systems, total, policyId
         } = this.props;
         const {
             page, perPage, InventoryCmp, selectedSystemId,
@@ -345,7 +345,7 @@ class SystemsTable extends React.Component {
             noError = true;
         }
 
-        if (!showAllSystems && total === 0) {
+        if (policyId && total === 0) {
             inventoryTableProps.tableProps.rows = [{ cells: [{ title: <NoSystemsTableBody /> }] }];
             inventoryTableProps.tableProps.columns = [];
             inventoryTableProps.hasItems = false;

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -575,8 +575,6 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
             ],
           }
         }
-        hasCheckbox={false}
-        hasItems={false}
         items={
           Array [
             1,
@@ -588,16 +586,6 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
         tableProps={
           Object {
             "canSelectAll": false,
-            "columns": Array [],
-            "rows": Array [
-              Object {
-                "cells": Array [
-                  Object {
-                    "title": <NoSystemsTableBody />,
-                  },
-                ],
-              },
-            ],
           }
         }
         total={0}
@@ -696,8 +684,6 @@ exports[`SystemsTable expect to set isDisable on export config to true total is 
             ],
           }
         }
-        hasCheckbox={false}
-        hasItems={false}
         items={
           Array [
             1,
@@ -709,16 +695,6 @@ exports[`SystemsTable expect to set isDisable on export config to true total is 
         tableProps={
           Object {
             "canSelectAll": false,
-            "columns": Array [],
-            "rows": Array [
-              Object {
-                "cells": Array [
-                  Object {
-                    "title": <NoSystemsTableBody />,
-                  },
-                ],
-              },
-            ],
           }
         }
         total={0}

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -8,7 +8,6 @@ Object {
     "70-89",
     "90-100",
   ],
-  "name": "",
 }
 `;
 
@@ -20,7 +19,6 @@ Object {
     "70-89",
     "90-100",
   ],
-  "name": "",
 }
 `;
 
@@ -29,7 +27,6 @@ Object {
   "compliant": Array [
     "false",
   ],
-  "name": "",
 }
 `;
 
@@ -38,15 +35,10 @@ Object {
   "compliant": Array [
     "false",
   ],
-  "name": "",
 }
 `;
 
-exports[`SystemsTable Instance functions #onFilterUpdate set search in state properly 1`] = `
-Object {
-  "name": "",
-}
-`;
+exports[`SystemsTable Instance functions #onFilterUpdate set search in state properly 1`] = `Object {}`;
 
 exports[`SystemsTable Instance functions #onFilterUpdate set search in state properly 2`] = `
 Object {
@@ -54,11 +46,7 @@ Object {
 }
 `;
 
-exports[`SystemsTable Instance functions #onFilterUpdate set search in state properly 3`] = `
-Object {
-  "name": "",
-}
-`;
+exports[`SystemsTable Instance functions #onFilterUpdate set search in state properly 3`] = `Object {}`;
 
 exports[`SystemsTable Instance functions #onFilterUpdate set search in state properly 4`] = `
 Object {
@@ -67,7 +55,6 @@ Object {
     "50-69",
     "90-100",
   ],
-  "name": "",
 }
 `;
 
@@ -129,7 +116,7 @@ exports[`SystemsTable expect to not render a loading state 1`] = `
               Object {
                 "filterValues": Object {
                   "onChange": [Function],
-                  "value": "",
+                  "value": undefined,
                 },
                 "id": "name",
                 "label": "Name",
@@ -219,7 +206,7 @@ exports[`SystemsTable expect to not show actions if showActions is false 1`] = `
               Object {
                 "filterValues": Object {
                   "onChange": [Function],
-                  "value": "",
+                  "value": undefined,
                 },
                 "id": "name",
                 "label": "Name",
@@ -321,7 +308,7 @@ exports[`SystemsTable expect to render a loading state 1`] = `
               Object {
                 "filterValues": Object {
                   "onChange": [Function],
-                  "value": "",
+                  "value": undefined,
                 },
                 "id": "name",
                 "label": "Name",
@@ -418,7 +405,7 @@ exports[`SystemsTable expect to set compliant filters when enabled 1`] = `
               Object {
                 "filterValues": Object {
                   "onChange": [Function],
-                  "value": "",
+                  "value": undefined,
                 },
                 "id": "name",
                 "label": "Name",
@@ -566,7 +553,7 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
               Object {
                 "filterValues": Object {
                   "onChange": [Function],
-                  "value": "",
+                  "value": undefined,
                 },
                 "id": "name",
                 "label": "Name",
@@ -675,7 +662,7 @@ exports[`SystemsTable expect to set isDisable on export config to true total is 
               Object {
                 "filterValues": Object {
                   "onChange": [Function],
-                  "value": "",
+                  "value": undefined,
                 },
                 "id": "name",
                 "label": "Name",
@@ -777,7 +764,7 @@ exports[`SystemsTable expect to set loading state correctly on updateSystems 1`]
               Object {
                 "filterValues": Object {
                   "onChange": [Function],
-                  "value": "",
+                  "value": undefined,
                 },
                 "id": "name",
                 "label": "Name",
@@ -874,7 +861,7 @@ exports[`SystemsTable expect to show actions if showActions is true or by defaul
               Object {
                 "filterValues": Object {
                   "onChange": [Function],
-                  "value": "",
+                  "value": undefined,
                 },
                 "id": "name",
                 "label": "Name",


### PR DESCRIPTION
This fixes the issue with the no systems warning showing up on other pages then the policy details systems tab.