### PR TITLE
[RHICOMPL-732] Default to failed rules on systems detail page

### DIFF
--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -4,7 +4,6 @@ import {
     useQuery
 } from '@apollo/react-hooks';
 import {
-    useLocation,
     useParams
 } from 'react-router-dom';
 import {
@@ -39,8 +38,6 @@ export const SystemDetails = () => {
     const { data, error, loading } = useQuery(QUERY, {
         variables: { inventoryId }
     });
-    const location = useLocation();
-    const hidePassed = location.query && location.query.hidePassed;
     const systemName = data?.system?.name;
 
     return <StateViewWithError stateValues={ { error, data, loading } }>
@@ -56,7 +53,7 @@ export const SystemDetails = () => {
                 <br/>
             </PageHeader>
             <Main>
-                <ComplianceSystemDetails hidePassed={ hidePassed } inventoryId={ inventoryId } />
+                <ComplianceSystemDetails hidePassed inventoryId={ inventoryId } />
             </Main>
         </StateViewPart>
         <StateViewPart stateKey='loading'>

--- a/src/SmartComponents/SystemDetails/__snapshots__/SystemDetails.test.js.snap
+++ b/src/SmartComponents/SystemDetails/__snapshots__/SystemDetails.test.js.snap
@@ -40,7 +40,7 @@ exports[`SystemDetails expect to render a 500 error 1`] = `
     </PageHeader>
     <Connect(Main)>
       <WrappedSystemDetails
-        hidePassed={false}
+        hidePassed={true}
         inventoryId={1}
       />
     </Connect(Main)>
@@ -146,7 +146,7 @@ exports[`SystemDetails expect to render loading 1`] = `
     </PageHeader>
     <Connect(Main)>
       <WrappedSystemDetails
-        hidePassed={false}
+        hidePassed={true}
         inventoryId={1}
       />
     </Connect(Main)>
@@ -199,7 +199,7 @@ exports[`SystemDetails expect to render without error 1`] = `
     </PageHeader>
     <Connect(Main)>
       <WrappedSystemDetails
-        hidePassed={false}
+        hidePassed={true}
         inventoryId={1}
       />
     </Connect(Main)>


### PR DESCRIPTION
Note, that the `useLocation().query` from React Router no longer works.

![Screenshot_2020-09-21 Compliance](https://user-images.githubusercontent.com/7695766/93782203-919c7f80-fc2a-11ea-94cb-73103858f8ce.png)
