### PR TITLE
refactor(RHICOMPL-1105): contextual useFeature hook

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -14,3 +14,27 @@ global.mount = mount;
 global.React = React;
 global.fetch = fetch;
 global.toJson = toJson;
+
+// https://github.com/facebook/jest/issues/2098#issuecomment-260733457
+const localStorageMock = (() => {
+    let store = {};
+
+    return {
+        getItem(key) {
+            return store[key] || null;
+        },
+        setItem(key, value) {
+            store[key] = value.toString();
+        },
+        clear() {
+            store = {};
+        }
+    };
+
+})();
+
+global.localStorageMock = localStorageMock;
+
+Object.defineProperty(window, 'localStorage', {
+    value: localStorageMock
+});

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { Routes } from './Routes';
 import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-notifications';
 import '@redhat-cloud-services/frontend-components-notifications/index.css';
 import './App.scss';
+import { EnabledFeatures } from './Utilities/EnabledFeatures';
 
 const App = (props) => {
     const appNavClick = {
@@ -36,7 +37,9 @@ const App = (props) => {
     return (
         <React.Fragment>
             <NotificationsPortal />
-            <Routes childProps={props} />
+            <EnabledFeatures>
+                <Routes childProps={props} />
+            </EnabledFeatures>
         </React.Fragment>
     );
 };

--- a/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
+++ b/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
@@ -19,7 +19,9 @@ exports[`Reports expect to render emptystate 1`] = `
   >
     <ReportsHeader />
     <Connect(Main)>
-      <LoadingView />
+      <LoadingView
+        showTableView={false}
+      />
     </Connect(Main)>
   </StateViewPart>
   <StateViewPart
@@ -48,7 +50,9 @@ exports[`Reports expect to render loading 1`] = `
   >
     <ReportsHeader />
     <Connect(Main)>
-      <LoadingView />
+      <LoadingView
+        showTableView={false}
+      />
     </Connect(Main)>
   </StateViewPart>
   <StateViewPart
@@ -97,7 +101,9 @@ exports[`Reports expect to render without error 1`] = `
   >
     <ReportsHeader />
     <Connect(Main)>
-      <LoadingView />
+      <LoadingView
+        showTableView={false}
+      />
     </Connect(Main)>
   </StateViewPart>
   <StateViewPart

--- a/src/Utilities/EnabledFeatures.js
+++ b/src/Utilities/EnabledFeatures.js
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from 'react';
+import propTypes from 'prop-types';
+import { useLocation } from 'react-router-dom';
+import { features } from '@/constants';
+
+const LOCAL_STORE_FEATURE_PREFIX = 'insights:compliance';
+
+export const EnabledFeaturesContext = React.createContext(features);
+
+export const getStoredFeatures = () => {
+    let savedState = { ...features };
+    Object.keys(features).forEach((feature) => {
+        let stored = localStorage.getItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`);
+        if (stored) {
+            savedState[feature] = !!stored;
+        }
+    });
+    return savedState;
+};
+
+const storeFeatureFlag = (feature, value) => {
+    if (!value) {
+        console.log(`Removing feature setting of ${feature}`);
+        localStorage.removeItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`);
+    } else {
+        console.log(`Setting feature value for ${feature} to ${value}`);
+        localStorage.setItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`, value);
+    }
+};
+
+export const EnabledFeatures = ({ children }) => {
+    const [enabledFeatures, setEnabledFeatures] = useState(getStoredFeatures);
+    const { search } = useLocation();
+
+    useEffect(() => {
+        let setFeatures = {};
+
+        const urlParams = new URLSearchParams(search || '');
+        urlParams.forEach((value, feature) => {
+            let featureEnabled = value === 'enable';
+            if (features[feature] === undefined && !featureEnabled) {
+                return;
+            }
+
+            storeFeatureFlag(feature, featureEnabled);
+            setFeatures[feature] = featureEnabled;
+        });
+
+        if (Object.keys(setFeatures).length > 0) {
+            setEnabledFeatures({ ...enabledFeatures, ...setFeatures });
+        }
+    }, [search]);
+
+    return (
+        <EnabledFeaturesContext.Provider value={enabledFeatures}>
+            { children }
+        </EnabledFeaturesContext.Provider>
+    );
+};
+
+EnabledFeatures.propTypes = {
+    children: propTypes.node
+};
+
+export default EnabledFeatures;

