### PR TITLE
RHICOMPL-667 - Enable policy filter on systems page

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -1,8 +1,26 @@
 import React from 'react';
-import { SystemsTable } from 'SmartComponents';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
 import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/frontend-components';
+import { StateViewPart, StateViewWithError } from 'PresentationalComponents';
+import { SystemsTable } from 'SmartComponents';
+
+const QUERY = gql`
+{
+    profiles(search: "external = false and canonical = false") {
+        edges {
+            node {
+                id
+                name
+                refId
+            }
+        }
+    }
+}
+`;
 
 export const ComplianceSystems = () => {
+    const { data, error, loading } = useQuery(QUERY);
     const columns = [{
         key: 'display_name',
         title: 'Name',
@@ -22,6 +40,10 @@ export const ComplianceSystems = () => {
             width: 20, isStatic: true
         }
     }];
+    let policies;
+    if (data) {
+        policies = data?.profiles?.edges.map((e) => (e.node));
+    }
 
     return (
         <React.Fragment>
@@ -29,7 +51,14 @@ export const ComplianceSystems = () => {
                 <PageHeaderTitle title="Compliance systems" />
             </PageHeader>
             <Main>
-                <SystemsTable showAllSystems remediationsEnabled={false} columns={columns} />
+                <StateViewWithError stateValues={ { error, data, loading } }>
+                    <StateViewPart stateKey="data">
+                        { policies && <SystemsTable
+                            remediationsEnabled={ false }
+                            columns={ columns }
+                            policies={ policies } /> }
+                    </StateViewPart>
+                </StateViewWithError>
             </Main>
         </React.Fragment>
     );

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -23,7 +23,7 @@ const QUERY = gql`
 export const ComplianceSystems = () => {
     const { data, error, loading } = useQuery(QUERY);
     const columns = [{
-        key: 'display_name',
+        key: 'facts.compliance.display_name',
         title: 'Name',
         props: {
             width: 40, isStatic: true

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -13,6 +13,7 @@ const QUERY = gql`
                 id
                 name
                 refId
+                majorOsVersion
             }
         }
     }
