### PR TITLE
[RHICOMPL-742] Always update state for selected entities

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -37,12 +37,10 @@ export const EditPolicy = () => {
     ];
 
     useEffect(() => {
-        if (selectedEntities) {
-            setUpdatedPolicy({
-                ...updatedPolicy,
-                hosts: selectedEntities
-            });
-        }
+        setUpdatedPolicy({
+            ...updatedPolicy,
+            hosts: selectedEntities ? selectedEntities : []
+        });
     }, [selectedEntities]);
 
     useEffect(() => {


### PR DESCRIPTION
When deselecting systems the reducer will set `selectedEntities` to `undefined` when there are no more systems selected.
The `hosts` property for the `updatedPolicy` should still be updated, but set to an empty array.

Best to test:

 1. Create a policy in the wizard assigning only one host
 2. Open the Edit Policy modal and remove the host.

Before this change when only one host is assigned it wouldn't allow to unassign this host.