### PR TITLE
fix(RHICOMPL-730): Request IDs for resources over GraphQL

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicyRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyRules.js
@@ -17,6 +17,7 @@ const QUERY = gql`
 query benchmarkAndProfile($benchmarkId: String!, $profileId: String!){
     benchmark(id: $benchmarkId) {
         rules {
+            id
             title
             severity
             rationale
@@ -27,6 +28,7 @@ query benchmarkAndProfile($benchmarkId: String!, $profileId: String!){
         }
     }
     profile(id: $profileId) {
+        id
         name
         refId
         rules {


### PR DESCRIPTION
Resources requested from GraphQL should have an ID to avoid issues with "caching" when re-requesting data.

The issue can be reproduced (without this fix) by opening the "Create policy" wizard twice.
The rules step will throw an error, with this fix the error does not appear and the rules step works as expected. 