### PR TITLE
[RHICOMPL-1027] Group reports by policy and aggregate systems

### DIFF
--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -11,8 +11,8 @@ import {
 import useFeature from 'Utilities/hooks/useFeature';
 
 const QUERY = gql`
-{
-    profiles(search: "has_test_results = true", limit: 1000){
+query Profiles($filter: String!) {
+    profiles(search: $filter, limit: 1000){
         edges {
             node {
                 id
@@ -84,9 +84,14 @@ export const Reports = () => {
     let profiles = [];
     let showView = false;
     const location = useLocation();
-    let { data, error, loading, refetch } = useQuery(QUERY);
     const showTableView = useFeature('reportsTableView');
     const View = showTableView ? ReportsTable : ReportCardGrid;
+    const filter = `(has_policy_test_results = true AND external = false)
+                    OR (has_policy = false AND has_test_results = true)`;
+
+    let { data, error, loading, refetch } = useQuery(QUERY, {
+        variables: { filter }
+    });
 
     useEffect(() => {
         refetch();

--- a/src/store/Reducers/SystemStore.test.js
+++ b/src/store/Reducers/SystemStore.test.js
@@ -1,6 +1,5 @@
 import {
     compliant,
-    findProfiles,
     hasOsInfo,
     lastScanned,
     profileNames,
@@ -73,17 +72,6 @@ describe('.lastScanned', () => {
         expect(lastScanned({ profiles: [] })).toEqual('Never');
         expect(lastScanned({ profiles: [{ lastScanned: 'Never' }] })).toEqual('Never');
     });
-
-    it('should find the latest scan date for a specific profile', () => {
-        const system = {
-            profiles: [
-                { id: '1', lastScanned: '2019-10-23T15:59:49Z' },
-                { id: '2', lastScanned: '2018-12-23T17:59:49Z' }
-            ]
-        };
-        expect(lastScanned(system, '1')).toEqual(new Date('2019-10-23T15:59:49Z'));
-        expect(lastScanned(system, '2')).toEqual(new Date('2018-12-23T17:59:49Z'));
-    });
 });
 
 describe('.compliant', () => {
@@ -105,40 +93,6 @@ describe('.compliant', () => {
             ]
         };
         expect(compliant(system)).toEqual(true);
-    });
-
-    it('should return value for a specific profile', () => {
-        const system = {
-            profiles: [
-                { id: '1', compliant: true },
-                { id: '2', compliant: false }
-            ]
-        };
-        expect(compliant(system, '1')).toEqual(true);
-        expect(compliant(system, '2')).toEqual(false);
-    });
-});
-
-describe('.findProfiles', () => {
-    it('should return all profiles if empty profileIds is sent', () => {
-        const system = {
-            profiles: [
-                { compliant: true },
-                { compliant: false }
-            ]
-        };
-        expect(findProfiles(system, [''])).toEqual(system.profiles);
-    });
-
-    it('should return a specific profile if profile Id is sent', () => {
-        const system = {
-            profiles: [
-                { id: '1', compliant: true },
-                { id: '2', compliant: true }
-            ]
-        };
-        expect(findProfiles(system, ['1'])).toEqual([system.profiles[0]]);
-        expect(findProfiles(system, ['1', '2'])).toEqual(system.profiles);
     });
 });
 


### PR DESCRIPTION
The reports page should group profiles by policy.
It queries internal profiles (act as a policy to a user) that have a
policy test result, and, it queries external profiles (not part of any
policy) that have a test result

Policy systems are aggregated from all policy profiles, by
leveraging filtering of system by a policy on GraphQL.

**Requires backend RedHatInsights/compliance-backend#647**

Please note, that the policy deduplication on Systems page will be done in separate PR.

![Screenshot_2020-11-10 Compliance](https://user-images.githubusercontent.com/7695766/98711676-97d6ee80-2385-11eb-8a37-23f3595bf677.png)
![Screenshot_2020-11-10 Compliance(1)](https://user-images.githubusercontent.com/7695766/98711684-9ad1df00-2385-11eb-8a2f-4a7dac814240.png)