@@ -54,6 +55,7 @@ export const ComplianceSystems = () => {
                 <StateViewWithError stateValues={ { error, data, loading } }>
                     <StateViewPart stateKey="data">
                         { policies && <SystemsTable
+                            showOsFilter
                             remediationsEnabled={ false }
                             columns={ columns }
                             policies={ policies } /> }

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.test.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.test.js
@@ -1,5 +1,11 @@
 import { ComplianceSystems } from './ComplianceSystems.js';
 
+jest.mock('@apollo/react-hooks', () => ({
+    useQuery: () => (
+        { data: [], error: undefined, loading: undefined }
+    )
+}));
+
 describe('ComplianceSystems', () => {
     it('expect to render without error', () => {
         const wrapper = shallow(

--- a/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
+++ b/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
@@ -10,38 +10,19 @@ exports[`ComplianceSystems expect to render without error 1`] = `
     />
   </PageHeader>
   <Connect(Main)>
-    <Connect(withApollo(ConnectedSystemsTable))
-      columns={
-        Array [
-          Object {
-            "key": "display_name",
-            "props": Object {
-              "isStatic": true,
-              "width": 40,
-            },
-            "title": "Name",
-          },
-          Object {
-            "key": "facts.compliance.policies",
-            "props": Object {
-              "isStatic": true,
-              "width": 40,
-            },
-            "title": "Policies",
-          },
-          Object {
-            "key": "facts.compliance.details_link",
-            "props": Object {
-              "isStatic": true,
-              "width": 20,
-            },
-            "title": "",
-          },
-        ]
+    <StateViewWithError
+      stateValues={
+        Object {
+          "data": Array [],
+          "error": undefined,
+          "loading": undefined,
+        }
       }
-      remediationsEnabled={false}
-      showAllSystems={true}
-    />
+    >
+      <StateViewPart
+        stateKey="data"
+      />
+    </StateViewWithError>
   </Connect(Main)>
 </Fragment>
 `;

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -28,7 +28,8 @@ import { systemsWithRuleObjectsFailed } from 'Utilities/ruleHelpers';
 import { FilterConfigBuilder } from '@redhat-cloud-services/frontend-components-inventory-compliance';
 import { entitiesReducer } from 'Store/Reducers/SystemStore';
 import {
-    DEFAULT_SYSTEMS_FILTER_CONFIGURATION, COMPLIANT_SYSTEMS_FILTER_CONFIGURATION
+    DEFAULT_SYSTEMS_FILTER_CONFIGURATION, COMPLIANT_SYSTEMS_FILTER_CONFIGURATION,
+    systemsPolicyFilterConfiguration
 } from '@/constants';
 import {
     ErrorPage,
@@ -104,7 +105,8 @@ class SystemsTable extends React.Component {
     inventory = React.createRef();
     filterConfig = new FilterConfigBuilder([
         ...DEFAULT_SYSTEMS_FILTER_CONFIGURATION,
-        ...(this.props.compliantFilter ? COMPLIANT_SYSTEMS_FILTER_CONFIGURATION : [])
+        ...(this.props.compliantFilter ? COMPLIANT_SYSTEMS_FILTER_CONFIGURATION : []),
+        ...(this.props.policies ? systemsPolicyFilterConfiguration(this.props.policies) : [])
     ]);
     chipBuilder = this.filterConfig.getChipBuilder();
     filterBuilder = this.filterConfig.getFilterBuilder();
@@ -412,6 +414,7 @@ SystemsTable.propTypes = {
     enableExport: propTypes.bool,
     error: propTypes.object,
     exportFromState: propTypes.func,
+	policies: propTypes.array,
     policyId: propTypes.string,
     preselectedSystems: propTypes.array,
     remediationsEnabled: propTypes.bool,

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -100,14 +100,19 @@ const initialState = {
     page: 1
 };
 
+const policyFilter = (policies, osFilter) => ([
+    ...systemsPolicyFilterConfiguration(policies),
+    ...(osFilter ? systemsOsFilterConfiguration(policies) : [])
+]);
+
 @registry()
 class SystemsTable extends React.Component {
     inventory = React.createRef();
     filterConfig = new FilterConfigBuilder([
         ...DEFAULT_SYSTEMS_FILTER_CONFIGURATION,
         ...(this.props.compliantFilter ? COMPLIANT_SYSTEMS_FILTER_CONFIGURATION : []),
-        ...(this.props.policies ? systemsPolicyFilterConfiguration(this.props.policies) : []),
-        ...(this.props.policies && this.props.showOsFilter ? systemsOsFilterConfiguration(this.props.policies) : [])
+        ...(this.props.policies && this.props.policies.length > 0 ?
+            policyFilter(this.props.policies, this.props.showOsFilter) : [])
     ]);
     chipBuilder = this.filterConfig.getChipBuilder();
     filterBuilder = this.filterConfig.getFilterBuilder();

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -29,7 +29,7 @@ import { FilterConfigBuilder } from '@redhat-cloud-services/frontend-components-
 import { entitiesReducer } from 'Store/Reducers/SystemStore';
 import {
     DEFAULT_SYSTEMS_FILTER_CONFIGURATION, COMPLIANT_SYSTEMS_FILTER_CONFIGURATION,
-    systemsPolicyFilterConfiguration
+    systemsPolicyFilterConfiguration, systemsOsFilterConfiguration
 } from '@/constants';
 import {
     ErrorPage,
@@ -106,7 +106,8 @@ class SystemsTable extends React.Component {
     filterConfig = new FilterConfigBuilder([
         ...DEFAULT_SYSTEMS_FILTER_CONFIGURATION,
         ...(this.props.compliantFilter ? COMPLIANT_SYSTEMS_FILTER_CONFIGURATION : []),
-        ...(this.props.policies ? systemsPolicyFilterConfiguration(this.props.policies) : [])
+        ...(this.props.policies ? systemsPolicyFilterConfiguration(this.props.policies) : []),
+        ...(this.props.policies && this.props.showOsFilter ? systemsOsFilterConfiguration(this.props.policies) : [])
     ]);
     chipBuilder = this.filterConfig.getChipBuilder();
     filterBuilder = this.filterConfig.getFilterBuilder();
@@ -414,7 +415,7 @@ SystemsTable.propTypes = {
     enableExport: propTypes.bool,
     error: propTypes.object,
     exportFromState: propTypes.func,
-	policies: propTypes.array,
+    policies: propTypes.array,
     policyId: propTypes.string,
     preselectedSystems: propTypes.array,
     remediationsEnabled: propTypes.bool,
@@ -424,6 +425,7 @@ SystemsTable.propTypes = {
     showActions: propTypes.bool,
     showAllSystems: propTypes.bool,
     showOnlySystemsWithTestResults: propTypes.bool,
+    showOsFilter: propTypes.bool,
     store: propTypes.object,
     systems: propTypes.array,
     total: propTypes.number,

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,6 +19,16 @@ export const DEFAULT_SYSTEMS_FILTER_CONFIGURATION = [
     }
 ];
 
+export const systemsPolicyFilterConfiguration = (policies) => ([{
+    type: conditionalFilterType.checkbox,
+    label: 'Policy',
+    filterString: (value) => (`profile_id = ${value}`),
+    items: policies.map((policy) => ({
+        label: policy.name,
+        value: policy.id
+    }))
+}]);
+
 export const COMPLIANT_SYSTEMS_FILTER_CONFIGURATION = [
     {
         type: conditionalFilterType.checkbox,

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,6 +29,22 @@ export const systemsPolicyFilterConfiguration = (policies) => ([{
     }))
 }]);
 
+const majorOsVersionsFromProfiles = (policies) => (
+    Array.from(new Set(policies.map((profile) => (
+        profile.majorOsVersion
+    ))))
+);
+
+export const systemsOsFilterConfiguration = (policies) => ([{
+    type: conditionalFilterType.checkbox,
+    label: 'Operating system',
+    filterString: (value) => (`os_major_version = ${value}`),
+    items: majorOsVersionsFromProfiles(policies).map(osVersion => ({
+        label: `RHEL ${osVersion}`,
+        value: osVersion
+    }))
+}]);
+
 export const COMPLIANT_SYSTEMS_FILTER_CONFIGURATION = [
     {
         type: conditionalFilterType.checkbox,


### PR DESCRIPTION
This enables filters on the Systems page for policy:
![Screenshot 2020-08-31 at 17 10 21](https://user-images.githubusercontent.com/7757/91735684-ed846300-ebac-11ea-95a4-25360352c578.png)

and operating systems:
![Screenshot 2020-08-31 at 17 10 31](https://user-images.githubusercontent.com/7757/91735687-eeb59000-ebac-11ea-85ce-2f8c2467b2d7.png)
