### PR TITLE
refactor: Update Ansible icons to use patternfly version

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -43,6 +43,10 @@ const frontendComponentsMappe = {
     TableFooter: 'Table'
 };
 
+const IconMapper = {
+    AnsibeTowerIcon: 'ansibeTower-icon'
+};
+
 module.exports = {
     presets: [
         [
@@ -89,10 +93,14 @@ module.exports = {
             },
             'react-core'
         ], [
-            'transform-imports',
-            {
+            'transform-imports', {
                 '@patternfly/react-icons': {
-                    transform: (importName, matches) => `@patternfly/react-icons/dist/js/icons/${importName.split(/(?=[A-Z])/).join('-').toLowerCase()}.js`,
+                    transform: (importName) => (
+                        `@patternfly/react-icons/dist/js/icons/${IconMapper[importName] || importName
+                        .split(/(?=[A-Z])/)
+                        .join('-')
+                        .toLowerCase()}.js`
+                    )
                 }
             },
             'react-icons'

--- a/src/SmartComponents/CreatePolicy/EditPolicyRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyRules.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { propTypes as reduxFormPropTypes, formValueSelector, reduxForm } from 'redux-form';
-import { SystemRulesTable, ANSIBLE_ICON } from '@redhat-cloud-services/frontend-components-inventory-compliance';
+import { SystemRulesTable } from '@redhat-cloud-services/frontend-components-inventory-compliance';
 import { EmptyTable, Spinner } from '@redhat-cloud-services/frontend-components';
 import { Button, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
+import { AnsibeTowerIcon } from '@patternfly/react-icons';
 import gql from 'graphql-tag';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -41,7 +42,7 @@ query benchmarkAndProfile($benchmarkId: String!, $profileId: String!){
 const columns = [
     { title: 'Rule', transforms: [sortable] },
     { title: 'Severity', transforms: [sortable] },
-    { title: <React.Fragment>{ ANSIBLE_ICON } Ansible</React.Fragment>, transforms: [sortable], original: 'Ansible' }
+    { title: <React.Fragment><AnsibeTowerIcon /> Ansible</React.Fragment>, transforms: [sortable], original: 'Ansible' }
 ];
 
 export const EditPolicyRules = ({ profileId, benchmarkId, selectedRuleRefIds, change }) => {

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyRules.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyRules.test.js.snap
@@ -56,6 +56,11 @@ exports[`EditPolicyRules expect to render with error on error 1`] = `
           Object {
             "original": "Ansible",
             "title": <React.Fragment>
+              <AnsibeTowerIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
                Ansible
             </React.Fragment>,
             "transforms": Array [
@@ -157,6 +162,11 @@ exports[`EditPolicyRules expect to render without error 1`] = `
           Object {
             "original": "Ansible",
             "title": <React.Fragment>
+              <AnsibeTowerIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
                Ansible
             </React.Fragment>,
             "transforms": Array [
@@ -273,6 +283,11 @@ exports[`EditPolicyRules expect to render without error 2`] = `
           Object {
             "original": "Ansible",
             "title": <React.Fragment>
+              <AnsibeTowerIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
                Ansible
             </React.Fragment>,
             "transforms": Array [
@@ -367,6 +382,11 @@ exports[`EditPolicyRules expect to render without error on loading 1`] = `
           Object {
             "original": "Ansible",
             "title": <React.Fragment>
+              <AnsibeTowerIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
                Ansible
             </React.Fragment>,
             "transforms": Array [

--- a/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Alert, Text, TextVariants, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import { SystemRulesTable, ANSIBLE_ICON } from '@redhat-cloud-services/frontend-components-inventory-compliance';
+import { AnsibeTowerIcon } from '@patternfly/react-icons';
+import { SystemRulesTable } from '@redhat-cloud-services/frontend-components-inventory-compliance';
 import { sortable } from '@patternfly/react-table';
 
 const PolicyRulesTab = ({ loading, policy }) => (
@@ -20,7 +21,8 @@ const PolicyRulesTab = ({ loading, policy }) => (
             columns={[
                 { title: 'Rule', transforms: [sortable] },
                 { title: 'Severity', transforms: [sortable] },
-                { title: <React.Fragment>{ ANSIBLE_ICON } Ansible</React.Fragment>, transforms: [sortable], original: 'Ansible' }
+                { title: <React.Fragment><AnsibeTowerIcon /> Ansible</React.Fragment>,
+                    transforms: [sortable], original: 'Ansible' }
             ]}
             loading={ loading }
             profileRules={[{


### PR DESCRIPTION
Just to be consistent and use the same icon as we do/will in `inventory-compliance`