### PR TITLE
fix(RHICOMPL-1005): Correct filter name on reports table

### DIFF
--- a/src/PresentationalComponents/ReportsTable/Filters.js
+++ b/src/PresentationalComponents/ReportsTable/Filters.js
@@ -42,7 +42,7 @@ export const operatingSystemFilter = (operatingSystems) => ([{
 
 export const policyComplianceFilter = [{
     type: conditionalFilterType.checkbox,
-    label: 'Systemsmeetingcompliance', // FIX in FC: The filterconfig helper can't handle two much space...
+    label: 'Systems meeting compliance',
     filter: (profiles, values) => (
         profiles.filter(({ totalHostCount, compliantHostCount }) => {
             const compliantHostsPercent = Math.round((100 / totalHostCount) * compliantHostCount);

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
@@ -79,7 +79,7 @@ exports[`ReportsTable expect to render without error 1`] = `
               "value": Array [],
             },
             "id": "systemsmeetingcompliance",
-            "label": "Systemsmeetingcompliance",
+            "label": "Systems meeting compliance",
             "type": "checkbox",
           },
         ],


### PR DESCRIPTION
Follow up to https://github.com/RedHatInsights/frontend-components/pull/761