### PR TITLE
fix(RHICOMPL-880): Use selectRulesTableColumns to not redefine columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4029,9 +4029,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-inventory-compliance": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-compliance/-/frontend-components-inventory-compliance-2.2.9.tgz",
-      "integrity": "sha512-k809g//ll9A2MoefmN84+kD4HvapZVSEVE01YUDEW9YOlKKthAmXhofNfcTEIon2YyMbH/J/RznXyv840AajqQ==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-compliance/-/frontend-components-inventory-compliance-2.2.10.tgz",
+      "integrity": "sha512-MTUhNB9VFm/j6lWKTckLRCFjD9EMLS+NMMVRI5lWFKgugrDgtcMMx6o/DTOjh/k8ck2xMv4Gn91LYno4LQPybw==",
       "requires": {
         "@apollo/react-hooks": "^3.1.5",
         "@redhat-cloud-services/frontend-components": "*",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@patternfly/react-table": "^4.16.20",
     "@patternfly/react-tokens": "^4.9.8",
     "@redhat-cloud-services/frontend-components": "^2.4.9",
-    "@redhat-cloud-services/frontend-components-inventory-compliance": "^2.2.9",
+    "@redhat-cloud-services/frontend-components-inventory-compliance": "^2.2.10",
     "@redhat-cloud-services/frontend-components-notifications": "^2.2.2",
     "@redhat-cloud-services/frontend-components-remediations": "^2.2.3",
     "@redhat-cloud-services/frontend-components-utilities": "^2.2.4",

--- a/src/SmartComponents/CreatePolicy/EditPolicyRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyRules.js
@@ -1,10 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { propTypes as reduxFormPropTypes, formValueSelector, reduxForm } from 'redux-form';
-import { SystemRulesTable } from '@redhat-cloud-services/frontend-components-inventory-compliance';
+import { SystemRulesTable, selectRulesTableColumns } from '@redhat-cloud-services/frontend-components-inventory-compliance';
 import { EmptyTable, Spinner } from '@redhat-cloud-services/frontend-components';
 import { Button, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { sortable } from '@patternfly/react-table';
-import { AnsibeTowerIcon } from '@patternfly/react-icons';
 import gql from 'graphql-tag';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -41,13 +39,8 @@ query benchmarkAndProfile($benchmarkId: String!, $profileId: String!){
 }
 `;
 
-const columns = [
-    { title: 'Rule', transforms: [sortable] },
-    { title: 'Severity', transforms: [sortable] },
-    { title: <React.Fragment><AnsibeTowerIcon /> Ansible</React.Fragment>, transforms: [sortable], original: 'Ansible' }
-];
-
 export const EditPolicyRules = ({ profileId, benchmarkId, selectedRuleRefIds, change }) => {
+    const columns = selectRulesTableColumns(['Rule', 'Severity', 'Ansible']);
     const { data, error, loading } = useQuery(QUERY, { variables: { profileId, benchmarkId } });
     const [defaultSelection, setDefaultSelection] = useState(null);
     const profileRules = data && [{

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyRules.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyRules.test.js.snap
@@ -51,10 +51,14 @@ exports[`EditPolicyRules expect to render with error on error 1`] = `
             "title": "Severity",
             "transforms": Array [
               [Function],
+              [Function],
             ],
           },
           Object {
             "original": "Ansible",
+            "props": Object {
+              "tooltip": "Ansible",
+            },
             "title": <React.Fragment>
               <AnsibeTowerIcon
                 color="currentColor"
@@ -64,6 +68,7 @@ exports[`EditPolicyRules expect to render with error on error 1`] = `
                Ansible
             </React.Fragment>,
             "transforms": Array [
+              [Function],
               [Function],
             ],
           },
@@ -157,10 +162,14 @@ exports[`EditPolicyRules expect to render without error 1`] = `
             "title": "Severity",
             "transforms": Array [
               [Function],
+              [Function],
             ],
           },
           Object {
             "original": "Ansible",
+            "props": Object {
+              "tooltip": "Ansible",
+            },
             "title": <React.Fragment>
               <AnsibeTowerIcon
                 color="currentColor"
@@ -170,6 +179,7 @@ exports[`EditPolicyRules expect to render without error 1`] = `
                Ansible
             </React.Fragment>,
             "transforms": Array [
+              [Function],
               [Function],
             ],
           },
@@ -278,10 +288,14 @@ exports[`EditPolicyRules expect to render without error 2`] = `
             "title": "Severity",
             "transforms": Array [
               [Function],
+              [Function],
             ],
           },
           Object {
             "original": "Ansible",
+            "props": Object {
+              "tooltip": "Ansible",
+            },
             "title": <React.Fragment>
               <AnsibeTowerIcon
                 color="currentColor"
@@ -291,6 +305,7 @@ exports[`EditPolicyRules expect to render without error 2`] = `
                Ansible
             </React.Fragment>,
             "transforms": Array [
+              [Function],
               [Function],
             ],
           },
@@ -377,10 +392,14 @@ exports[`EditPolicyRules expect to render without error on loading 1`] = `
             "title": "Severity",
             "transforms": Array [
               [Function],
+              [Function],
             ],
           },
           Object {
             "original": "Ansible",
+            "props": Object {
+              "tooltip": "Ansible",
+            },
             "title": <React.Fragment>
               <AnsibeTowerIcon
                 color="currentColor"
@@ -390,6 +409,7 @@ exports[`EditPolicyRules expect to render without error on loading 1`] = `
                Ansible
             </React.Fragment>,
             "transforms": Array [
+              [Function],
               [Function],
             ],
           },

--- a/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Alert, Text, TextVariants, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import { AnsibeTowerIcon } from '@patternfly/react-icons';
-import { SystemRulesTable } from '@redhat-cloud-services/frontend-components-inventory-compliance';
-import { sortable } from '@patternfly/react-table';
+import { SystemRulesTable, selectRulesTableColumns } from '@redhat-cloud-services/frontend-components-inventory-compliance';
 
 const PolicyRulesTab = ({ loading, policy }) => (
     <React.Fragment>
@@ -18,12 +16,7 @@ const PolicyRulesTab = ({ loading, policy }) => (
         </PageSection>
         <SystemRulesTable
             remediationsEnabled={false}
-            columns={[
-                { title: 'Rule', transforms: [sortable] },
-                { title: 'Severity', transforms: [sortable] },
-                { title: <React.Fragment><AnsibeTowerIcon /> Ansible</React.Fragment>,
-                    transforms: [sortable], original: 'Ansible' }
-            ]}
+            columns={ selectRulesTableColumns(['Rule', 'Severity', 'Ansible']) }
             loading={ loading }
             profileRules={[{
                 profile: { refId: policy.refId, name: policy.name },


### PR DESCRIPTION
This uses the helper function to get column definitions for the rules table introduced with https://github.com/RedHatInsights/frontend-components/pull/765 and will also fixes the issues with html in the tooltip, by avoiding it.