### PR TITLE
[RHICOMPL-959] Use policyType field in policy details

### DIFF
--- a/src/PresentationalComponents/PolicyDetailsDescription/PolicyDetailsDescription.js
+++ b/src/PresentationalComponents/PolicyDetailsDescription/PolicyDetailsDescription.js
@@ -65,7 +65,7 @@ const PolicyDetailsDescription = ({ policy }) => (
                     { policy.benchmark.title } { policy.benchmark.version }
                 </Text>
                 <Text component={TextVariants.h5}>Policy type </Text>
-                <Text component={TextVariants.p}>{ policy.policy.name }</Text>
+                <Text component={TextVariants.p}>{ policy.policyType }</Text>
                 <Text component={TextVariants.h5}>Reference ID</Text>
                 <Text component={TextVariants.p}>{ policy.refId }</Text>
             </TextContent>

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -29,6 +29,7 @@ const QUERY = gql`
                 complianceThreshold
                 totalHostCount
                 majorOsVersion
+                policyType
                 benchmark {
                     id
                     title

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -31,6 +31,7 @@ query Profile($policyId: String!){
         complianceThreshold
         majorOsVersion
         lastScanned
+        policyType
         policy {
             id
             name
@@ -79,6 +80,7 @@ query Profile($policyId: String!){
         complianceThreshold
         majorOsVersion
         lastScanned
+        policyType
         policy {
             id
             name


### PR DESCRIPTION
A new attribute, policyType, is now exposed on a profile. This updates
the policy details page to use it.

Requires https://github.com/RedHatInsights/compliance-backend/pull/642

Signed-off-by: Andrew Kofink <akofink@redhat.com>