### PR TITLE
[RHICOMPL-574] Fix issues with versions containing 0

### DIFF
--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -81,12 +81,18 @@ export const policiesCell = (system) => {
     };
 };
 
+export const hasOsInfo = (matchingSystem) => (
+    typeof(matchingSystem.osMajorVersion) !== 'undefined' && typeof(matchingSystem.osMinorVersion) !== 'undefined' &&
+        matchingSystem.osMajorVersion !== null && matchingSystem.osMinorVersion !== null &&
+        !(matchingSystem.osMajorVersion === 0 && matchingSystem.osMinorVersion === 0)
+);
+
 const displayNameCell = (system, matchingSystem) =>  ({
     title: <TextContent>
         { matchingSystem.name ? <Link to={{ pathname: `/systems/${matchingSystem.id}` }}>
             { matchingSystem.name }
         </Link> : system.display_name }
-        { matchingSystem.osMajorVersion && matchingSystem.osMinorVersion &&
+        { hasOsInfo(matchingSystem) &&
             <Text component={TextVariants.small}>RHEL {matchingSystem.osMajorVersion}.{matchingSystem.osMinorVersion}</Text> }
     </TextContent>,
     exportValue: system.display_name || matchingSystem.name

--- a/src/store/Reducers/SystemStore.test.js
+++ b/src/store/Reducers/SystemStore.test.js
@@ -1,7 +1,8 @@
 import {
-    lastScanned,
     compliant,
     findProfiles,
+    hasOsInfo,
+    lastScanned,
     profileNames,
     systemsToInventoryEntities
 } from './SystemStore';
@@ -153,3 +154,36 @@ describe('.profileNames', () => {
     });
 });
 
+describe('hasOsInfo', () => {
+    it('return true for 7.3', () => {
+        const result = hasOsInfo({
+            osMajorVersion: 7,
+            osMinorVersion: 3
+        });
+        expect(result).toEqual(true);
+    });
+
+    it('return true for 8.0', () => {
+        const result = hasOsInfo({
+            osMajorVersion: 8,
+            osMinorVersion: 0
+        });
+        expect(result).toEqual(true);
+    });
+
+    it('return false for both versions being 0', () => {
+        const result = hasOsInfo({
+            osMajorVersion: 0,
+            osMinorVersion: 0
+        });
+        expect(result).toEqual(false);
+    });
+
+    it('return false for version being null', () => {
+        const result = hasOsInfo({
+            osMajorVersion: null,
+            osMinorVersion: null
+        });
+        expect(result).toEqual(false);
+    });
+});


### PR DESCRIPTION
There were issues with how the conditions got interpreted with `&&`.

With version numbers like `8.0` it would show just `0`.
This fixes these issues and OS information is correctly shown.
