### PR TITLE
fix(RHICOMPL-1052): external profiles means no policy

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -82,6 +82,9 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
                     external
                     compliant
                     score
+                    policy {
+                        id
+                    }
                 }
             }
         }

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -61,7 +61,7 @@ export const profileNames = (system) => {
     if (system === {}) { return ''; }
 
     return system.profiles.map(
-        (profile) => `${profile.external ? '(External) ' : '' }${profile.name}`
+        (profile) => `${profile.policy ? '' : '(External) ' }${profile.name}`
     ).join(', ');
 };
 

--- a/src/store/Reducers/SystemStore.test.js
+++ b/src/store/Reducers/SystemStore.test.js
@@ -146,8 +146,8 @@ describe('.profileNames', () => {
     it('should include external if profile is external', () => {
         const system = {
             profiles: [
-                { external: true, name: 'HIPAA' },
-                { external: false, name: 'PCI' }
+                { name: 'HIPAA' },
+                { policy: {}, name: 'PCI' }
             ]
         };
         expect(profileNames(system)).toEqual('(External) HIPAA, PCI');

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -18,7 +18,7 @@ Array [
               id="d5bc2459-21ce-4d11-bc0b-03ea7513dfa6"
               lastScanned={2019-11-21T14:32:19.000Z}
               name="demo.lobatolan.home"
-              profileNames="Standard System Security Profile for Red Hat Enterprise Linux 7, DISA STIG for Red Hat Enterprise Linux 7, United States Government Configuration Baseline, C2S for Red Hat Enterprise Linux 7"
+              profileNames="(External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7"
               profiles={
                 Array [
                   Object {
@@ -356,9 +356,9 @@ Array [
         },
         "last_scanned_text": 2019-11-21T14:32:19.000Z,
         "policies": Object {
-          "exportValue": "Standard System Security Profile for Red Hat Enterprise Linux 7, DISA STIG for Red Hat Enterprise Linux 7, United States Government Configuration Baseline, C2S for Red Hat Enterprise Linux 7",
+          "exportValue": "(External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7",
           "title": <Tooltip
-            content="Standard System Security Profile for Red Hat Enterprise Linux 7, DISA STIG for Red Hat Enterprise Linux 7, United States Government Configuration Baseline, C2S for Red Hat Enterprise Linux 7"
+            content="(External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7"
           >
             <Truncate
               ellipsis="…"
@@ -366,7 +366,7 @@ Array [
               trimWhitespace={false}
               width={540}
             >
-              Standard System Security Profile for Red Hat Enterprise Linux 7, DISA STIG for Red Hat Enterprise Linux 7, United States Government Configuration Baseline, C2S for Red Hat Enterprise Linux 7
+              (External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7
             </Truncate>
           </Tooltip>,
         },


### PR DESCRIPTION
This changes the systems view in the UI to determine if a policy is
external by looking at the profile's policy attribute rather than the
external attribute.

Signed-off-by: Andrew Kofink <akofink@redhat.com>