### PR TITLE
[RHICOMPL-680] Implement reports as a table view

### DIFF
--- a/src/PresentationalComponents/NoResultsTable/NoResultsTable.js
+++ b/src/PresentationalComponents/NoResultsTable/NoResultsTable.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+    Bullseye, EmptyState, EmptyStateBody, EmptyStateVariant, Title
+} from '@patternfly/react-core';
+import { EmptyTable } from '@redhat-cloud-services/frontend-components';
+
+const NoResultsTable = () => (
+    <EmptyTable>
+        <Bullseye>
+            <EmptyState variant={ EmptyStateVariant.full }>
+                <Title headingLevel="h5" size="lg">
+                    No matching policies found
+                </Title>
+                <EmptyStateBody>
+                    This filter criteria matches no policies. <br /> Try changing your filter settings.
+                </EmptyStateBody>
+            </EmptyState>
+        </Bullseye>
+    </EmptyTable>
+);
+
+export const emptyRows = [{
+    cells: [
+        {
+            title: () => (<NoResultsTable />),  // eslint-disable-line
+            props: {
+                colSpan: 3
+            }
+        }
+    ]
+}];
+
+export default NoResultsTable;

--- a/src/PresentationalComponents/NoResultsTable/NoResultsTable.test.js
+++ b/src/PresentationalComponents/NoResultsTable/NoResultsTable.test.js
@@ -1,0 +1,17 @@
+import NoResultsTable, { emptyRows } from './NoResultsTable';
+
+describe('NoResultsTable', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <NoResultsTable />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});
+
+describe('emptyRows', () => {
+    it('expect to render without error', () => {
+        expect(emptyRows).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/NoResultsTable/__snapshots__/NoResultsTable.test.js.snap
+++ b/src/PresentationalComponents/NoResultsTable/__snapshots__/NoResultsTable.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoResultsTable expect to render without error 1`] = `
+<EmptyTable>
+  <Bullseye>
+    <EmptyState
+      variant="full"
+    >
+      <Title
+        headingLevel="h5"
+        size="lg"
+      >
+        No matching policies found
+      </Title>
+      <EmptyStateBody>
+        This filter criteria matches no policies. 
+        <br />
+         Try changing your filter settings.
+      </EmptyStateBody>
+    </EmptyState>
+  </Bullseye>
+</EmptyTable>
+`;
+
+exports[`emptyRows expect to render without error 1`] = `
+Array [
+  Object {
+    "cells": Array [
+      Object {
+        "props": Object {
+          "colSpan": 3,
+        },
+        "title": [Function],
+      },
+    ],
+  },
+]
+`;

--- a/src/PresentationalComponents/PolicyPopover/PolicyPopover.js
+++ b/src/PresentationalComponents/PolicyPopover/PolicyPopover.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import {
+    Button,
     Popover,
     TextList,
     TextListVariants,
@@ -14,10 +15,11 @@ import {
 } from 'react-router-dom';
 import propTypes from 'prop-types';
 
-const PolicyPopover = ({ profile }) => {
+const PolicyPopover = ({ profile, position = 'top' }) => {
     const { name, policy, complianceThreshold, majorOsVersion, businessObjective } = profile;
     return (
         <Popover
+            { ...{ position } }
             headerContent={name}
             footerContent={
                 <Link to={'/scappolicies/' + policy.id} >
@@ -58,13 +60,16 @@ const PolicyPopover = ({ profile }) => {
                 </TextContent>
             }
         >
-            <OutlinedQuestionCircleIcon className='grey-icon'/>
+            <Button variant="link" isInline>
+                <OutlinedQuestionCircleIcon className='grey-icon'/>
+            </Button>
         </Popover>
     );
 };
 
 PolicyPopover.propTypes = {
-    profile: propTypes.object
+    profile: propTypes.object,
+    position: propTypes.string
 };
 
 export default PolicyPopover;

--- a/src/PresentationalComponents/PolicyPopover/PolicyPopover.test.js
+++ b/src/PresentationalComponents/PolicyPopover/PolicyPopover.test.js
@@ -1,0 +1,12 @@
+import PolicyPopover from './PolicyPopover';
+import { policies } from '@/__fixtures__/policies.js';
+
+describe('PolicyPopover', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <PolicyPopover profile={ policies.edges[0].node } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/PolicyPopover/__snapshots__/PolicyPopover.test.js.snap
+++ b/src/PresentationalComponents/PolicyPopover/__snapshots__/PolicyPopover.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PolicyPopover expect to render without error 1`] = `
+<Popover
+  bodyContent={
+    <TextContent
+      className="policy-details"
+    >
+      <TextList
+        component="dl"
+      >
+        <TextListItem
+          component="dt"
+        >
+          Operating system
+        </TextListItem>
+        <TextListItem
+          component="dd"
+        >
+          RHEL 
+          7
+        </TextListItem>
+        <TextListItem
+          component="dt"
+        >
+          Policy SSG version
+        </TextListItem>
+        <TextListItem
+          component="dd"
+        />
+        <TextListItem
+          component="dt"
+        >
+          Compliance threshold
+        </TextListItem>
+        <TextListItem
+          component="dd"
+        >
+          100.0%
+        </TextListItem>
+      </TextList>
+    </TextContent>
+  }
+  footerContent={
+    <Link
+      to="/scappolicies/b71376fd-015e-4209-99af-4543e82e5dc5-policy"
+    >
+      View policy
+    </Link>
+  }
+  headerContent="United States Government Configuration Baseline23"
+  position="top"
+>
+  <Button
+    isInline={true}
+    variant="link"
+  >
+    <OutlinedQuestionCircleIcon
+      className="grey-icon"
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+    />
+  </Button>
+</Popover>
+`;

--- a/src/PresentationalComponents/ReportCard/ReportCard.js
+++ b/src/PresentationalComponents/ReportCard/ReportCard.js
@@ -16,7 +16,7 @@ import {
     Grid,
     GridItem
 } from '@patternfly/react-core';
-import PolicyPopover from './PolicyPopover';
+import { PolicyPopover } from 'PresentationalComponents';
 import {
     ChartDonut,
     ChartThemeColor,

--- a/src/PresentationalComponents/ReportCardGrid/ReportCardGrid.js
+++ b/src/PresentationalComponents/ReportCardGrid/ReportCardGrid.js
@@ -1,31 +1,18 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import {
-    Button,
-    GridItem
-} from '@patternfly/react-core';
-import { ComplianceEmptyState } from '@redhat-cloud-services/frontend-components-inventory-compliance';
-import { BackgroundLink, ReportCard } from 'PresentationalComponents';
-
-const EmptyState = () => (
-    <ComplianceEmptyState
-        title={ 'No policies are reporting' }
-        mainButton={ <BackgroundLink to='/scappolicies/new'>
-            <Button variant='primary'>Create new policy</Button>
-        </BackgroundLink> }
-    />
-);
+import { Grid, GridItem } from '@patternfly/react-core';
+import { ReportCard } from 'PresentationalComponents';
 
 const ReportCardGrid = ({ profiles }) => (
-    profiles && profiles.length > 0 ?
-        profiles.map((profile, i) => (
+    <Grid hasGutter>
+        { profiles.map((profile, i) => (
             <GridItem sm={12} md={12} lg={6} xl={4} key={i}>
                 <ReportCard
                     key={ `profile-report-card-${i}`}
                     profile={ profile }
                 />
-            </GridItem>
-        )) : <EmptyState />
+            </GridItem>)) }
+    </Grid>
 );
 
 ReportCardGrid.propTypes = {

--- a/src/PresentationalComponents/ReportsEmptyState/ReportsEmptyState.js
+++ b/src/PresentationalComponents/ReportsEmptyState/ReportsEmptyState.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { ComplianceEmptyState } from '@redhat-cloud-services/frontend-components-inventory-compliance';
+import { BackgroundLink } from 'PresentationalComponents';
+
+const ReportsEmptyState = () => (
+    <ComplianceEmptyState
+        title={ 'No policies are reporting' }
+        mainButton={ <BackgroundLink to='/scappolicies/new'>
+            <Button variant='primary'>Create new policy</Button>
+        </BackgroundLink> }
+    />
+);
+
+export default ReportsEmptyState;

--- a/src/PresentationalComponents/ReportsEmptyState/ReportsEmptyState.test.js
+++ b/src/PresentationalComponents/ReportsEmptyState/ReportsEmptyState.test.js
@@ -1,0 +1,11 @@
+import ReportsEmptyState from './ReportsEmptyState';
+
+describe('ReportsEmptyState', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <ReportsEmptyState />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/ReportsEmptyState/__snapshots__/ReportsEmptyState.test.js.snap
+++ b/src/PresentationalComponents/ReportsEmptyState/__snapshots__/ReportsEmptyState.test.js.snap
@@ -1,0 +1,232 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportsEmptyState expect to render without error 1`] = `
+<ComplianceEmptyState
+  client={
+    ApolloClient {
+      "cache": InMemoryCache {
+        "addTypename": true,
+        "cacheKeyRoot": KeyTrie {
+          "weakness": true,
+        },
+        "config": Object {
+          "addTypename": true,
+          "dataIdFromObject": [Function],
+          "fragmentMatcher": HeuristicFragmentMatcher {},
+          "freezeResults": false,
+          "resultCaching": true,
+        },
+        "data": DepTrackingCache {
+          "data": Object {},
+          "depend": [Function],
+        },
+        "maybeBroadcastWatch": [Function],
+        "optimisticData": DepTrackingCache {
+          "data": Object {},
+          "depend": [Function],
+        },
+        "silenceBroadcast": false,
+        "storeReader": StoreReader {
+          "executeSelectionSet": [Function],
+          "executeStoreQuery": [Function],
+          "executeSubSelectedArray": [Function],
+          "freezeResults": false,
+        },
+        "storeWriter": StoreWriter {},
+        "typenameDocumentCache": Array [],
+        "watches": Array [],
+      },
+      "clearStoreCallbacks": Array [],
+      "defaultOptions": Object {},
+      "disableNetworkFetches": false,
+      "link": HttpLink {
+        "request": [Function],
+      },
+      "localState": LocalState {
+        "cache": InMemoryCache {
+          "addTypename": true,
+          "cacheKeyRoot": KeyTrie {
+            "weakness": true,
+          },
+          "config": Object {
+            "addTypename": true,
+            "dataIdFromObject": [Function],
+            "fragmentMatcher": HeuristicFragmentMatcher {},
+            "freezeResults": false,
+            "resultCaching": true,
+          },
+          "data": DepTrackingCache {
+            "data": Object {},
+            "depend": [Function],
+          },
+          "maybeBroadcastWatch": [Function],
+          "optimisticData": DepTrackingCache {
+            "data": Object {},
+            "depend": [Function],
+          },
+          "silenceBroadcast": false,
+          "storeReader": StoreReader {
+            "executeSelectionSet": [Function],
+            "executeStoreQuery": [Function],
+            "executeSubSelectedArray": [Function],
+            "freezeResults": false,
+          },
+          "storeWriter": StoreWriter {},
+          "typenameDocumentCache": Array [],
+          "watches": Array [],
+        },
+        "client": [Circular],
+      },
+      "mutate": [Function],
+      "query": [Function],
+      "queryDeduplication": true,
+      "queryManager": QueryManager {
+        "assumeImmutableResults": false,
+        "clientAwareness": Object {
+          "name": undefined,
+          "version": undefined,
+        },
+        "dataStore": DataStore {
+          "cache": InMemoryCache {
+            "addTypename": true,
+            "cacheKeyRoot": KeyTrie {
+              "weakness": true,
+            },
+            "config": Object {
+              "addTypename": true,
+              "dataIdFromObject": [Function],
+              "fragmentMatcher": HeuristicFragmentMatcher {},
+              "freezeResults": false,
+              "resultCaching": true,
+            },
+            "data": DepTrackingCache {
+              "data": Object {},
+              "depend": [Function],
+            },
+            "maybeBroadcastWatch": [Function],
+            "optimisticData": DepTrackingCache {
+              "data": Object {},
+              "depend": [Function],
+            },
+            "silenceBroadcast": false,
+            "storeReader": StoreReader {
+              "executeSelectionSet": [Function],
+              "executeStoreQuery": [Function],
+              "executeSubSelectedArray": [Function],
+              "freezeResults": false,
+            },
+            "storeWriter": StoreWriter {},
+            "typenameDocumentCache": Array [],
+            "watches": Array [],
+          },
+        },
+        "fetchQueryRejectFns": Array [],
+        "idCounter": 1,
+        "inFlightLinkObservables": Array [],
+        "link": HttpLink {
+          "request": [Function],
+        },
+        "localState": LocalState {
+          "cache": InMemoryCache {
+            "addTypename": true,
+            "cacheKeyRoot": KeyTrie {
+              "weakness": true,
+            },
+            "config": Object {
+              "addTypename": true,
+              "dataIdFromObject": [Function],
+              "fragmentMatcher": HeuristicFragmentMatcher {},
+              "freezeResults": false,
+              "resultCaching": true,
+            },
+            "data": DepTrackingCache {
+              "data": Object {},
+              "depend": [Function],
+            },
+            "maybeBroadcastWatch": [Function],
+            "optimisticData": DepTrackingCache {
+              "data": Object {},
+              "depend": [Function],
+            },
+            "silenceBroadcast": false,
+            "storeReader": StoreReader {
+              "executeSelectionSet": [Function],
+              "executeStoreQuery": [Function],
+              "executeSubSelectedArray": [Function],
+              "freezeResults": false,
+            },
+            "storeWriter": StoreWriter {},
+            "typenameDocumentCache": Array [],
+            "watches": Array [],
+          },
+          "client": [Circular],
+        },
+        "mutationStore": MutationStore {
+          "store": Object {},
+        },
+        "onBroadcast": [Function],
+        "pollingInfoByQueryId": Array [],
+        "queries": Array [],
+        "queryDeduplication": true,
+        "queryStore": QueryStore {
+          "store": Object {},
+        },
+        "ssrMode": false,
+        "transformCache": WeakMap {},
+      },
+      "reFetchObservableQueries": [Function],
+      "resetStore": [Function],
+      "resetStoreCallbacks": Array [],
+      "store": DataStore {
+        "cache": InMemoryCache {
+          "addTypename": true,
+          "cacheKeyRoot": KeyTrie {
+            "weakness": true,
+          },
+          "config": Object {
+            "addTypename": true,
+            "dataIdFromObject": [Function],
+            "fragmentMatcher": HeuristicFragmentMatcher {},
+            "freezeResults": false,
+            "resultCaching": true,
+          },
+          "data": DepTrackingCache {
+            "data": Object {},
+            "depend": [Function],
+          },
+          "maybeBroadcastWatch": [Function],
+          "optimisticData": DepTrackingCache {
+            "data": Object {},
+            "depend": [Function],
+          },
+          "silenceBroadcast": false,
+          "storeReader": StoreReader {
+            "executeSelectionSet": [Function],
+            "executeStoreQuery": [Function],
+            "executeSubSelectedArray": [Function],
+            "freezeResults": false,
+          },
+          "storeWriter": StoreWriter {},
+          "typenameDocumentCache": Array [],
+          "watches": Array [],
+        },
+      },
+      "typeDefs": undefined,
+      "version": "2.6.10",
+      "watchQuery": [Function],
+    }
+  }
+  mainButton={
+    <BackgroundLink
+      to="/scappolicies/new"
+    >
+      <Button
+        variant="primary"
+      >
+        Create new policy
+      </Button>
+    </BackgroundLink>
+  }
+  title="No policies are reporting"
+/>
+`;

--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Label, Text, TextContent, TextVariants, Progress } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { PolicyPopover } from 'PresentationalComponents';
+
+export const GreySmallText = ({ children }) => (
+    <Text
+        style={{ color: 'var(--pf-global--Color--200)' }}
+        component={ TextVariants.small }>{ children }</Text>
+);
+
+GreySmallText.propTypes = {
+    children: propTypes.node
+};
+
+export const Name = (profile) => (
+    <TextContent>
+        <Link to={'/reports/' + profile.id} style={ { marginRight: '.5rem' }}>
+            { profile.name }
+        </Link>
+        { profile.policy && <PolicyPopover { ...{ profile, position: 'right' } } /> }
+        { !profile.policy && <Label color="red">
+            External
+        </Label> }
+        { profile.policy && <GreySmallText>{ profile.policy.name }</GreySmallText> }
+    </TextContent>
+);
+
+Name.propTypes = {
+    id: propTypes.string,
+    name: propTypes.string,
+    policy: propTypes.object
+};
+
+export const rhelColorMap = {
+    7: 'cyan',
+    8: 'purple'
+};
+export const OperatingSystem = ({ majorOsVersion }) => (
+    <Label color={ rhelColorMap[majorOsVersion] }>RHEL { majorOsVersion }</Label>
+);
+
+OperatingSystem.propTypes = {
+    majorOsVersion: propTypes.string
+};
+
+export const CompliantSystems = ({ totalHostCount = 0, compliantHostCount = 0 }) => (
+    <React.Fragment>
+        <Progress
+            measureLocation={ 'outside' }
+            value={ (100 / totalHostCount) * compliantHostCount } />
+        <GreySmallText>{ `${ compliantHostCount } of ${ totalHostCount } systems` }</GreySmallText>
+    </React.Fragment>
+);
+
+CompliantSystems.propTypes = {
+    totalHostCount: propTypes.number,
+    compliantHostCount: propTypes.number
+};

--- a/src/PresentationalComponents/ReportsTable/Cells.test.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.test.js
@@ -1,0 +1,50 @@
+import { GreySmallText, Name, OperatingSystem, CompliantSystems } from './Cells';
+
+describe('GreySmallText', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <GreySmallText>
+                <span>THIS IS A TEST</span>
+            </GreySmallText>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});
+
+describe('Name', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <Name { ...{
+                id: 'ID',
+                name: 'NAME',
+                policy: {
+                    id: 'POLICY_ID',
+                    name: 'POLICY_NAME'
+                }
+            }} />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});
+
+describe('OperatingSystem', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <OperatingSystem majorOsVersion="7" />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});
+
+describe('CompliantSystems', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <CompliantSystems totalHostCount={ 10 } compliantHostCount={ 9 } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/ReportsTable/Filters.js
+++ b/src/PresentationalComponents/ReportsTable/Filters.js
@@ -1,0 +1,62 @@
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+
+export const policyNameFilter = [{
+    type: conditionalFilterType.text,
+    label: 'Policy name',
+    filter: (profiles, value) => {
+        const lowerCaseValue = value.toLowerCase();
+        return profiles.filter((profile) => (
+            [
+                profile.name,
+                (profile?.policy?.name || '')
+            ].join().toLowerCase().includes(lowerCaseValue)
+        ));
+    }
+}];
+
+export const policyTypeFilter = (policies) => ([{
+    type: conditionalFilterType.checkbox,
+    label: 'Policy type',
+    filter: (profiles, values) => (
+        profiles.filter(({ policy }) => values.includes(policy?.id))
+    ),
+    items: policies.map((policy) => ({
+        label: policy.name,
+        value: policy.id
+    }))
+}]);
+
+export const operatingSystemFilter = (operatingSystems) => ([{
+    type: conditionalFilterType.checkbox,
+    label: 'Operating system',
+    filter: (profiles, values) => (
+        profiles.filter(({ majorOsVersion }) => (
+            values.includes(majorOsVersion)
+        ))
+    ),
+    items: operatingSystems.map((operatingSystem) => ({
+        label: `RHEL ${operatingSystem}`,
+        value: operatingSystem
+    }))
+}]);
+
+export const policyComplianceFilter = [{
+    type: conditionalFilterType.checkbox,
+    label: 'Systemsmeetingcompliance', // FIX in FC: The filterconfig helper can't handle two much space...
+    filter: (profiles, values) => (
+        profiles.filter(({ totalHostCount, compliantHostCount }) => {
+            const compliantHostsPercent = Math.round((100 / totalHostCount) * compliantHostCount);
+            const matching = values.map((value) => {
+                const [min, max] = value.split('-');
+                return compliantHostsPercent >= min && compliantHostsPercent <= max;
+            }).filter((i) => (!!i));
+            return matching.length > 0;
+        })
+    ),
+    items: [
+        { label: '90 - 100%', value: '90-100' },
+        { label: '70 - 89%', value: '70-89' },
+        { label: '50 - 69%', value: '50-69' },
+        { label: 'Less than 50%', value: '0-49' }
+    ]
+}];

--- a/src/PresentationalComponents/ReportsTable/Filters.test.js
+++ b/src/PresentationalComponents/ReportsTable/Filters.test.js
@@ -1,0 +1,37 @@
+import {
+    policyNameFilter, policyTypeFilter, operatingSystemFilter, policyComplianceFilter
+} from './Filters';
+import { policies as rawPolicies  } from '@/__fixtures__/policies.js';
+const profiles = rawPolicies.edges.map((policy) => (policy.node));
+
+describe('policyNameFilter', () => {
+    it('expect to return results', () => {
+        const filterFunction = policyNameFilter[0].filter;
+        const result = filterFunction(profiles, 'Unclassified');
+        expect(result).toMatchSnapshot();
+    });
+});
+
+describe('policyTypeFilter', () => {
+    it('expect to return results', () => {
+        const filterFunction = policyTypeFilter([])[0].filter;
+        const result = filterFunction(profiles, ['b71376fd-015e-4209-99af-4543e82e5dc5-policy']);
+        expect(result).toMatchSnapshot();
+    });
+});
+
+describe('operatingSystemFilter', () => {
+    it('expect to return results', () => {
+        const filterFunction = operatingSystemFilter([])[0].filter;
+        const result = filterFunction(profiles, [7]);
+        expect(result).toMatchSnapshot();
+    });
+});
+
+describe('policyComplianceFilter', () => {
+    it('expect to return results', () => {
+        const filterFunction = policyComplianceFilter[0].filter;
+        const result = filterFunction(profiles, ['0-49']);
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/ReportsTable/ReportsTable.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Table, TableBody, TableHeader, sortable } from '@patternfly/react-table';
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
+import { emptyRows } from 'PresentationalComponents';
+import useFilterConfig from 'Utilities/hooks/useFilterConfig';
+import useTableSort from 'Utilities/hooks/useTableSort';
+import { Name, OperatingSystem, CompliantSystems } from './Cells';
+import {
+    policyNameFilter, policyTypeFilter, operatingSystemFilter, policyComplianceFilter
+} from './Filters';
+
+const ReportsTable = ({ profiles }) => {
+    const columns = [
+        {
+            title: 'Policy',
+            transforms: [sortable],
+            sortByProperty: 'name'
+        },
+        {
+            title: 'Operating system',
+            transforms: [sortable],
+            sortByProperty: 'majorOsVersion'
+        },
+        {
+            title: 'Systems meeting compliance',
+            transforms: [sortable],
+            sortByFunction: ({ totalHostCount, compliantHostCount }) => (
+                (100 / totalHostCount) * compliantHostCount
+            )
+        }
+    ];
+    const policyTypes = profiles.map(({ policy }) => (policy)).filter((i) => (!!i));
+    const operatingSystems = [...new Set(
+        profiles.map(({ majorOsVersion }) => (majorOsVersion)).filter((i) => (!!i))
+    )];
+    const { conditionalFilter, filtered: filteredProfiles } = useFilterConfig([
+        ...policyNameFilter,
+        ...policyTypes.length > 0 && policyTypeFilter(policyTypes) || [],
+        ...operatingSystems.length > 0 && operatingSystemFilter(operatingSystems) || [],
+        ...policyComplianceFilter
+    ], profiles);
+    const { tableSort, sorted: sortedProfiles } = useTableSort(filteredProfiles, columns);
+    const rows = sortedProfiles.length > 0 ? sortedProfiles.map((profile) => ({
+        cells: [
+            { title: <Name { ...profile } /> },
+            { title: <OperatingSystem { ...profile } /> },
+            { title: <CompliantSystems { ...profile } /> }
+        ]
+    })) : emptyRows;
+
+    return <React.Fragment>
+        <PrimaryToolbar { ...conditionalFilter } />
+        <Table
+            aria-label='Reports'
+            cells={ columns }
+            rows={ rows }
+            { ...tableSort }>
+            <TableHeader />
+            <TableBody />
+        </Table>
+    </React.Fragment>;
+};
+
+ReportsTable.propTypes = {
+    profiles: propTypes.array
+};
+
+export default ReportsTable;

--- a/src/PresentationalComponents/ReportsTable/ReportsTable.test.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.test.js
@@ -1,0 +1,14 @@
+import { policies as rawPolicies  } from '@/__fixtures__/policies.js';
+import ReportsTable from './ReportsTable';
+
+const profiles = rawPolicies.edges.map((profile) => (profile.node));
+
+describe('ReportsTable', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <ReportsTable profiles={ profiles } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CompliantSystems expect to render without error 1`] = `
+<Fragment>
+  <Progress
+    className=""
+    id=""
+    label={null}
+    max={100}
+    measureLocation="outside"
+    min={0}
+    size={null}
+    title=""
+    value={90}
+    valueText={null}
+    variant={null}
+  />
+  <GreySmallText>
+    9 of 10 systems
+  </GreySmallText>
+</Fragment>
+`;
+
+exports[`GreySmallText expect to render without error 1`] = `
+<Text
+  component="small"
+  style={
+    Object {
+      "color": "var(--pf-global--Color--200)",
+    }
+  }
+>
+  <span>
+    THIS IS A TEST
+  </span>
+</Text>
+`;
+
+exports[`Name expect to render without error 1`] = `
+<TextContent>
+  <Link
+    style={
+      Object {
+        "marginRight": ".5rem",
+      }
+    }
+    to="/reports/ID"
+  >
+    NAME
+  </Link>
+  <PolicyPopover
+    position="right"
+    profile={
+      Object {
+        "id": "ID",
+        "name": "NAME",
+        "policy": Object {
+          "id": "POLICY_ID",
+          "name": "POLICY_NAME",
+        },
+      }
+    }
+  />
+  <GreySmallText>
+    POLICY_NAME
+  </GreySmallText>
+</TextContent>
+`;
+
+exports[`OperatingSystem expect to render without error 1`] = `
+<Label
+  color="cyan"
+>
+  RHEL 
+  7
+</Label>
+`;

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Filters.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Filters.test.js.snap
@@ -1,0 +1,263 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`operatingSystemFilter expect to return results 1`] = `
+Array [
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "compliantHostCount": 4,
+    "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
+    "majorOsVersion": 7,
+    "name": "United States Government Configuration Baseline23",
+    "policy": Object {
+      "__typename": "Profile",
+      "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+      "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+    },
+    "refId": "xccdf_org.ssgproject.content_profile_ospp23",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 67,
+    "id": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
+    "majorOsVersion": 7,
+    "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+    "refId": "xccdf_org.ssgproject.content_profile_pci-dss3",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "dae0487d-3201-4ee0-af5f-b94cde2af818",
+    "majorOsVersion": 7,
+    "name": "United States Government Configuration Baseline2",
+    "refId": "xccdf_org.ssgproject.content_profile_ospp2",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 69.5,
+    "id": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
+    "majorOsVersion": 7,
+    "name": "C2S for Red Hat Enterprise Linux 7",
+    "refId": "xccdf_org.ssgproject.content_profile_C2S",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
+    "majorOsVersion": 7,
+    "name": "Criminal Justice Information Services (CJIS) Security Policy",
+    "refId": "xccdf_org.ssgproject.content_profile_cjis",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
+    "majorOsVersion": 7,
+    "name": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
+    "refId": "xccdf_org.ssgproject.content_profile_nist-800-171-cui",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
+    "majorOsVersion": 7,
+    "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+    "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
+    "majorOsVersion": 7,
+    "name": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
+    "refId": "xccdf_org.ssgproject.content_profile_rht-ccp",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
+    "majorOsVersion": 7,
+    "name": "Health Insurance Portability and Accountability Act (HIPAA)",
+    "refId": "xccdf_org.ssgproject.content_profile_hipaa",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
+    "majorOsVersion": 7,
+    "name": "United States Government Configuration Baseline",
+    "refId": "xccdf_org.ssgproject.content_profile_ospp",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "4c27fe09-9a7f-437c-b38b-e42272d9ccf0",
+    "majorOsVersion": 7,
+    "name": "Standard System Security Profile for Red Hat Enterprise Linux 7",
+    "refId": "xccdf_org.ssgproject.content_profile_standard",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "9b034440-e3dd-4c19-8f2c-ca75e813d57d",
+    "majorOsVersion": 7,
+    "name": "DISA STIG for Red Hat Enterprise Linux 7",
+    "refId": "xccdf_org.ssgproject.content_profile_stig-rhel7-disa",
+    "totalHostCount": 10,
+  },
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "19921ca4-8526-4651-8876-3c8587e8e125",
+    "majorOsVersion": 7,
+    "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72",
+    "refId": "xccdf_org.ssgproject.content_profile_pci-dss2",
+    "totalHostCount": 10,
+  },
+]
+`;
+
+exports[`policyComplianceFilter expect to return results 1`] = `
+Array [
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "compliantHostCount": 4,
+    "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
+    "majorOsVersion": 7,
+    "name": "United States Government Configuration Baseline23",
+    "policy": Object {
+      "__typename": "Profile",
+      "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+      "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+    },
+    "refId": "xccdf_org.ssgproject.content_profile_ospp23",
+    "totalHostCount": 10,
+  },
+]
+`;
+
+exports[`policyNameFilter expect to return results 1`] = `
+Array [
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "id": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
+    "majorOsVersion": 7,
+    "name": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
+    "refId": "xccdf_org.ssgproject.content_profile_nist-800-171-cui",
+    "totalHostCount": 10,
+  },
+]
+`;
+
+exports[`policyTypeFilter expect to return results 1`] = `
+Array [
+  Object {
+    "__typename": "Profile",
+    "benchmark": Object {
+      "title": "Guide to the Secure Configuration of RHEL 7",
+      "version": "0.1.49",
+    },
+    "businessObjective": null,
+    "complianceThreshold": 100,
+    "compliantHostCount": 4,
+    "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
+    "majorOsVersion": 7,
+    "name": "United States Government Configuration Baseline23",
+    "policy": Object {
+      "__typename": "Profile",
+      "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+      "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+    },
+    "refId": "xccdf_org.ssgproject.content_profile_ospp23",
+    "totalHostCount": 10,
+  },
+]
+`;

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
@@ -1,0 +1,920 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportsTable expect to render without error 1`] = `
+<Fragment>
+  <PrimaryToolbar
+    activeFiltersConfig={
+      Object {
+        "filters": Array [],
+        "onDelete": [Function],
+      }
+    }
+    filterConfig={
+      Object {
+        "items": Array [
+          Object {
+            "filterValues": Object {
+              "onChange": [Function],
+              "value": "",
+            },
+            "id": "policyname",
+            "label": "Policy name",
+            "type": "text",
+          },
+          Object {
+            "filterValues": Object {
+              "items": Array [
+                Object {
+                  "label": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+                  "value": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+                },
+              ],
+              "onChange": [Function],
+              "value": Array [],
+            },
+            "id": "policytype",
+            "label": "Policy type",
+            "type": "checkbox",
+          },
+          Object {
+            "filterValues": Object {
+              "items": Array [
+                Object {
+                  "label": "RHEL 7",
+                  "value": 7,
+                },
+              ],
+              "onChange": [Function],
+              "value": Array [],
+            },
+            "id": "operatingsystem",
+            "label": "Operating system",
+            "type": "checkbox",
+          },
+          Object {
+            "filterValues": Object {
+              "items": Array [
+                Object {
+                  "label": "90 - 100%",
+                  "value": "90-100",
+                },
+                Object {
+                  "label": "70 - 89%",
+                  "value": "70-89",
+                },
+                Object {
+                  "label": "50 - 69%",
+                  "value": "50-69",
+                },
+                Object {
+                  "label": "Less than 50%",
+                  "value": "0-49",
+                },
+              ],
+              "onChange": [Function],
+              "value": Array [],
+            },
+            "id": "systemsmeetingcompliance",
+            "label": "Systemsmeetingcompliance",
+            "type": "checkbox",
+          },
+        ],
+      }
+    }
+    toggleIsExpanded={[Function]}
+  />
+  <Table
+    aria-label="Reports"
+    borders={true}
+    canSelectAll={true}
+    cells={
+      Array [
+        Object {
+          "sortByProperty": "name",
+          "title": "Policy",
+          "transforms": Array [
+            [Function],
+          ],
+        },
+        Object {
+          "sortByProperty": "majorOsVersion",
+          "title": "Operating system",
+          "transforms": Array [
+            [Function],
+          ],
+        },
+        Object {
+          "sortByFunction": [Function],
+          "title": "Systems meeting compliance",
+          "transforms": Array [
+            [Function],
+          ],
+        },
+      ]
+    }
+    className=""
+    contentId="expanded-content"
+    dropdownDirection="down"
+    dropdownPosition="right"
+    expandId="expandable-toggle"
+    gridBreakPoint="grid-md"
+    isStickyHeader={false}
+    onSort={[Function]}
+    ouiaSafe={true}
+    role="grid"
+    rowLabeledBy="simple-node"
+    rows={
+      Array [
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                compliantHostCount={4}
+                id="b71376fd-015e-4209-99af-4543e82e5dc5"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline23"
+                policy={
+                  Object {
+                    "__typename": "Profile",
+                    "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+                    "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+                  }
+                }
+                refId="xccdf_org.ssgproject.content_profile_ospp23"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                compliantHostCount={4}
+                id="b71376fd-015e-4209-99af-4543e82e5dc5"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline23"
+                policy={
+                  Object {
+                    "__typename": "Profile",
+                    "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+                    "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+                  }
+                }
+                refId="xccdf_org.ssgproject.content_profile_ospp23"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                compliantHostCount={4}
+                id="b71376fd-015e-4209-99af-4543e82e5dc5"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline23"
+                policy={
+                  Object {
+                    "__typename": "Profile",
+                    "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+                    "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+                  }
+                }
+                refId="xccdf_org.ssgproject.content_profile_ospp23"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="dae0487d-3201-4ee0-af5f-b94cde2af818"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline2"
+                refId="xccdf_org.ssgproject.content_profile_ospp2"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="dae0487d-3201-4ee0-af5f-b94cde2af818"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline2"
+                refId="xccdf_org.ssgproject.content_profile_ospp2"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="dae0487d-3201-4ee0-af5f-b94cde2af818"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline2"
+                refId="xccdf_org.ssgproject.content_profile_ospp2"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline"
+                refId="xccdf_org.ssgproject.content_profile_ospp"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline"
+                refId="xccdf_org.ssgproject.content_profile_ospp"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220"
+                majorOsVersion={7}
+                name="United States Government Configuration Baseline"
+                refId="xccdf_org.ssgproject.content_profile_ospp"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="c8e15347-9c2b-495d-8e54-503c2f9582b6"
+                majorOsVersion={7}
+                name="Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)"
+                refId="xccdf_org.ssgproject.content_profile_nist-800-171-cui"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="c8e15347-9c2b-495d-8e54-503c2f9582b6"
+                majorOsVersion={7}
+                name="Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)"
+                refId="xccdf_org.ssgproject.content_profile_nist-800-171-cui"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="c8e15347-9c2b-495d-8e54-503c2f9582b6"
+                majorOsVersion={7}
+                name="Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)"
+                refId="xccdf_org.ssgproject.content_profile_nist-800-171-cui"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="4c27fe09-9a7f-437c-b38b-e42272d9ccf0"
+                majorOsVersion={7}
+                name="Standard System Security Profile for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_standard"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="4c27fe09-9a7f-437c-b38b-e42272d9ccf0"
+                majorOsVersion={7}
+                name="Standard System Security Profile for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_standard"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="4c27fe09-9a7f-437c-b38b-e42272d9ccf0"
+                majorOsVersion={7}
+                name="Standard System Security Profile for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_standard"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="f7b7977a-403b-4cd1-ab90-20b6f9a5a359"
+                majorOsVersion={7}
+                name="Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)"
+                refId="xccdf_org.ssgproject.content_profile_rht-ccp"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="f7b7977a-403b-4cd1-ab90-20b6f9a5a359"
+                majorOsVersion={7}
+                name="Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)"
+                refId="xccdf_org.ssgproject.content_profile_rht-ccp"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="f7b7977a-403b-4cd1-ab90-20b6f9a5a359"
+                majorOsVersion={7}
+                name="Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)"
+                refId="xccdf_org.ssgproject.content_profile_rht-ccp"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={67}
+                id="719999b6-d230-4ba5-8dba-7ab3dc6561e0"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss3"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={67}
+                id="719999b6-d230-4ba5-8dba-7ab3dc6561e0"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss3"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={67}
+                id="719999b6-d230-4ba5-8dba-7ab3dc6561e0"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss3"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="19921ca4-8526-4651-8876-3c8587e8e125"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss2"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="19921ca4-8526-4651-8876-3c8587e8e125"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss2"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="19921ca4-8526-4651-8876-3c8587e8e125"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss2"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="3c4823a1-2c16-46ae-b2fe-0cebf5a03931"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="3c4823a1-2c16-46ae-b2fe-0cebf5a03931"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="3c4823a1-2c16-46ae-b2fe-0cebf5a03931"
+                majorOsVersion={7}
+                name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_pci-dss"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="36abc364-6dc3-4e35-94f4-d10fa77e866e"
+                majorOsVersion={7}
+                name="Health Insurance Portability and Accountability Act (HIPAA)"
+                refId="xccdf_org.ssgproject.content_profile_hipaa"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="36abc364-6dc3-4e35-94f4-d10fa77e866e"
+                majorOsVersion={7}
+                name="Health Insurance Portability and Accountability Act (HIPAA)"
+                refId="xccdf_org.ssgproject.content_profile_hipaa"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="36abc364-6dc3-4e35-94f4-d10fa77e866e"
+                majorOsVersion={7}
+                name="Health Insurance Portability and Accountability Act (HIPAA)"
+                refId="xccdf_org.ssgproject.content_profile_hipaa"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="9b034440-e3dd-4c19-8f2c-ca75e813d57d"
+                majorOsVersion={7}
+                name="DISA STIG for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="9b034440-e3dd-4c19-8f2c-ca75e813d57d"
+                majorOsVersion={7}
+                name="DISA STIG for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="9b034440-e3dd-4c19-8f2c-ca75e813d57d"
+                majorOsVersion={7}
+                name="DISA STIG for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="6d345bd2-d597-4df8-9bcf-71c41155b42c"
+                majorOsVersion={7}
+                name="Criminal Justice Information Services (CJIS) Security Policy"
+                refId="xccdf_org.ssgproject.content_profile_cjis"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="6d345bd2-d597-4df8-9bcf-71c41155b42c"
+                majorOsVersion={7}
+                name="Criminal Justice Information Services (CJIS) Security Policy"
+                refId="xccdf_org.ssgproject.content_profile_cjis"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={100}
+                id="6d345bd2-d597-4df8-9bcf-71c41155b42c"
+                majorOsVersion={7}
+                name="Criminal Justice Information Services (CJIS) Security Policy"
+                refId="xccdf_org.ssgproject.content_profile_cjis"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+        Object {
+          "cells": Array [
+            Object {
+              "title": <Name
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={69.5}
+                id="20a9d997-62a6-40cc-a5f3-19d466eb975e"
+                majorOsVersion={7}
+                name="C2S for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_C2S"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <OperatingSystem
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={69.5}
+                id="20a9d997-62a6-40cc-a5f3-19d466eb975e"
+                majorOsVersion={7}
+                name="C2S for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_C2S"
+                totalHostCount={10}
+              />,
+            },
+            Object {
+              "title": <CompliantSystems
+                __typename="Profile"
+                benchmark={
+                  Object {
+                    "title": "Guide to the Secure Configuration of RHEL 7",
+                    "version": "0.1.49",
+                  }
+                }
+                businessObjective={null}
+                complianceThreshold={69.5}
+                id="20a9d997-62a6-40cc-a5f3-19d466eb975e"
+                majorOsVersion={7}
+                name="C2S for Red Hat Enterprise Linux 7"
+                refId="xccdf_org.ssgproject.content_profile_C2S"
+                totalHostCount={10}
+              />,
+            },
+          ],
+        },
+      ]
+    }
+    sortBy={
+      Object {
+        "direction": "desc",
+        "index": 0,
+      }
+    }
+    variant={null}
+  >
+    <TableHeader />
+    <Component />
+  </Table>
+</Fragment>
+`;

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -18,3 +18,7 @@ export { default as WarningText } from './WarningText/WarningText';
 export { default as NoSystemsTableBody } from './NoSystemsTableBody/NoSystemsTableBody';
 export { default as BackgroundLink } from './BackgroundLink/BackgroundLink';
 export { default as BreadcrumbLinkItem } from './BreadcrumbLinkItem/BreadcrumbLinkItem';
+export { default as ReportsTable } from './ReportsTable/ReportsTable';
+export { default as ReportsEmptyState } from './ReportsEmptyState/ReportsEmptyState';
+export { default as PolicyPopover } from './PolicyPopover/PolicyPopover';
+export { default as NoResultsTable, emptyRows } from './NoResultsTable/NoResultsTable';

--- a/src/SmartComponents/Reports/Reports.test.js
+++ b/src/SmartComponents/Reports/Reports.test.js
@@ -3,6 +3,10 @@ import { useQuery } from '@apollo/react-hooks';
 import { Reports } from './Reports.js';
 
 jest.mock('@apollo/react-hooks');
+jest.mock('react-router-dom', () => ({
+    ...require.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({}))
+}));
 
 describe('Reports', () => {
     it('expect to render without error', () => {

--- a/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
+++ b/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
@@ -1,189 +1,130 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Reports expect to render emptystate 1`] = `
-<Fragment>
-  <PageHeader>
-    <PageHeaderTitle
-      title="Compliance reports"
-    />
-  </PageHeader>
-  <Connect(Main)>
-    <StateViewWithError
-      stateValues={
-        Object {
-          "data": Object {
-            "profiles": Object {
-              "edges": Array [],
-            },
-          },
-          "error": undefined,
-          "loading": undefined,
-        }
-      }
-    >
-      <StateViewPart
-        stateKey="loading"
-      >
-        <div
-          className="policies-donuts"
-        >
-          <Grid
-            hasGutter={true}
-          >
-            <LoadingComplianceCards />
-          </Grid>
-        </div>
-      </StateViewPart>
-      <StateViewPart
-        stateKey="data"
-      >
-        <div
-          className="policies-donuts"
-        >
-          <Grid
-            hasGutter={true}
-          >
-            <ReportCardGrid
-              profiles={Array []}
-            />
-          </Grid>
-        </div>
-      </StateViewPart>
-    </StateViewWithError>
-  </Connect(Main)>
-</Fragment>
+<StateViewWithError
+  stateValues={
+    Object {
+      "data": Object {
+        "profiles": Object {
+          "edges": Array [],
+        },
+      },
+      "error": undefined,
+      "loading": undefined,
+    }
+  }
+>
+  <StateViewPart
+    stateKey="loading"
+  >
+    <ReportsHeader />
+    <Connect(Main)>
+      <LoadingView />
+    </Connect(Main)>
+  </StateViewPart>
+  <StateViewPart
+    stateKey="data"
+  >
+    <ReportsHeader />
+    <Connect(Main)>
+      <ReportsEmptyState />
+    </Connect(Main)>
+  </StateViewPart>
+</StateViewWithError>
 `;
 
 exports[`Reports expect to render loading 1`] = `
-<Fragment>
-  <PageHeader>
-    <PageHeaderTitle
-      title="Compliance reports"
-    />
-  </PageHeader>
-  <Connect(Main)>
-    <StateViewWithError
-      stateValues={
-        Object {
-          "data": undefined,
-          "error": false,
-          "loading": true,
-        }
-      }
-    >
-      <StateViewPart
-        stateKey="loading"
-      >
-        <div
-          className="policies-donuts"
-        >
-          <Grid
-            hasGutter={true}
-          >
-            <LoadingComplianceCards />
-          </Grid>
-        </div>
-      </StateViewPart>
-      <StateViewPart
-        stateKey="data"
-      >
-        <div
-          className="policies-donuts"
-        >
-          <Grid
-            hasGutter={true}
-          >
-            <ReportCardGrid />
-          </Grid>
-        </div>
-      </StateViewPart>
-    </StateViewWithError>
-  </Connect(Main)>
-</Fragment>
+<StateViewWithError
+  stateValues={
+    Object {
+      "data": undefined,
+      "error": false,
+      "loading": true,
+    }
+  }
+>
+  <StateViewPart
+    stateKey="loading"
+  >
+    <ReportsHeader />
+    <Connect(Main)>
+      <LoadingView />
+    </Connect(Main)>
+  </StateViewPart>
+  <StateViewPart
+    stateKey="data"
+  >
+    <ReportsHeader />
+    <Connect(Main)>
+      <ReportsEmptyState />
+    </Connect(Main)>
+  </StateViewPart>
+</StateViewWithError>
 `;
 
 exports[`Reports expect to render without error 1`] = `
-<Fragment>
-  <PageHeader>
-    <PageHeaderTitle
-      title="Compliance reports"
-    />
-  </PageHeader>
-  <Connect(Main)>
-    <StateViewWithError
-      stateValues={
-        Object {
-          "data": Object {
-            "profiles": Object {
-              "edges": Array [
-                Object {
-                  "node": Object {
-                    "businessObjective": Object {
-                      "id": "1",
-                      "title": "BO 1",
-                    },
-                    "complianceThreshold": 1,
-                    "compliantHostCount": 1,
-                    "description": "profile description",
-                    "id": "1",
-                    "name": "profile1",
-                    "refId": "121212",
-                    "totalHostCount": 1,
-                  },
+<StateViewWithError
+  stateValues={
+    Object {
+      "data": Object {
+        "profiles": Object {
+          "edges": Array [
+            Object {
+              "node": Object {
+                "businessObjective": Object {
+                  "id": "1",
+                  "title": "BO 1",
                 },
-              ],
+                "complianceThreshold": 1,
+                "compliantHostCount": 1,
+                "description": "profile description",
+                "id": "1",
+                "name": "profile1",
+                "refId": "121212",
+                "totalHostCount": 1,
+              },
             },
-          },
-          "error": undefined,
-          "loading": undefined,
+          ],
+        },
+      },
+      "error": undefined,
+      "loading": undefined,
+    }
+  }
+>
+  <StateViewPart
+    stateKey="loading"
+  >
+    <ReportsHeader />
+    <Connect(Main)>
+      <LoadingView />
+    </Connect(Main)>
+  </StateViewPart>
+  <StateViewPart
+    stateKey="data"
+  >
+    <ReportsHeader />
+    <Connect(Main)>
+      <ReportCardGrid
+        profiles={
+          Array [
+            Object {
+              "businessObjective": Object {
+                "id": "1",
+                "title": "BO 1",
+              },
+              "complianceThreshold": 1,
+              "compliantHostCount": 1,
+              "description": "profile description",
+              "id": "1",
+              "name": "profile1",
+              "refId": "121212",
+              "totalHostCount": 1,
+            },
+          ]
         }
-      }
-    >
-      <StateViewPart
-        stateKey="loading"
-      >
-        <div
-          className="policies-donuts"
-        >
-          <Grid
-            hasGutter={true}
-          >
-            <LoadingComplianceCards />
-          </Grid>
-        </div>
-      </StateViewPart>
-      <StateViewPart
-        stateKey="data"
-      >
-        <div
-          className="policies-donuts"
-        >
-          <Grid
-            hasGutter={true}
-          >
-            <ReportCardGrid
-              profiles={
-                Array [
-                  Object {
-                    "businessObjective": Object {
-                      "id": "1",
-                      "title": "BO 1",
-                    },
-                    "complianceThreshold": 1,
-                    "compliantHostCount": 1,
-                    "description": "profile description",
-                    "id": "1",
-                    "name": "profile1",
-                    "refId": "121212",
-                    "totalHostCount": 1,
-                  },
-                ]
-              }
-            />
-          </Grid>
-        </div>
-      </StateViewPart>
-    </StateViewWithError>
-  </Connect(Main)>
-</Fragment>
+      />
+    </Connect(Main)>
+  </StateViewPart>
+</StateViewWithError>
 `;

--- a/src/Utilities/hooks/useFeature.js
+++ b/src/Utilities/hooks/useFeature.js
@@ -1,0 +1,53 @@
+import { features } from '@/constants';
+import { useLocation, useHistory } from 'react-router-dom';
+const LOCAL_STORE_FEATURE_PREFIX = 'insights:compliance';
+
+const setFeatureFlag = (featureValue, feature) => {
+    const value = featureValue === 'enable';
+
+    if (!value) {
+        console.log(`Removing feature setting of ${feature}`);
+        localStorage.removeItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`);
+    } else {
+        console.log(`Setting feature value for ${feature} to ${value}`);
+        localStorage.setItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`, value);
+    }
+};
+
+// Allows setting feature flag values via ?feature|(enable/disable)
+const setFlagsFromUrl = () => {
+    const { search, pathName: path } = useLocation();
+    const history = useHistory();
+    if (!search) {
+        return;
+    }
+
+    const urlParams = new URLSearchParams(search);
+    urlParams.forEach(setFeatureFlag);
+
+    history.push(path);
+};
+
+// Queries the local storage for feature flag values
+const getLocatStateFlag = (feature) => (
+    localStorage.getItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`)
+);
+
+// A hook to query feature values
+const useFeature = (feature) => {
+    const featureDefault = features[feature];
+    if (!feature) {
+        return;
+    }
+
+    setFlagsFromUrl();
+
+    const localStoreValue = getLocatStateFlag(feature);
+    const featureEnabled = localStoreValue || featureDefault;
+
+    console.log(`Feature ${feature} is set to ${featureEnabled}`);
+    return featureEnabled;
+};
+
+export default useFeature;
+

--- a/src/Utilities/hooks/useFilterConfig.js
+++ b/src/Utilities/hooks/useFilterConfig.js
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { FilterConfigBuilder } from '@redhat-cloud-services/frontend-components-inventory-compliance';
+
+const useFilterConfig = (initialConfig, arrayToFilter) => {
+    const filterConfigBuilder = new FilterConfigBuilder(initialConfig);
+    const [activeFilters, setActiveFilters] = useState(filterConfigBuilder.initialDefaultState());
+    const onFilterUpdate = (filter, value) => (
+        setActiveFilters({
+            ...activeFilters,
+            [filter]: value
+        })
+    );
+    const clearAllFilter = () => (
+        setActiveFilters(filterConfigBuilder.initialDefaultState())
+    );
+    const deleteFilter = (chips) => (
+        setActiveFilters(filterConfigBuilder.removeFilterWithChip(
+            chips, activeFilters
+        ))
+    );
+    const onFilterDelete = (_event, chips, clearAll = false) => (
+        clearAll ? clearAllFilter() : deleteFilter(chips[0])
+    );
+    const chipBuilder = filterConfigBuilder.getChipBuilder();
+    const filterConfig = filterConfigBuilder.buildConfiguration(
+        onFilterUpdate,
+        activeFilters
+    );
+    const filterChips = chipBuilder.chipsFor(activeFilters);
+    const filteredArray = arrayToFilter ? filterConfigBuilder.applyFilterToObjectArray(
+        arrayToFilter, activeFilters
+    ) : undefined;
+
+    return {
+        conditionalFilter: {
+            filterConfig,
+            activeFiltersConfig: {
+                filters: filterChips,
+                onDelete: onFilterDelete
+            }
+        },
+        filtered: filteredArray
+    };
+};
+
+export default useFilterConfig;

--- a/src/Utilities/hooks/useTableSort.js
+++ b/src/Utilities/hooks/useTableSort.js
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+const getSortable = (property, item) => {
+    if (typeof(property) === 'function') {
+        return property(item);
+    } else {
+        return item[property];
+    }
+};
+
+export const orderArrayByProp = (property, objects, direction) => (
+    objects.sort((a, b) => {
+        if (direction === 'asc') {
+            return String(getSortable(property, a)).localeCompare(String(getSortable(property, b)));
+        } else {
+            return -String(getSortable(property, a)).localeCompare(String(getSortable(property, b)));
+        }
+    })
+);
+
+export const orderByArray = (objectArray, orderProp, orderArray, direction) => (
+    (direction !== 'asc' ? orderArray.reverse() : orderArray).flatMap((orderKey) => (
+        objectArray.filter((item) => (item[orderProp] === orderKey))
+    ))
+);
+
+const useTableSort = (array, columns) => {
+    const [sortBy, setSortBy] = useState({
+        index: 0,
+        direction: 'desc'
+    });
+    const column = columns[sortBy.index];
+    const onSort = (_, index, direction) => (
+        setSortBy({
+            index,
+            direction
+        })
+    );
+
+    return {
+        tableSort: {
+            onSort,
+            sortBy
+        },
+        sorted: orderArrayByProp(
+            (column?.sortByProperty || column?.sortByFunction), array, sortBy.direction
+        )
+    };
+};
+
+export default useTableSort;

--- a/src/__fixtures__/policies.js
+++ b/src/__fixtures__/policies.js
@@ -8,10 +8,16 @@ export const policies = {
                 complianceThreshold: 100,
                 businessObjective: null,
                 totalHostCount: 10,
+                compliantHostCount: 4,
                 majorOsVersion: 7,
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
+                },
+                policy: {
+                    id: 'b71376fd-015e-4209-99af-4543e82e5dc5-policy',
+                    name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73',
+                    __typename: 'Profile'
                 },
                 __typename: 'Profile'
             },

--- a/src/constants.js
+++ b/src/constants.js
@@ -70,3 +70,8 @@ export const COMPLIANT_SYSTEMS_FILTER_CONFIGURATION = [
         ]
     }
 ];
+
+export const features = {
+    // Enable via /insights/compliance/reports?reportsTableView=enable (or disable)
+    reportTableView: false
+};


### PR DESCRIPTION
This implements a table view for reports:

![Screenshot 2020-09-29 at 21 22 32](https://user-images.githubusercontent.com/7757/94609100-a8804900-029e-11eb-8db1-160cd32e4eed.png)

It can be enabled via https://prod.foo.redhat.com:1337/insights/compliance/reports?reportsTableView=enable and disabled by using `disable` instead.
