### PR TITLE
[RHICOMPL-974] Mark systems table as full view

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -55,6 +55,9 @@ export const ComplianceSystems = () => {
                 <StateViewWithError stateValues={ { error, data, loading } }>
                     <StateViewPart stateKey="data">
                         { policies && <SystemsTable
+                            systemProps={{
+                                isFullView: true
+                            }}
                             showOsFilter
                             enableEditPolicy={ false }
                             remediationsEnabled={ false }

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -285,7 +285,7 @@ class SystemsTable extends React.Component {
     render() {
         const {
             remediationsEnabled, compact, enableExport, showAllSystems, showActions,
-            selectedEntities, selectedEntitiesIds, systems, total, policyId
+            selectedEntities, selectedEntitiesIds, systems, total, policyId, systemProps
         } = this.props;
         const {
             page, perPage, InventoryCmp, activeFilters, error
@@ -302,6 +302,7 @@ class SystemsTable extends React.Component {
             onSelect: this.onExportSelect
         } : {};
         const inventoryTableProps = {
+            ...systemProps,
             onRefresh: this.onRefresh,
             ref: this.inventory,
             page,
@@ -409,7 +410,10 @@ SystemsTable.propTypes = {
     systems: propTypes.array,
     total: propTypes.number,
     updateRows: propTypes.func,
-    updateSystems: propTypes.func
+    updateSystems: propTypes.func,
+    systemProps: propTypes.shape({
+        isFullView: propTypes.bool
+    })
 };
 
 SystemsTable.defaultProps = {
@@ -426,7 +430,8 @@ SystemsTable.defaultProps = {
     selectedEntitiesIds: [],
     systems: [],
     clearAll: () => ({}),
-    exportFromState: () => ({})
+    exportFromState: () => ({}),
+    systemProps: {}
 };
 
 const mapStateToProps = state => {


### PR DESCRIPTION
### Inventory full view [1]

In order to show proper RBAC state in systems table we need to pass `fullView` prop to inventory component. This applies only to systems page as it's the only place where inventory table is just one component on screen. Without this prop the `unAuthorized` component would be in table, which is not correct based on our mocks.

[1] https://github.com/RedHatInsights/frontend-components/blob/master/packages/inventory/doc/inventory.md#using-rbac-with-inventory