### PR TITLE
fix(RHICOMPL-1014): Show custom policy name primarily on Reports table and Popover

### DIFF
--- a/src/PresentationalComponents/PolicyPopover/PolicyPopover.js
+++ b/src/PresentationalComponents/PolicyPopover/PolicyPopover.js
@@ -3,11 +3,13 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import {
     Button,
     Popover,
+    Text,
     TextList,
     TextListVariants,
     TextListItem,
     TextListItemVariants,
-    TextContent
+    TextContent,
+    TextVariants
 } from '@patternfly/react-core';
 import { fixedPercentage } from 'Utilities/TextHelper';
 import {
@@ -20,7 +22,12 @@ const PolicyPopover = ({ profile, position = 'top' }) => {
     return (
         <Popover
             { ...{ position } }
-            headerContent={name}
+            headerContent={
+                <TextContent>
+                    { policy.name }
+                    <Text component={ TextVariants.small }>{ name }</Text>
+                </TextContent>
+            }
             footerContent={
                 <Link to={'/scappolicies/' + policy.id} >
                     View policy

--- a/src/PresentationalComponents/PolicyPopover/__snapshots__/PolicyPopover.test.js.snap
+++ b/src/PresentationalComponents/PolicyPopover/__snapshots__/PolicyPopover.test.js.snap
@@ -48,7 +48,16 @@ exports[`PolicyPopover expect to render without error 1`] = `
       View policy
     </Link>
   }
-  headerContent="United States Government Configuration Baseline23"
+  headerContent={
+    <TextContent>
+      PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73
+      <Text
+        component="small"
+      >
+        United States Government Configuration Baseline23
+      </Text>
+    </TextContent>
+  }
   position="top"
 >
   <Button

--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -17,13 +17,13 @@ GreySmallText.propTypes = {
 export const Name = (profile) => (
     <TextContent>
         <Link to={'/reports/' + profile.id} style={ { marginRight: '.5rem' }}>
-            { profile.name }
+            { profile.policy ? profile.policy.name : profile.name }
         </Link>
         { profile.policy && <PolicyPopover { ...{ profile, position: 'right' } } /> }
         { !profile.policy && <Label color="red">
             External
         </Label> }
-        { profile.policy && <GreySmallText>{ profile.policy.name }</GreySmallText> }
+        { profile.policy && <GreySmallText>{ profile.name }</GreySmallText> }
     </TextContent>
 );
 

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -46,7 +46,7 @@ exports[`Name expect to render without error 1`] = `
     }
     to="/reports/ID"
   >
-    NAME
+    POLICY_NAME
   </Link>
   <PolicyPopover
     position="right"
@@ -62,7 +62,7 @@ exports[`Name expect to render without error 1`] = `
     }
   />
   <GreySmallText>
-    POLICY_NAME
+    NAME
   </GreySmallText>
 </TextContent>
 `;


### PR DESCRIPTION
Custom policy name should be shown primarily on the Reports table, and the canonical policy name shown underneath.
The same should be shown on the Policy Popover.

![Screenshot_2020-10-06 Compliance](https://user-images.githubusercontent.com/7695766/95202251-5af56600-07e1-11eb-8a89-fd602b3a8f7a.png)
![Screenshot from 2020-10-06 15-06-23](https://user-images.githubusercontent.com/7695766/95205920-53848b80-07e6-11eb-9c56-a462a14b27d5.png)
