### PR TITLE
[RHICOMPL-1027][RHICOMPL-1036] Reports grouped by policy

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.test.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.test.js
@@ -6,6 +6,13 @@ import { Provider as ReduxProvider } from 'react-redux';
 
 const mockStore = configureStore();
 
+jest.mock('react-router-dom', () => ({
+    ...require.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({})),
+    useHistory: jest.fn(() => ({
+        push: jest.fn()
+    }))
+}));
 import EditPolicySystems from './EditPolicySystems.js';
 
 describe('EditPolicySystems', () => {

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -10,8 +10,8 @@ import {
 import useFeature from 'Utilities/hooks/useFeature';
 
 const QUERY = gql`
-{
-    profiles(search: "has_test_results = true", limit: 1000){
+query Profiles($filter: String!) {
+    profiles(search: $filter, limit: 1000){
         edges {
             node {
                 id
@@ -71,9 +71,21 @@ export const Reports = () => {
     let profiles = [];
     let showView = false;
     const location = useLocation();
-    let { data, error, loading, refetch } = useQuery(QUERY);
+    const profilesGroupedByPolicy = useFeature('profilesGroupedByPolicy');
     const showTableView = useFeature('reportsTableView');
     const View = showTableView ? ReportsTable : ReportCardGrid;
+
+    let searchFilter;
+    if (profilesGroupedByPolicy) {
+        searchFilter = `(has_policy_test_results = true AND external = false)
+                        OR (has_policy = false AND has_test_results = true)`;
+    } else {
+        searchFilter = 'has_test_results = true';
+    }
+
+    let { data, error, loading, refetch } = useQuery(QUERY, {
+        variables: { filter: searchFilter }
+    });
 
     useEffect(() => {
         refetch();

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -22,6 +22,7 @@ import {
 
 import { exportFromState, selectAll, clearSelection, SELECT_ENTITY } from 'Store/ActionTypes';
 import { systemsWithRuleObjectsFailed } from 'Utilities/ruleHelpers';
+import useFeature from 'Utilities/hooks/useFeature';
 import { FilterConfigBuilder } from '@redhat-cloud-services/frontend-components-inventory-compliance';
 import { entitiesReducer } from 'Store/Reducers/SystemStore';
 import {
@@ -57,6 +58,9 @@ query getSystems($filter: String!, $perPage: Int, $page: Int) {
                         title
                         compliant
                         remediationAvailable
+                    }
+                    policy {
+                        id
                     }
                 }
             }
@@ -257,7 +261,7 @@ class SystemsTable extends React.Component {
     }
 
     async fetchInventory() {
-        const { columns, policyId, showAllSystems, clearInventoryFilter } = this.props;
+        const { columns, policyId, showAllSystems, clearInventoryFilter, profilesGroupedByPolicy } = this.props;
         const {
             inventoryConnector,
             INVENTORY_ACTION_TYPES,
@@ -276,7 +280,8 @@ class SystemsTable extends React.Component {
         this.getRegistry().register({
             ...mergeWithEntities(
                 entitiesReducer(
-                    INVENTORY_ACTION_TYPES, columns, showAllSystems, policyId
+                    INVENTORY_ACTION_TYPES, columns, showAllSystems,
+                    policyId, profilesGroupedByPolicy
                 ))
         });
 
@@ -403,6 +408,7 @@ SystemsTable.propTypes = {
     exportFromState: propTypes.func,
     policies: propTypes.array,
     policyId: propTypes.string,
+    profilesGroupedByPolicy: propTypes.bool,
     preselectedSystems: propTypes.array,
     remediationsEnabled: propTypes.bool,
     selectAll: propTypes.func,
@@ -426,6 +432,7 @@ SystemsTable.propTypes = {
 
 SystemsTable.defaultProps = {
     policyId: '',
+    profilesGroupedByPolicy: false,
     remediationsEnabled: true,
     compact: false,
     enableExport: true,
@@ -486,7 +493,12 @@ const mapDispatchToProps = dispatch => {
 };
 
 const ConnectedSystemsTable = (props) => {
-    return <SystemsTable {...props} store={ReactRedux.useStore()} />;
+    const profilesGroupedByPolicy = useFeature('profilesGroupedByPolicy');
+    props = {
+        ...{ profilesGroupedByPolicy: profilesGroupedByPolicy },
+        ...props
+    };
+    return <SystemsTable {  ...props } store={ReactRedux.useStore()} />;
 };
 
 export { SystemsTable };

--- a/src/constants.js
+++ b/src/constants.js
@@ -74,5 +74,6 @@ export const COMPLIANT_SYSTEMS_FILTER_CONFIGURATION = [
 export const features = {
     // Enable via /insights/compliance/reports?reportsTableView=enable (or disable)
     reportTableView: false,
-    multiversionTabs: false
+    multiversionTabs: false,
+    profilesGroupedByPolicy: false
 };


### PR DESCRIPTION
The reports page should group profiles by policy.

It queries internal profiles (act as a policy to a user) that have a policy test result, and, it queries external profiles (not part of any policy) that have a test result. 
Note, that a policy test result happens when at least one policy profile has a test result.

The system reducer should pick profiles that are part of the policy.

This covers case when a policy report is shown (with internal profile
loaded) having a system scanned with a different SSG.  In that case the
host would have different profileId, however it is still part of the
policy.

