### PR TITLE
[RHICOMPL-831] Enable filename hashing only on production envs

### DIFF
--- a/config/base.webpack.config.js
+++ b/config/base.webpack.config.js
@@ -25,10 +25,10 @@ const webpackConfig = {
         App: config.paths.entry
     },
     output: {
-        filename: 'js/[name]-[contenthash].js',
+        filename: process.env.NODE_ENV === 'production' ? 'js/[name]-[contenthash].js' : 'js/[name].js',
         path: config.paths.public,
         publicPath: config.paths.publicPath,
-        chunkFilename: 'js/[name]-[contenthash].js'
+        chunkFilename: process.env.NODE_ENV === 'production' ? 'js/[name]-[contenthash].js' : 'js/[name].js'
     },
     resolve: {
         alias: {
@@ -70,7 +70,7 @@ const webpackConfig = {
             use: [{
                 loader: 'file-loader',
                 options: {
-                    name: '[name]-[contenthash].[ext]',
+                    name: process.env.NODE_ENV === 'production' ? '[name]-[contenthash].[ext]' : '[name].[ext]',
                     outputPath: 'fonts/'
                 }
             }]

--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -37,7 +37,7 @@ plugins.push(HtmlWebpackPlugin);
 const SourceMapsPlugin = new webpack.SourceMapDevToolPlugin({
     test: /\.js/i,
     exclude: /(node_modules|bower_components)/i,
-    filename: `sourcemaps/[name]-[contenthash].js.map`
+    filename: process.env.NODE_ENV === 'production' ? `sourcemaps/[name]-[contenthash].js.map` : `sourcemaps/[name].js.map`
 });
 plugins.push(SourceMapsPlugin);
 
@@ -76,8 +76,8 @@ plugins.push(LodashWebpackPlugin);
  * Writes final css to file
  */
 const ExtractCssWebpackPlugin = new (require('mini-css-extract-plugin'))({
-    chunkFilename: 'css/[name]-[contenthash].css',
-    filename: 'css/[name]-[contenthash].css'
+    chunkFilename: process.env.NODE_ENV === 'production' ? 'css/[name]-[contenthash].css' : 'css/[name].css',
+    filename: process.env.NODE_ENV === 'production' ? 'css/[name]-[contenthash].css' : 'css/[name].css'
 });
 plugins.push(ExtractCssWebpackPlugin);
 


### PR DESCRIPTION
In development the hashing introduces a noticeable lag when it rebuilds.
This will only enable it in production environments.