### PR TITLE
fix(RHICOMPL-1069): SystemsTable to show systems for a policy

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -173,7 +173,7 @@ class SystemsTable extends React.Component {
         }
 
         if (policyId && policyId.length > 0) {
-            filter = `profile_id = ${policyId} and ${filter}`;
+            filter = `policy_id = ${policyId} and ${filter}`;
         }
 
         return client.query({


### PR DESCRIPTION
querying GQL `policy_id`, which also accepts profile id of policy that
the system is assigned to.

Requires backend changes RedHatInsights/compliance-backend#629