### PR TITLE
[RHICOMPL-784] Provide Remediations button with proper system nodes

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -288,7 +288,7 @@ class SystemsTable extends React.Component {
     render() {
         const {
             remediationsEnabled, compact, enableExport, showAllSystems, showActions,
-            selectedEntities, systems, total, policyId, enableEditPolicy
+            selectedEntities, selectedEntitiesIds, systems, total, policyId, enableEditPolicy
         } = this.props;
         const {
             page, perPage, InventoryCmp, selectedSystemId, activeFilters,
@@ -381,9 +381,9 @@ class SystemsTable extends React.Component {
                         { remediationsEnabled &&
                             <reactCore.ToolbarItem style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}>
                                 <ComplianceRemediationButton
-                                    allSystems={ systemsWithRuleObjectsFailed(
-                                        systems.filter(edge => selectedEntities.includes(edge.node.id)
-                                        ).map(edge => edge.node))}
+                                    allSystems={ systemsWithRuleObjectsFailed(systems.filter((edge) => (
+                                        selectedEntitiesIds.includes(edge.node.id)
+                                    )).map(edge => edge.node)) }
                                     selectedRules={ [] } />
                             </reactCore.ToolbarItem>
                         }
@@ -428,6 +428,7 @@ SystemsTable.propTypes = {
     selectAll: propTypes.func,
     selectEntities: propTypes.func,
     selectedEntities: propTypes.array,
+    selectedEntitiesIds: propTypes.array,
     showActions: propTypes.bool,
     showAllSystems: propTypes.bool,
     showOnlySystemsWithTestResults: propTypes.bool,
@@ -451,6 +452,7 @@ SystemsTable.defaultProps = {
     showActions: true,
     compliantFilter: false,
     selectedEntities: [],
+    selectedEntitiesIds: [],
     systems: [],
     clearAll: () => ({}),
     exportFromState: () => ({})
@@ -468,6 +470,7 @@ const mapStateToProps = state => {
     return {
         allSelectedOnPage,
         selectedEntities: state.entities.selectedEntities,
+        selectedEntitiesIds: (state.entities.selectedEntities || []).map((e) => (e.id)),
         systems: state.entities.systems,
         total: state.entities.total
     };

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -577,14 +577,7 @@ exports[`SystemsTable expect to set isDisable on export config to false total is
           }
         >
           <Connect(ComplianceRemediationButton)
-            allSystems={
-              Array [
-                Object {
-                  "id": 1,
-                  "ruleObjectsFailed": Array [],
-                },
-              ]
-            }
+            allSystems={Array []}
             selectedRules={Array []}
           />
         </ToolbarItem>


### PR DESCRIPTION
When we fixed issues with selecting systems for exporting, we changed `selectedEntities` from containing only IDs to hold the system nodes and did not adjust the selecting of systems for the Remediations button.

How to test:

 1) Make sure to have a report with systems that have failed rules, which have remediations available
 2) Got a the report details to verify this behaviour:

![Kapture 2020-09-04 at 10 24 32](https://user-images.githubusercontent.com/7757/92218134-f15c0200-ee98-11ea-85e2-df1836c06eff.gif)

Before this the behaviour was broken and the "Remediations" button would stay disabled.

Note: To test this with no remediations imported, the `rulesHelpers.js` can be changed to mock this and test the button still:

```
export const systemsWithRuleObjectsFailed = (systems) => (
    systems.map(system => (
        {
            ruleObjectsFailed: systemRulesFailed(system)
            .map((r) => ({ ...r, remediationAvailable: [true, false][Math.floor(Math.random() * 2)] })),
            ...system
        }
    ))
);
```