### PR TITLE
fix(RHICOMPL-730): Add id for benchmark object as well

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicyRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyRules.js
@@ -17,6 +17,7 @@ import {
 const QUERY = gql`
 query benchmarkAndProfile($benchmarkId: String!, $profileId: String!){
     benchmark(id: $benchmarkId) {
+        id
         rules {
             id
             title
@@ -33,6 +34,7 @@ query benchmarkAndProfile($benchmarkId: String!, $profileId: String!){
         name
         refId
         rules {
+            id
             refId
         }
     }


### PR DESCRIPTION
The Rule step in the wizard was still failing for opening it a second time.
Giving an ID to benchmarks has solved the issue for RHEL + Policy Type where it would raise an error before this change.

Please see Jira for these cases and how to reproduce the issue.