### PR TITLE
[RHICOMPL-906] Remove actions from Policy Details completely

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -5,6 +5,7 @@ import { SystemsTable } from 'SmartComponents';
 const PolicySystemsTab = ({ policy, systemTableProps }) => (
     <SystemsTable
         policyId={ policy.id }
+        showActions={ false }
         remediationsEnabled={ false }
         columns={[{
             key: 'facts.compliance.display_name',


### PR DESCRIPTION
RHICOMPL-906 actually instructs to remove the Kebab menu from the policy details completely.

![Screenshot 2020-09-14 at 17 09 05](https://user-images.githubusercontent.com/7757/93103629-2b08e600-f6ad-11ea-86a3-58d0da02512a.png)
