### PR TITLE
fix(RHICOMPL-1023): Add withRouter back to make actions work again

### DIFF
--- a/src/PresentationalComponents/PoliciesTable/PoliciesTable.js
+++ b/src/PresentationalComponents/PoliciesTable/PoliciesTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link, withRouter } from 'react-router-dom';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 import {
     Button, Pagination, PaginationVariant, ToolbarItem, Tooltip
@@ -225,4 +225,4 @@ PoliciesTable.defaultProps = {
 
 export { policiesToRows };
 
-export default PoliciesTable;
+export default withRouter(PoliciesTable);

--- a/src/SmartComponents/CompliancePolicies/__snapshots__/CompliancePolicies.test.js.snap
+++ b/src/SmartComponents/CompliancePolicies/__snapshots__/CompliancePolicies.test.js.snap
@@ -247,7 +247,7 @@ exports[`CompliancePolicies expect to render a policies table 1`] = `
       <StateViewPart
         stateKey="data"
       >
-        <PoliciesTable
+        <withRouter(PoliciesTable)
           policies={
             Array [
               Object {
@@ -457,9 +457,7 @@ exports[`CompliancePolicies expect to render an error 1`] = `
       <StateViewPart
         stateKey="data"
       >
-        <PoliciesTable
-          policies={Array []}
-        />
+        <withRouter(PoliciesTable) />
       </StateViewPart>
     </StateView>
   </Connect(Main)>
@@ -772,9 +770,7 @@ exports[`CompliancePolicies expect to render loading 1`] = `
       <StateViewPart
         stateKey="data"
       >
-        <PoliciesTable
-          policies={Array []}
-        />
+        <withRouter(PoliciesTable) />
       </StateViewPart>
     </StateView>
   </Connect(Main)>
@@ -828,7 +824,7 @@ exports[`CompliancePolicies expect to render without error 1`] = `
       <StateViewPart
         stateKey="data"
       >
-        <PoliciesTable
+        <withRouter(PoliciesTable)
           policies={
             Array [
               undefined,


### PR DESCRIPTION
https://github.com/RedHatInsights/compliance-frontend/pull/779 Remove the withRouter decorator, which causes the actionResolver functions not to work properly.