--- a/src/Utilities/EnabledFeatures.test.js
+++ b/src/Utilities/EnabledFeatures.test.js
@@ -1,0 +1,43 @@
+/*global localStorageMock*/
+import { getStoredFeatures, EnabledFeatures } from './EnabledFeatures';
+
+jest.mock('@/constants', () => ({
+    features: {
+        defaultFeature: true,
+        featureToEnable: false
+    }
+}));
+jest.mock('react-router-dom', () => ({
+    ...require.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({}))
+}));
+
+afterEach(() => (localStorageMock.clear()));
+
+describe('getStoredFeatures', () => {
+    it('loads defaults', () => {
+        expect(getStoredFeatures()).toStrictEqual({
+            defaultFeature: true,
+            featureToEnable: false
+        });
+    });
+
+    it('loads defaults and stored feature configuration', () => {
+        localStorageMock.setItem('insights:compliance:featureToEnable', 'true');
+        expect(getStoredFeatures()).toStrictEqual({
+            defaultFeature: true,
+            featureToEnable: true
+        });
+    });
+});
+
+describe('Reports', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <EnabledFeatures>
+                <div>PAGE</div>
+            </EnabledFeatures>
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/Utilities/__snapshots__/EnabledFeatures.test.js.snap
+++ b/src/Utilities/__snapshots__/EnabledFeatures.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reports expect to render without error 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "defaultFeature": true,
+      "featureToEnable": false,
+    }
+  }
+>
+  <div>
+    PAGE
+  </div>
+</ContextProvider>
+`;

--- a/src/Utilities/hooks/useFeature.js
+++ b/src/Utilities/hooks/useFeature.js
@@ -30,7 +30,7 @@ const setFlagsFromUrl = () => {
 
 // Queries the local storage for feature flag values
 const getLocatStateFlag = (feature) => (
-    localStorage.getItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`)
+    !!localStorage.getItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`)
 );
 
 // A hook to query feature values

--- a/src/Utilities/hooks/useFeature.js
+++ b/src/Utilities/hooks/useFeature.js
@@ -1,52 +1,10 @@
-import { features } from '@/constants';
-import { useLocation, useHistory } from 'react-router-dom';
-const LOCAL_STORE_FEATURE_PREFIX = 'insights:compliance';
-
-const setFeatureFlag = (featureValue, feature) => {
-    const value = featureValue === 'enable';
-
-    if (!value) {
-        console.log(`Removing feature setting of ${feature}`);
-        localStorage.removeItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`);
-    } else {
-        console.log(`Setting feature value for ${feature} to ${value}`);
-        localStorage.setItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`, value);
-    }
-};
-
-// Allows setting feature flag values via ?feature|(enable/disable)
-const setFlagsFromUrl = () => {
-    const { search, pathName: path } = useLocation();
-    const history = useHistory();
-    if (!search) {
-        return;
-    }
-
-    const urlParams = new URLSearchParams(search);
-    urlParams.forEach(setFeatureFlag);
-
-    history.push(path);
-};
-
-// Queries the local storage for feature flag values
-const getLocatStateFlag = (feature) => (
-    !!localStorage.getItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`)
-);
+import { useContext } from 'react';
+import { EnabledFeaturesContext } from '../EnabledFeatures';
 
 // A hook to query feature values
 const useFeature = (feature) => {
-    const featureDefault = features[feature];
-    if (!feature) {
-        return;
-    }
-
-    setFlagsFromUrl();
-
-    const localStoreValue = getLocatStateFlag(feature);
-    const featureEnabled = localStoreValue || featureDefault;
-
-    console.log(`Feature ${feature} is set to ${featureEnabled}`);
-    return featureEnabled;
+    const enabledFeatures = useContext(EnabledFeaturesContext);
+    return enabledFeatures[feature];
 };
 
 export default useFeature;

--- a/src/constants.js
+++ b/src/constants.js
@@ -73,7 +73,7 @@ export const COMPLIANT_SYSTEMS_FILTER_CONFIGURATION = [
 
 export const features = {
     // Enable via /insights/compliance/reports?reportsTableView=enable (or disable)
-    reportTableView: false,
+    reportsTableView: false,
     multiversionTabs: false,
     showSsgVersions: false
 };


### PR DESCRIPTION
useFeature hook now uses global EnabledFeaturesContext.

This improves:
* parsing URL only once
* setting and checking stored values only once
* globally accessible context through useFeature hook

Also fixes:
* warnings on non-boolean value passed from a stored value
* `reportsTableView` constant (typo)