### PR TITLE
feat: Implement unsupported SSG version warning

### DIFF
--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { Label, TextContent, Progress } from '@patternfly/react-core';
+import { Label, TextContent, Text, Progress } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { PolicyPopover, GreySmallText } from 'PresentationalComponents';
+import { PolicyPopover, GreySmallText, SSGVersionWarning } from 'PresentationalComponents';
 
 export const Name = (profile) => (
     <TextContent>
@@ -21,33 +21,56 @@ export const Name = (profile) => (
 );
 
 Name.propTypes = {
-    id: propTypes.string,
-    name: propTypes.string,
-    policy: propTypes.object
+    profile: propTypes.object
 };
 
-export const rhelColorMap = {
-    7: 'cyan',
-    8: 'purple'
+export const OperatingSystem = ({ majorOsVersion, ssgVersion, supported }) => {
+    const rhelColorMap = {
+        7: 'cyan',
+        8: 'purple',
+        default: 'var(--pf-global--disabled-color--200)'
+    };
+    const color = rhelColorMap[majorOsVersion] || rhelColorMap.default;
+
+    return <React.Fragment>
+        <Label { ...{ color } }>RHEL { majorOsVersion }</Label>
+        { ssgVersion && <Text>
+            <GreySmallText>
+                <SSGVersionWarning supported={ supported }>{ ssgVersion }</SSGVersionWarning>
+            </GreySmallText>
+        </Text> }
+    </React.Fragment>;
 };
-export const OperatingSystem = ({ majorOsVersion }) => (
-    <Label color={ rhelColorMap[majorOsVersion] }>RHEL { majorOsVersion }</Label>
-);
 
 OperatingSystem.propTypes = {
-    majorOsVersion: propTypes.string
+    majorOsVersion: propTypes.string,
+    ssgVersion: propTypes.string,
+    supported: propTypes.bool
 };
 
-export const CompliantSystems = ({ totalHostCount = 0, compliantHostCount = 0 }) => (
-    <React.Fragment>
+export const CompliantSystems = ({ totalHostCount = 0, compliantHostCount = 0, unsupportedSystems = 0 }) => {
+    const tooltipText = 'Insights cannot provide a compliance score for systems running an unsupported ' +
+        'version of the SSG at the time this report was created, as the SSG version was not supported by RHEL.';
+
+    return <React.Fragment>
         <Progress
             measureLocation={ 'outside' }
             value={ (100 / totalHostCount) * compliantHostCount } />
-        <GreySmallText>{ `${ compliantHostCount } of ${ totalHostCount } systems` }</GreySmallText>
-    </React.Fragment>
-);
+        <GreySmallText>
+            { `${ compliantHostCount } of ${ totalHostCount } systems ` }
+
+            { unsupportedSystems > 0 && <SSGVersionWarning
+                supported={ false }
+                tooltipText={ tooltipText }
+                style={ { marginLeft: '.5em' } }>
+                <strong className='ins-u-warning'>{ unsupportedSystems } unsupported</strong>
+            </SSGVersionWarning> }
+        </GreySmallText>
+    </React.Fragment>;
+};
 
 CompliantSystems.propTypes = {
     totalHostCount: propTypes.number,
-    compliantHostCount: propTypes.number
+    compliantHostCount: propTypes.number,
+    unsupportedSystems: propTypes.number
 };

--- a/src/PresentationalComponents/ReportsTable/Cells.test.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.test.js
@@ -19,9 +19,29 @@ describe('Name', () => {
 });
 
 describe('OperatingSystem', () => {
+    const defaultProps = {
+        majorOsVersion: 7
+    };
+
     it('expect to render without error', () => {
         const wrapper = shallow(
-            <OperatingSystem majorOsVersion="7" />
+            <OperatingSystem { ...defaultProps } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render with SSG version', () => {
+        const wrapper = shallow(
+            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render with unsupported warning', () => {
+        const wrapper = shallow(
+            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' supported={ false } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -29,9 +49,22 @@ describe('OperatingSystem', () => {
 });
 
 describe('CompliantSystems', () => {
+    const deftaultProps = {
+        totalHostCount: 10,
+        compliantHostCount: 9
+    };
+
     it('expect to render without error', () => {
         const wrapper = shallow(
-            <CompliantSystems totalHostCount={ 10 } compliantHostCount={ 9 } />
+            <CompliantSystems { ...deftaultProps } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render with unsupported hosts', () => {
+        const wrapper = shallow(
+            <CompliantSystems { ...deftaultProps } unsupportedSystems={ 42 } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/PresentationalComponents/ReportsTable/ReportsTable.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { Table, TableBody, TableHeader, sortable } from '@patternfly/react-table';
+import { Table, TableBody, TableHeader, sortable, fitContent } from '@patternfly/react-table';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
 import { emptyRows } from 'PresentationalComponents';
 import useFilterConfig from 'Utilities/hooks/useFilterConfig';
@@ -19,12 +19,12 @@ const ReportsTable = ({ profiles }) => {
         },
         {
             title: 'Operating system',
-            transforms: [sortable],
+            transforms: [sortable, fitContent],
             sortByProperty: 'majorOsVersion'
         },
         {
             title: 'Systems meeting compliance',
-            transforms: [sortable],
+            transforms: [sortable, fitContent],
             sortByFunction: ({ totalHostCount, compliantHostCount }) => (
                 (100 / totalHostCount) * compliantHostCount
             )
@@ -44,7 +44,7 @@ const ReportsTable = ({ profiles }) => {
     const rows = sortedProfiles.length > 0 ? sortedProfiles.map((profile) => ({
         cells: [
             { title: <Name { ...profile } /> },
-            { title: <OperatingSystem { ...profile } /> },
+            { title: <OperatingSystem { ...profile } />, props: { textCenter: true } },
             { title: <CompliantSystems { ...profile } /> }
         ]
     })) : emptyRows;

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CompliantSystems expect to render with unsupported hosts 1`] = `
+<Fragment>
+  <Progress
+    className=""
+    id=""
+    label={null}
+    max={100}
+    measureLocation="outside"
+    min={0}
+    size={null}
+    title=""
+    value={90}
+    valueText={null}
+    variant={null}
+  />
+  <GreySmallText>
+    9 of 10 systems 
+    <SSGVersionWarning
+      style={
+        Object {
+          "marginLeft": ".5em",
+        }
+      }
+      supported={false}
+      tooltipText="Insights cannot provide a compliance score for systems running an unsupported version of the SSG at the time this report was created, as the SSG version was not supported by RHEL."
+    >
+      <strong
+        className="ins-u-warning"
+      >
+        42
+         unsupported
+      </strong>
+    </SSGVersionWarning>
+  </GreySmallText>
+</Fragment>
+`;
+
 exports[`CompliantSystems expect to render without error 1`] = `
 <Fragment>
   <Progress
@@ -16,7 +53,7 @@ exports[`CompliantSystems expect to render without error 1`] = `
     variant={null}
   />
   <GreySmallText>
-    9 of 10 systems
+    9 of 10 systems 
   </GreySmallText>
 </Fragment>
 `;
@@ -53,11 +90,51 @@ exports[`Name expect to render without error 1`] = `
 </TextContent>
 `;
 
+exports[`OperatingSystem expect to render with SSG version 1`] = `
+<Fragment>
+  <Label
+    color="cyan"
+  >
+    RHEL 
+    7
+  </Label>
+  <Text>
+    <GreySmallText>
+      <SSGVersionWarning>
+        1.2.3
+      </SSGVersionWarning>
+    </GreySmallText>
+  </Text>
+</Fragment>
+`;
+
+exports[`OperatingSystem expect to render with unsupported warning 1`] = `
+<Fragment>
+  <Label
+    color="cyan"
+  >
+    RHEL 
+    7
+  </Label>
+  <Text>
+    <GreySmallText>
+      <SSGVersionWarning
+        supported={false}
+      >
+        1.2.3
+      </SSGVersionWarning>
+    </GreySmallText>
+  </Text>
+</Fragment>
+`;
+
 exports[`OperatingSystem expect to render without error 1`] = `
-<Label
-  color="cyan"
->
-  RHEL 
-  7
-</Label>
+<Fragment>
+  <Label
+    color="cyan"
+  >
+    RHEL 
+    7
+  </Label>
+</Fragment>
 `;

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
@@ -105,12 +105,14 @@ exports[`ReportsTable expect to render without error 1`] = `
           "title": "Operating system",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "sortByFunction": [Function],
           "title": "Systems meeting compliance",
           "transforms": Array [
+            [Function],
             [Function],
           ],
         },
@@ -239,6 +241,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -475,6 +480,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -533,6 +541,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -591,6 +602,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -649,6 +663,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -707,6 +724,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -818,6 +838,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -982,6 +1005,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -1040,6 +1066,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -1098,6 +1127,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -1156,6 +1188,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -1214,6 +1249,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={
@@ -1272,6 +1310,9 @@ exports[`ReportsTable expect to render without error 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "textCenter": true,
+              },
               "title": <OperatingSystem
                 __typename="Profile"
                 benchmark={

--- a/src/PresentationalComponents/SSGVersionWarning/SSGVersionWarning.js
+++ b/src/PresentationalComponents/SSGVersionWarning/SSGVersionWarning.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Popover, Tooltip } from '@patternfly/react-core';
+import { ExclamationTriangleIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+
+const WarningSignWithPopup = ({ children }) => (
+    <Popover
+        headerContent={ 'Unsupported SSG versions' }
+        bodyContent={
+            'This system is running an unsupported version of the SCAP Security Guide (SSG).' +
+            'This information is based on the last report uploaded for this system to the Compliance service.'
+        }
+        footerContent={
+            <a href="#">Supported SSG versions</a>
+        }
+    >
+        { children }
+    </Popover>
+);
+WarningSignWithPopup.propTypes = {
+    children: propTypes.node
+};;
+
+const WarningWithTooltip = ({ children, content }) => (
+    <Tooltip content={ content } position='bottom'>
+        { children }
+    </Tooltip>
+);
+
+WarningWithTooltip.propTypes = {
+    content: propTypes.string,
+    children: propTypes.node
+};;
+
+const TooltipOrPopover = ({ variant, children, tooltipProps }) => (
+    variant === 'tooltip' ? <WarningWithTooltip { ...tooltipProps }>
+        { children }
+    </WarningWithTooltip> : <WarningSignWithPopup>{ children }</WarningSignWithPopup>
+);
+
+TooltipOrPopover.propTypes = {
+    children: propTypes.node,
+    variant: propTypes.string,
+    tooltipProps: propTypes.object
+};
+
+const SSGVersionWarning = ({
+    showWarningIcon = true, showHelpIcon = false, children, style, tooltipText, supported = true
+}) => {
+    const tooltipProps = {
+        content: <div>{ tooltipText }</div>
+    };
+    const variant = tooltipText ? 'tooltip' : 'popover';
+    const iconProps = {
+        variant,
+        tooltipProps
+    };
+    const defaultStyle = {
+        ...!tooltipText ? {
+            cursor: 'pointer'
+        } : {}
+    };
+
+    return <span style={ {
+        ...style,
+        display: 'inline-block'
+    }}>
+        { (!supported && showWarningIcon) && <TooltipOrPopover { ...iconProps }>
+            <ExclamationTriangleIcon
+                className='ins-u-warning'
+                style={ {
+                    ...defaultStyle,
+                    marginRight: '.25em'
+                } }
+            />
+        </TooltipOrPopover> }
+
+        { children }
+
+        { (!supported && showHelpIcon) &&  <TooltipOrPopover { ...iconProps }>
+            <QuestionCircleIcon
+                style={ {
+                    ...defaultStyle,
+                    marginLeft: '.25em'
+                } }
+            />
+        </TooltipOrPopover> }
+    </span>;
+};
+
+SSGVersionWarning.propTypes = {
+    children: propTypes.node,
+    tooltipText: propTypes.string,
+    showHelpIcon: propTypes.bool,
+    showWarningIcon: propTypes.bool,
+    style: propTypes.object,
+    supported: propTypes.bool
+};
+
+export default SSGVersionWarning;

--- a/src/PresentationalComponents/SSGVersionWarning/SSGVersionWarning.test.js
+++ b/src/PresentationalComponents/SSGVersionWarning/SSGVersionWarning.test.js
@@ -1,0 +1,47 @@
+import SSGVersionWarning from './SSGVersionWarning';
+
+describe('SSGVersionWarning', () => {
+    const defaultProps = {
+        style: { margin: '1em' }
+    };
+
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <SSGVersionWarning { ...defaultProps }>
+                Warning text
+            </SSGVersionWarning>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render no warning sign', () => {
+        const wrapper = shallow(
+            <SSGVersionWarning { ...defaultProps } showWarningIcon={ false }>
+                Warning text
+            </SSGVersionWarning>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render tooltip', () => {
+        const wrapper = shallow(
+            <SSGVersionWarning { ...defaultProps } tooltipText='TOOLTIP TEXT'>
+                Warning text
+            </SSGVersionWarning>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render help sign', () => {
+        const wrapper = shallow(
+            <SSGVersionWarning { ...defaultProps } showHelpIcon={ true }>
+                Warning text
+            </SSGVersionWarning>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/SSGVersionWarning/__snapshots__/SSGVersionWarning.test.js.snap
+++ b/src/PresentationalComponents/SSGVersionWarning/__snapshots__/SSGVersionWarning.test.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SSGVersionWarning expect to render help sign 1`] = `
+<span
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1em",
+    }
+  }
+>
+  Warning text
+</span>
+`;
+
+exports[`SSGVersionWarning expect to render no warning sign 1`] = `
+<span
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1em",
+    }
+  }
+>
+  Warning text
+</span>
+`;
+
+exports[`SSGVersionWarning expect to render tooltip 1`] = `
+<span
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1em",
+    }
+  }
+>
+  Warning text
+</span>
+`;
+
+exports[`SSGVersionWarning expect to render without error 1`] = `
+<span
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1em",
+    }
+  }
+>
+  Warning text
+</span>
+`;

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -25,3 +25,4 @@ export { default as PolicyPopover } from './PolicyPopover/PolicyPopover';
 export { default as NoResultsTable, emptyRows } from './NoResultsTable/NoResultsTable';
 export { default as PoliciesTable } from './PoliciesTable/PoliciesTable';
 export { default as ProfileThresholdField } from './ProfileThresholdField/ProfileThresholdField';
+export { default as SSGVersionWarning } from './SSGVersionWarning/SSGVersionWarning';

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -1,9 +1,13 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 import propTypes from 'prop-types';
-import { SystemsTable } from 'SmartComponents';
+import SystemsTable, { Cells } from '@/SmartComponents/SystemsTable/SystemsTable';
+import useFeature from 'Utilities/hooks/useFeature';
 
-const PolicySystemsTab = ({ policy, systemTableProps }) => (
-    <SystemsTable
+const PolicySystemsTab = ({ policy, systemTableProps }) => {
+    let showSsgVersions = useFeature('showSsgVersions');
+
+    return <SystemsTable
         policyId={ policy.id }
         showActions={ false }
         remediationsEnabled={ false }
@@ -13,11 +17,17 @@ const PolicySystemsTab = ({ policy, systemTableProps }) => (
             props: {
                 width: 40, isStatic: true
             }
-        }]}
+        }, ...showSsgVersions ? [{
+            key: 'facts.compliance.profiles',
+            title: 'SSG version',
+            renderFunc: (profiles) => (
+                <Cells.SSGVersion { ...{ profiles } } />
+            )
+        }] : []]}
         complianceThreshold={ policy.complianceThreshold }
         { ...systemTableProps }
-    />
-);
+    />;
+};
 
 PolicySystemsTab.propTypes = {
     policy: propTypes.shape({

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -5,7 +6,7 @@ import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 
 import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
-import { Breadcrumb, BreadcrumbItem, Button, Grid, GridItem } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Button, Grid, GridItem, Text } from '@patternfly/react-core';
 
 import {
     PageHeader, PageHeaderTitle, Main, EmptyTable, Spinner
@@ -15,9 +16,9 @@ import { fixedPercentage, pluralize } from 'Utilities/TextHelper';
 import useFeature from 'Utilities/hooks/useFeature';
 import {
     BackgroundLink, BreadcrumbLinkItem, ReportDetailsContentLoader, ReportDetailsDescription,
-    StateViewWithError, StateViewPart
+    StateViewWithError, StateViewPart, SSGVersionWarning
 } from 'PresentationalComponents';
-import { SystemsTable } from 'SmartComponents';
+import SystemsTable, { Cells } from '@/SmartComponents/SystemsTable/SystemsTable';
 
 import '@/Charts.scss';
 import './ReportDetails.scss';
@@ -95,11 +96,14 @@ export const ReportDetails = () => {
             width: 5
         }
     }, ...showSsgVersions ? [{
-        key: 'facts.compliance.ssg_version',
+        key: 'facts.compliance.profiles',
         title: 'SSG version',
         props: {
             width: 5
-        }
+        },
+        renderFunc: (profiles) => (
+            <Cells.SSGVersion { ...{ profiles } } />
+        )
     }] : [], {
         key: 'facts.compliance.compliance_score',
         title: 'Compliance score',
@@ -164,6 +168,13 @@ export const ReportDetails = () => {
                                 />
                             </div>
                         </div>
+                        {  profile.unsupportedSystems > 0 && <Text>
+                            <SSGVersionWarning unsupported>
+                                <strong className='ins-u-warning'>
+                                    { profile.unsupportedSystems } systems not supported
+                                </strong>
+                            </SSGVersionWarning>
+                        </Text> }
                     </GridItem>
                     <GridItem sm={12} md={12} lg={12} xl={6}>
                         <ReportDetailsDescription profile={profile} />

--- a/src/SmartComponents/ReportDetails/ReportDetails.test.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.test.js
@@ -26,9 +26,10 @@ const mocks = [
                     policyType: 'policy type',
                     description: 'profile description',
                     external: false,
-                    totalHostCount: 1,
+                    totalHostCount: 10,
                     complianceThreshold: 1,
-                    compliantHostCount: 1,
+                    compliantHostCount: 5,
+                    unsupportedSystems: 5,
                     policy: {
                         id: 'thepolicyid',
                         name: 'the policy name'

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -57,7 +57,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                     "title": "BO 1",
                   },
                   "complianceThreshold": 1,
-                  "compliantHostCount": 1,
+                  "compliantHostCount": 5,
                   "description": "profile description",
                   "external": false,
                   "id": "1",
@@ -68,7 +68,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                   },
                   "policyType": "policy type",
                   "refId": "121212",
-                  "totalHostCount": 1,
+                  "totalHostCount": 10,
+                  "unsupportedSystems": 5,
                 },
               },
               "error": false,
@@ -89,7 +90,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                       "title": "BO 1",
                     },
                     "complianceThreshold": 1,
-                    "compliantHostCount": 1,
+                    "compliantHostCount": 5,
                     "description": "profile description",
                     "external": false,
                     "id": "1",
@@ -100,7 +101,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                     },
                     "policyType": "policy type",
                     "refId": "121212",
-                    "totalHostCount": 1,
+                    "totalHostCount": 10,
+                    "unsupportedSystems": 5,
                   },
                 },
                 "error": false,
@@ -271,7 +273,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                     "title": "BO 1",
                                   },
                                   "complianceThreshold": 1,
-                                  "compliantHostCount": 1,
+                                  "compliantHostCount": 5,
                                   "description": "profile description",
                                   "external": false,
                                   "id": "1",
@@ -282,7 +284,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                                   },
                                   "policyType": "policy type",
                                   "refId": "121212",
-                                  "totalHostCount": 1,
+                                  "totalHostCount": 10,
+                                  "unsupportedSystems": 5,
                                 },
                               }
                             }
@@ -309,7 +312,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                         "title": "BO 1",
                                       },
                                       "complianceThreshold": 1,
-                                      "compliantHostCount": 1,
+                                      "compliantHostCount": 5,
                                       "description": "profile description",
                                       "external": false,
                                       "id": "1",
@@ -320,7 +323,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                                       },
                                       "policyType": "policy type",
                                       "refId": "121212",
-                                      "totalHostCount": 1,
+                                      "totalHostCount": 10,
+                                      "unsupportedSystems": 5,
                                     },
                                   },
                                 }
@@ -385,11 +389,11 @@ exports[`ReportDetails expect to render without error 1`] = `
                                   Array [
                                     Object {
                                       "x": "Compliant",
-                                      "y": 1,
+                                      "y": 5,
                                     },
                                     Object {
                                       "x": "Non-compliant",
-                                      "y": 0,
+                                      "y": 5,
                                     },
                                   ]
                                 }
@@ -398,10 +402,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                 legendData={
                                   Array [
                                     Object {
-                                      "name": "1 system compliant",
+                                      "name": "5 systems compliant",
                                     },
                                     Object {
-                                      "name": "0 systems non-compliant",
+                                      "name": "5 systems non-compliant",
                                     },
                                   ]
                                 }
@@ -423,7 +427,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                 subTitle="Compliant"
                                 themeColor="blue"
                                 themeVariant="light"
-                                title="100%"
+                                title="50%"
                                 width={462}
                               >
                                 <ChartContainer
@@ -1369,11 +1373,11 @@ exports[`ReportDetails expect to render without error 1`] = `
                                             Array [
                                               Object {
                                                 "x": "Compliant",
-                                                "y": 1,
+                                                "y": 5,
                                               },
                                               Object {
                                                 "x": "Non-compliant",
-                                                "y": 0,
+                                                "y": 5,
                                               },
                                             ]
                                           }
@@ -1384,10 +1388,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                           legendData={
                                             Array [
                                               Object {
-                                                "name": "1 system compliant",
+                                                "name": "5 systems compliant",
                                               },
                                               Object {
-                                                "name": "0 systems non-compliant",
+                                                "name": "5 systems non-compliant",
                                               },
                                             ]
                                           }
@@ -1873,11 +1877,11 @@ exports[`ReportDetails expect to render without error 1`] = `
                                               Array [
                                                 Object {
                                                   "x": "Compliant",
-                                                  "y": 1,
+                                                  "y": 5,
                                                 },
                                                 Object {
                                                   "x": "Non-compliant",
-                                                  "y": 0,
+                                                  "y": 5,
                                                 },
                                               ]
                                             }
@@ -2823,30 +2827,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Array [
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                   ]
                                                 }
                                                 datum={
                                                   Object {
                                                     "_x": 1,
-                                                    "_y": 1,
-                                                    "endAngle": 359,
+                                                    "_y": 5,
+                                                    "endAngle": 180,
                                                     "padAngle": 1,
                                                     "startAngle": 0,
                                                     "x": "Compliant",
                                                     "xName": "Compliant",
-                                                    "y": 1,
+                                                    "y": 5,
                                                   }
                                                 }
                                                 events={
@@ -2878,16 +2882,16 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Object {
                                                     "data": Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
-                                                    "endAngle": 6.265732014659643,
+                                                    "endAngle": 3.141592653589793,
                                                     "index": 0,
                                                     "padAngle": 0.017453292519943295,
                                                     "startAngle": 0,
-                                                    "value": 1,
+                                                    "value": 5,
                                                   }
                                                 }
                                                 style={
@@ -2900,7 +2904,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 }
                                               >
                                                 <Path
-                                                  d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
+                                                  d="M1.130044229770525,-94.99327870980537A95,95,0,0,1,1.130044229770525,94.99327870980537L1.1300442297705258,87.99274401925855A88,88,0,0,0,1.1300442297705258,-87.99274401925855Z"
                                                   onBlur={[Function]}
                                                   onFocus={[Function]}
                                                   onMouseOut={[Function]}
@@ -2920,7 +2924,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   transform="translate(106, 115)"
                                                 >
                                                   <path
-                                                    d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
+                                                    d="M1.130044229770525,-94.99327870980537A95,95,0,0,1,1.130044229770525,94.99327870980537L1.1300442297705258,87.99274401925855A88,88,0,0,0,1.1300442297705258,-87.99274401925855Z"
                                                     onBlur={[Function]}
                                                     onFocus={[Function]}
                                                     onMouseOut={[Function]}
@@ -2947,30 +2951,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Array [
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                   ]
                                                 }
                                                 datum={
                                                   Object {
                                                     "_x": 2,
-                                                    "_y": 0,
+                                                    "_y": 5,
                                                     "endAngle": 360,
                                                     "padAngle": 1,
-                                                    "startAngle": 359,
+                                                    "startAngle": 180,
                                                     "x": "Non-compliant",
                                                     "xName": "Non-compliant",
-                                                    "y": 0,
+                                                    "y": 5,
                                                   }
                                                 }
                                                 events={
@@ -3002,16 +3006,16 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Object {
                                                     "data": Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                     "endAngle": 6.283185307179586,
                                                     "index": 1,
                                                     "padAngle": 0.017453292519943295,
-                                                    "startAngle": 6.265732014659643,
-                                                    "value": 0,
+                                                    "startAngle": 3.141592653589793,
+                                                    "value": 5,
                                                   }
                                                 }
                                                 style={
@@ -3024,7 +3028,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 }
                                               >
                                                 <Path
-                                                  d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
+                                                  d="M-1.1300442297705133,94.99327870980537A95,95,0,0,1,-1.1300442297705369,-94.99327870980537L-1.1300442297705169,-87.99274401925855A88,88,0,0,0,-1.1300442297705149,87.99274401925855Z"
                                                   onBlur={[Function]}
                                                   onFocus={[Function]}
                                                   onMouseOut={[Function]}
@@ -3044,7 +3048,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   transform="translate(106, 115)"
                                                 >
                                                   <path
-                                                    d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
+                                                    d="M-1.1300442297705133,94.99327870980537A95,95,0,0,1,-1.1300442297705369,-94.99327870980537L-1.1300442297705169,-87.99274401925855A88,88,0,0,0,-1.1300442297705149,87.99274401925855Z"
                                                     onBlur={[Function]}
                                                     onFocus={[Function]}
                                                     onMouseOut={[Function]}
@@ -3073,30 +3077,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Array [
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                   ]
                                                 }
                                                 datum={
                                                   Object {
                                                     "_x": 1,
-                                                    "_y": 1,
-                                                    "endAngle": 359,
+                                                    "_y": 5,
+                                                    "endAngle": 180,
                                                     "padAngle": 1,
                                                     "startAngle": 0,
                                                     "x": "Compliant",
                                                     "xName": "Compliant",
-                                                    "y": 1,
+                                                    "y": 5,
                                                   }
                                                 }
                                                 events={Object {}}
@@ -3114,23 +3118,23 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 id="pie-labels-0"
                                                 index={0}
                                                 key="pie-labels-0"
-                                                orientation="bottom"
+                                                orientation="right"
                                                 pointerLength={10}
                                                 pointerWidth={20}
                                                 slice={
                                                   Object {
                                                     "data": Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
-                                                    "endAngle": 6.265732014659643,
+                                                    "endAngle": 3.141592653589793,
                                                     "index": 0,
                                                     "padAngle": 0.017453292519943295,
                                                     "startAngle": 0,
-                                                    "value": 1,
+                                                    "value": 5,
                                                   }
                                                 }
                                                 style={
@@ -3145,7 +3149,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   }
                                                 }
                                                 text="Compliant"
-                                                textAnchor="middle"
+                                                textAnchor="start"
                                                 theme={
                                                   Object {
                                                     "area": Object {
@@ -3596,10 +3600,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     },
                                                   }
                                                 }
-                                                verticalAnchor="start"
+                                                verticalAnchor="middle"
                                                 width={462}
-                                                x={107}
-                                                y={218}
+                                                x={209}
+                                                y={115}
                                               >
                                                 <VictoryTooltip
                                                   active={false}
@@ -3610,30 +3614,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Array [
                                                       Object {
                                                         "_x": 1,
-                                                        "_y": 1,
+                                                        "_y": 5,
                                                         "x": "Compliant",
                                                         "xName": "Compliant",
-                                                        "y": 1,
+                                                        "y": 5,
                                                       },
                                                       Object {
                                                         "_x": 2,
-                                                        "_y": 0,
+                                                        "_y": 5,
                                                         "x": "Non-compliant",
                                                         "xName": "Non-compliant",
-                                                        "y": 0,
+                                                        "y": 5,
                                                       },
                                                     ]
                                                   }
                                                   datum={
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
-                                                      "endAngle": 359,
+                                                      "_y": 5,
+                                                      "endAngle": 180,
                                                       "padAngle": 1,
                                                       "startAngle": 0,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     }
                                                   }
                                                   events={Object {}}
@@ -4112,7 +4116,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       }
                                                     />
                                                   }
-                                                  orientation="bottom"
+                                                  orientation="right"
                                                   pointerLength={10}
                                                   pointerWidth={20}
                                                   renderInPortal={true}
@@ -4120,16 +4124,16 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "data": Object {
                                                         "_x": 1,
-                                                        "_y": 1,
+                                                        "_y": 5,
                                                         "x": "Compliant",
                                                         "xName": "Compliant",
-                                                        "y": 1,
+                                                        "y": 5,
                                                       },
-                                                      "endAngle": 6.265732014659643,
+                                                      "endAngle": 3.141592653589793,
                                                       "index": 0,
                                                       "padAngle": 0.017453292519943295,
                                                       "startAngle": 0,
-                                                      "value": 1,
+                                                      "value": 5,
                                                     }
                                                   }
                                                   style={
@@ -4144,7 +4148,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     }
                                                   }
                                                   text="Compliant"
-                                                  textAnchor="middle"
+                                                  textAnchor="start"
                                                   theme={
                                                     Object {
                                                       "area": Object {
@@ -4595,10 +4599,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       },
                                                     }
                                                   }
-                                                  verticalAnchor="start"
+                                                  verticalAnchor="middle"
                                                   width={462}
-                                                  x={107}
-                                                  y={218}
+                                                  x={209}
+                                                  y={115}
                                                 >
                                                   <VictoryPortal
                                                     groupComponent={<g />}
@@ -4613,30 +4617,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Array [
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                   ]
                                                 }
                                                 datum={
                                                   Object {
                                                     "_x": 2,
-                                                    "_y": 0,
+                                                    "_y": 5,
                                                     "endAngle": 360,
                                                     "padAngle": 1,
-                                                    "startAngle": 359,
+                                                    "startAngle": 180,
                                                     "x": "Non-compliant",
                                                     "xName": "Non-compliant",
-                                                    "y": 0,
+                                                    "y": 5,
                                                   }
                                                 }
                                                 events={Object {}}
@@ -4654,23 +4658,23 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 id="pie-labels-1"
                                                 index={1}
                                                 key="pie-labels-1"
-                                                orientation="top"
+                                                orientation="left"
                                                 pointerLength={10}
                                                 pointerWidth={20}
                                                 slice={
                                                   Object {
                                                     "data": Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                     "endAngle": 6.283185307179586,
                                                     "index": 1,
                                                     "padAngle": 0.017453292519943295,
-                                                    "startAngle": 6.265732014659643,
-                                                    "value": 0,
+                                                    "startAngle": 3.141592653589793,
+                                                    "value": 5,
                                                   }
                                                 }
                                                 style={
@@ -4685,7 +4689,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   }
                                                 }
                                                 text="Non-compliant"
-                                                textAnchor="middle"
+                                                textAnchor="end"
                                                 theme={
                                                   Object {
                                                     "area": Object {
@@ -5136,10 +5140,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     },
                                                   }
                                                 }
-                                                verticalAnchor="end"
+                                                verticalAnchor="middle"
                                                 width={462}
-                                                x={105}
-                                                y={12}
+                                                x={3}
+                                                y={115}
                                               >
                                                 <VictoryTooltip
                                                   active={false}
@@ -5150,30 +5154,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Array [
                                                       Object {
                                                         "_x": 1,
-                                                        "_y": 1,
+                                                        "_y": 5,
                                                         "x": "Compliant",
                                                         "xName": "Compliant",
-                                                        "y": 1,
+                                                        "y": 5,
                                                       },
                                                       Object {
                                                         "_x": 2,
-                                                        "_y": 0,
+                                                        "_y": 5,
                                                         "x": "Non-compliant",
                                                         "xName": "Non-compliant",
-                                                        "y": 0,
+                                                        "y": 5,
                                                       },
                                                     ]
                                                   }
                                                   datum={
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "endAngle": 360,
                                                       "padAngle": 1,
-                                                      "startAngle": 359,
+                                                      "startAngle": 180,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     }
                                                   }
                                                   events={Object {}}
@@ -5652,7 +5656,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       }
                                                     />
                                                   }
-                                                  orientation="top"
+                                                  orientation="left"
                                                   pointerLength={10}
                                                   pointerWidth={20}
                                                   renderInPortal={true}
@@ -5660,16 +5664,16 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "data": Object {
                                                         "_x": 2,
-                                                        "_y": 0,
+                                                        "_y": 5,
                                                         "x": "Non-compliant",
                                                         "xName": "Non-compliant",
-                                                        "y": 0,
+                                                        "y": 5,
                                                       },
                                                       "endAngle": 6.283185307179586,
                                                       "index": 1,
                                                       "padAngle": 0.017453292519943295,
-                                                      "startAngle": 6.265732014659643,
-                                                      "value": 0,
+                                                      "startAngle": 3.141592653589793,
+                                                      "value": 5,
                                                     }
                                                   }
                                                   style={
@@ -5684,7 +5688,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     }
                                                   }
                                                   text="Non-compliant"
-                                                  textAnchor="middle"
+                                                  textAnchor="end"
                                                   theme={
                                                     Object {
                                                       "area": Object {
@@ -6135,10 +6139,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       },
                                                     }
                                                   }
-                                                  verticalAnchor="end"
+                                                  verticalAnchor="middle"
                                                   width={462}
-                                                  x={105}
-                                                  y={12}
+                                                  x={3}
+                                                  y={115}
                                                 >
                                                   <VictoryPortal
                                                     groupComponent={<g />}
@@ -6151,10 +6155,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                             data={
                                               Array [
                                                 Object {
-                                                  "name": "1 system compliant",
+                                                  "name": "5 systems compliant",
                                                 },
                                                 Object {
-                                                  "name": "0 systems non-compliant",
+                                                  "name": "5 systems non-compliant",
                                                 },
                                               ]
                                             }
@@ -7080,10 +7084,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                               data={
                                                 Array [
                                                   Object {
-                                                    "name": "1 system compliant",
+                                                    "name": "5 systems compliant",
                                                   },
                                                   Object {
-                                                    "name": "0 systems non-compliant",
+                                                    "name": "5 systems non-compliant",
                                                   },
                                                 ]
                                               }
@@ -7597,10 +7601,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   data={
                                                     Array [
                                                       Object {
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                       },
                                                       Object {
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                       },
                                                     ]
                                                   }
@@ -7608,13 +7612,13 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "column": 0,
                                                       "fontSize": 14,
-                                                      "name": "1 system compliant",
+                                                      "name": "5 systems compliant",
                                                       "row": 0,
                                                       "size": 5.6,
                                                       "symbolSpacer": 14,
                                                       "textSize": Object {
                                                         "height": 16.904999999999998,
-                                                        "width": 119.70000000000002,
+                                                        "width": 126.70000000000002,
                                                       },
                                                     }
                                                   }
@@ -7668,10 +7672,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   data={
                                                     Array [
                                                       Object {
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                       },
                                                       Object {
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                       },
                                                     ]
                                                   }
@@ -7679,7 +7683,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "column": 0,
                                                       "fontSize": 14,
-                                                      "name": "0 systems non-compliant",
+                                                      "name": "5 systems non-compliant",
                                                       "row": 1,
                                                       "size": 5.6,
                                                       "symbolSpacer": 14,
@@ -7739,10 +7743,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   data={
                                                     Array [
                                                       Object {
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                       },
                                                       Object {
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                       },
                                                     ]
                                                   }
@@ -7750,13 +7754,13 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "column": 0,
                                                       "fontSize": 14,
-                                                      "name": "1 system compliant",
+                                                      "name": "5 systems compliant",
                                                       "row": 0,
                                                       "size": 5.6,
                                                       "symbolSpacer": 14,
                                                       "textSize": Object {
                                                         "height": 16.904999999999998,
-                                                        "width": 119.70000000000002,
+                                                        "width": 126.70000000000002,
                                                       },
                                                     }
                                                   }
@@ -7772,7 +7776,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       "stroke": "transparent",
                                                     }
                                                   }
-                                                  text="1 system compliant"
+                                                  text="5 systems compliant"
                                                   x={239.8}
                                                   y={100.095}
                                                 >
@@ -7782,10 +7786,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     data={
                                                       Array [
                                                         Object {
-                                                          "name": "1 system compliant",
+                                                          "name": "5 systems compliant",
                                                         },
                                                         Object {
-                                                          "name": "0 systems non-compliant",
+                                                          "name": "5 systems non-compliant",
                                                         },
                                                       ]
                                                     }
@@ -7793,13 +7797,13 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       Object {
                                                         "column": 0,
                                                         "fontSize": 14,
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                         "row": 0,
                                                         "size": 5.6,
                                                         "symbolSpacer": 14,
                                                         "textSize": Object {
                                                           "height": 16.904999999999998,
-                                                          "width": 119.70000000000002,
+                                                          "width": 126.70000000000002,
                                                         },
                                                       }
                                                     }
@@ -7818,7 +7822,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                         "textAnchor": undefined,
                                                       }
                                                     }
-                                                    text="1 system compliant"
+                                                    text="5 systems compliant"
                                                     textComponent={<Text />}
                                                     tspanComponent={<TSpan />}
                                                     x={239.8}
@@ -7874,7 +7878,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                             textAnchor="start"
                                                             x={239.8}
                                                           >
-                                                            1 system compliant
+                                                            5 systems compliant
                                                           </tspan>
                                                         </TSpan>
                                                       </text>
@@ -7885,10 +7889,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   data={
                                                     Array [
                                                       Object {
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                       },
                                                       Object {
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                       },
                                                     ]
                                                   }
@@ -7896,7 +7900,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "column": 0,
                                                       "fontSize": 14,
-                                                      "name": "0 systems non-compliant",
+                                                      "name": "5 systems non-compliant",
                                                       "row": 1,
                                                       "size": 5.6,
                                                       "symbolSpacer": 14,
@@ -7918,7 +7922,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       "stroke": "transparent",
                                                     }
                                                   }
-                                                  text="0 systems non-compliant"
+                                                  text="5 systems non-compliant"
                                                   x={239.8}
                                                   y={131}
                                                 >
@@ -7928,10 +7932,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     data={
                                                       Array [
                                                         Object {
-                                                          "name": "1 system compliant",
+                                                          "name": "5 systems compliant",
                                                         },
                                                         Object {
-                                                          "name": "0 systems non-compliant",
+                                                          "name": "5 systems non-compliant",
                                                         },
                                                       ]
                                                     }
@@ -7939,7 +7943,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       Object {
                                                         "column": 0,
                                                         "fontSize": 14,
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                         "row": 1,
                                                         "size": 5.6,
                                                         "symbolSpacer": 14,
@@ -7964,7 +7968,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                         "textAnchor": undefined,
                                                       }
                                                     }
-                                                    text="0 systems non-compliant"
+                                                    text="5 systems non-compliant"
                                                     textComponent={<Text />}
                                                     tspanComponent={<TSpan />}
                                                     x={239.8}
@@ -8020,7 +8024,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                             textAnchor="start"
                                                             x={239.8}
                                                           >
-                                                            0 systems non-compliant
+                                                            5 systems non-compliant
                                                           </tspan>
                                                         </TSpan>
                                                       </text>
@@ -8047,7 +8051,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                           }
                                           text={
                                             Array [
-                                              "100%",
+                                              "50%",
                                               "Compliant",
                                             ]
                                           }
@@ -8081,7 +8085,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                             }
                                             text={
                                               Array [
-                                                "100%",
+                                                "50%",
                                                 "Compliant",
                                               ]
                                             }
@@ -8138,7 +8142,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     textAnchor="middle"
                                                     x={106}
                                                   >
-                                                    100%
+                                                    50%
                                                   </tspan>
                                                 </TSpan>
                                                 <TSpan
@@ -8226,6 +8230,31 @@ exports[`ReportDetails expect to render without error 1`] = `
                               </ChartDonut>
                             </div>
                           </div>
+                          <Text>
+                            <p
+                              className=""
+                              data-pf-content={true}
+                            >
+                              <SSGVersionWarning
+                                unsupported={true}
+                              >
+                                <span
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                    }
+                                  }
+                                >
+                                  <strong
+                                    className="ins-u-warning"
+                                  >
+                                    5
+                                     systems not supported
+                                  </strong>
+                                </span>
+                              </SSGVersionWarning>
+                            </p>
+                          </Text>
                         </div>
                       </GridItem>
                       <GridItem
@@ -8248,7 +8277,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                   "title": "BO 1",
                                 },
                                 "complianceThreshold": 1,
-                                "compliantHostCount": 1,
+                                "compliantHostCount": 5,
                                 "description": "profile description",
                                 "external": false,
                                 "id": "1",
@@ -8259,7 +8288,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                                 },
                                 "policyType": "policy type",
                                 "refId": "121212",
-                                "totalHostCount": 1,
+                                "totalHostCount": 10,
+                                "unsupportedSystems": 5,
                               }
                             }
                           >
@@ -8486,7 +8516,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
             "title": "BO 1",
           },
           "complianceThreshold": 1,
-          "compliantHostCount": 1,
+          "compliantHostCount": 5,
           "description": "profile description",
           "external": false,
           "id": "1",
@@ -8497,7 +8527,8 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
           },
           "policyType": "policy type",
           "refId": "121212",
-          "totalHostCount": 1,
+          "totalHostCount": 10,
+          "unsupportedSystems": 5,
         },
       },
       "error": false,
@@ -8565,7 +8596,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                     "title": "BO 1",
                   },
                   "complianceThreshold": 1,
-                  "compliantHostCount": 1,
+                  "compliantHostCount": 5,
                   "description": "profile description",
                   "external": false,
                   "id": "1",
@@ -8576,7 +8607,8 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   },
                   "policyType": "policy type",
                   "refId": "121212",
-                  "totalHostCount": 1,
+                  "totalHostCount": 10,
+                  "unsupportedSystems": 5,
                 },
               }
             }
@@ -8611,11 +8643,11 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   Array [
                     Object {
                       "x": "Compliant",
-                      "y": 1,
+                      "y": 5,
                     },
                     Object {
                       "x": "Non-compliant",
-                      "y": 0,
+                      "y": 5,
                     },
                   ]
                 }
@@ -8624,10 +8656,10 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 legendData={
                   Array [
                     Object {
-                      "name": "1 system compliant",
+                      "name": "5 systems compliant",
                     },
                     Object {
-                      "name": "0 systems non-compliant",
+                      "name": "5 systems non-compliant",
                     },
                   ]
                 }
@@ -8649,11 +8681,23 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 subTitle="Compliant"
                 themeColor="blue"
                 themeVariant="light"
-                title="100%"
+                title="50%"
                 width={462}
               />
             </div>
           </div>
+          <Text>
+            <SSGVersionWarning
+              unsupported={true}
+            >
+              <strong
+                className="ins-u-warning"
+              >
+                5
+                 systems not supported
+              </strong>
+            </SSGVersionWarning>
+          </Text>
         </GridItem>
         <GridItem
           lg={12}
@@ -8672,7 +8716,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "title": "BO 1",
                 },
                 "complianceThreshold": 1,
-                "compliantHostCount": 1,
+                "compliantHostCount": 5,
                 "description": "profile description",
                 "external": false,
                 "id": "1",
@@ -8683,7 +8727,8 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 },
                 "policyType": "policy type",
                 "refId": "121212",
-                "totalHostCount": 1,
+                "totalHostCount": 10,
+                "unsupportedSystems": 5,
               }
             }
           />
@@ -8715,10 +8760,11 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "title": "Rules failed",
                 },
                 Object {
-                  "key": "facts.compliance.ssg_version",
+                  "key": "facts.compliance.profiles",
                   "props": Object {
                     "width": 5,
                   },
+                  "renderFunc": [Function],
                   "title": "SSG version",
                 },
                 Object {
@@ -8762,7 +8808,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
             "title": "BO 1",
           },
           "complianceThreshold": 1,
-          "compliantHostCount": 1,
+          "compliantHostCount": 5,
           "description": "profile description",
           "external": false,
           "id": "1",
@@ -8770,7 +8816,8 @@ exports[`ReportDetails expect to render without ssg version for external profile
           "policy": null,
           "policyType": "policy type",
           "refId": "121212",
-          "totalHostCount": 1,
+          "totalHostCount": 10,
+          "unsupportedSystems": 5,
         },
       },
       "error": false,
@@ -8838,7 +8885,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
                     "title": "BO 1",
                   },
                   "complianceThreshold": 1,
-                  "compliantHostCount": 1,
+                  "compliantHostCount": 5,
                   "description": "profile description",
                   "external": false,
                   "id": "1",
@@ -8846,7 +8893,8 @@ exports[`ReportDetails expect to render without ssg version for external profile
                   "policy": null,
                   "policyType": "policy type",
                   "refId": "121212",
-                  "totalHostCount": 1,
+                  "totalHostCount": 10,
+                  "unsupportedSystems": 5,
                 },
               }
             }
@@ -8881,11 +8929,11 @@ exports[`ReportDetails expect to render without ssg version for external profile
                   Array [
                     Object {
                       "x": "Compliant",
-                      "y": 1,
+                      "y": 5,
                     },
                     Object {
                       "x": "Non-compliant",
-                      "y": 0,
+                      "y": 5,
                     },
                   ]
                 }
@@ -8894,10 +8942,10 @@ exports[`ReportDetails expect to render without ssg version for external profile
                 legendData={
                   Array [
                     Object {
-                      "name": "1 system compliant",
+                      "name": "5 systems compliant",
                     },
                     Object {
-                      "name": "0 systems non-compliant",
+                      "name": "5 systems non-compliant",
                     },
                   ]
                 }
@@ -8919,11 +8967,23 @@ exports[`ReportDetails expect to render without ssg version for external profile
                 subTitle="Compliant"
                 themeColor="blue"
                 themeVariant="light"
-                title="100%"
+                title="50%"
                 width={462}
               />
             </div>
           </div>
+          <Text>
+            <SSGVersionWarning
+              unsupported={true}
+            >
+              <strong
+                className="ins-u-warning"
+              >
+                5
+                 systems not supported
+              </strong>
+            </SSGVersionWarning>
+          </Text>
         </GridItem>
         <GridItem
           lg={12}
@@ -8942,7 +9002,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
                   "title": "BO 1",
                 },
                 "complianceThreshold": 1,
-                "compliantHostCount": 1,
+                "compliantHostCount": 5,
                 "description": "profile description",
                 "external": false,
                 "id": "1",
@@ -8950,7 +9010,8 @@ exports[`ReportDetails expect to render without ssg version for external profile
                 "policy": null,
                 "policyType": "policy type",
                 "refId": "121212",
-                "totalHostCount": 1,
+                "totalHostCount": 10,
+                "unsupportedSystems": 5,
               }
             }
           />

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -23,7 +23,7 @@ query Profiles($filter: String!) {
                 totalHostCount
                 compliantHostCount
                 majorOsVersion
-                complianceThreshold
+                ssgVersion
                 businessObjective {
                     id
                     title
@@ -31,6 +31,7 @@ query Profiles($filter: String!) {
                 policy {
                     id
                     name
+                    complianceThreshold
                     benchmark {
                         id
                         version

--- a/src/SmartComponents/SystemsTable/Cells.js
+++ b/src/SmartComponents/SystemsTable/Cells.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { SSGVersionWarning } from 'PresentationalComponents';
+import joinComponents from 'Utilities/joinComponents';
+
+const SSGVersion = ({ profiles }) => (
+    joinComponents(profiles.map((p) => (
+        p.ssgVersion && <SSGVersionWarning key={ `profile-ssg-${ p.id }` } supported={ p.supported }>
+            { p.ssgVersion }
+        </SSGVersionWarning>
+    )).filter((version) => (!!version)), ', ')
+);
+
+SSGVersion.propTypes = {
+    profiles: propTypes.array
+};
+
+export default {
+    SSGVersion
+};

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -83,6 +83,7 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
                     external
                     compliant
                     score
+                    ssgVersion
                     policy {
                         id
                     }
@@ -491,6 +492,7 @@ const ConnectedSystemsTable = (props) => {
     return <SystemsTable {...props} store={ReactRedux.useStore()} />;
 };
 
+export { default as Cells } from './Cells';
 export { SystemsTable };
 export const SystemsTableWithApollo = withApollo(ConnectedSystemsTable);
 export default connect(

--- a/src/Utilities/joinComponents.js
+++ b/src/Utilities/joinComponents.js
@@ -1,0 +1,5 @@
+const joinComponents = (array, seperator = '') => (
+    array.reduce((prev, curr) => [prev, curr && seperator, curr])
+);
+
+export default joinComponents;

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -89,10 +89,6 @@ const isSelected = (id, selectedEntities) => (
     !!(selectedEntities || []).find((entity) => (entity.id === id))
 );
 
-const profilesSsgVersions = (profiles) => (
-    profiles.map((p) => (p.ssgVersion)).filter((version) => (!!version)).join(', ')
-);
-
 export const systemsToInventoryEntities = (systems, entities, showAllSystems, selectedEntities) => (
     entities.map(entity => {
         // This should compare the inventory ID instead with
@@ -166,7 +162,7 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, se
                         { title: <DateFormat date={Date.parse(matchingSystem.lastScanned)} type='relative' /> } :
                         matchingSystem.lastScanned,
                     last_scanned_text: matchingSystem.lastScanned,
-                    ssg_version: profilesSsgVersions(matchingSystem.profiles)
+                    profiles: matchingSystem.profiles
                 }
             }
             /* eslint-enable camelcase */

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -372,6 +372,302 @@ Array [
             </Truncate>
           </Tooltip>,
         },
+        "profiles": Array [
+          Object {
+            "compliant": false,
+            "lastScanned": "2019-11-21T14:32:19Z",
+            "name": "Standard System Security Profile for Red Hat Enterprise Linux 7",
+            "rules": Array [
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
+                "title": "Ensure Software Patches Installed",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg User Ownership",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
+                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
+                "title": "Record Attempts to Alter Logon and Logout Events",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
+                "title": "Record Attempts to Alter Time Through stime",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
+                "title": "Record attempts to alter time through settimeofday",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                "title": "Record Attempts to Alter the localtime File",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                "title": "Record Attempts to Alter Time Through clock_settime",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
+                "title": "Record Events that Modify the System's Network Environment",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
+                "title": "Record Events that Modify User/Group Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
+                "title": "Record Attempts to Alter Process and Session Initiation Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
+                "title": "Make the auditd Configuration Immutable",
+              },
+            ],
+            "score": 40,
+            "ssgVersion": "0.14.3",
+          },
+          Object {
+            "compliant": false,
+            "lastScanned": "2019-11-21T14:32:19Z",
+            "name": "DISA STIG for Red Hat Enterprise Linux 7",
+            "rules": Array [
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
+                "title": "Ensure Software Patches Installed",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg User Ownership",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
+                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
+                "title": "Record Attempts to Alter Logon and Logout Events",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
+                "title": "Record Attempts to Alter Time Through stime",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
+                "title": "Record attempts to alter time through settimeofday",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                "title": "Record Attempts to Alter the localtime File",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                "title": "Record Attempts to Alter Time Through clock_settime",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
+                "title": "Record Events that Modify the System's Network Environment",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
+                "title": "Record Events that Modify User/Group Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
+                "title": "Record Attempts to Alter Process and Session Initiation Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
+                "title": "Make the auditd Configuration Immutable",
+              },
+            ],
+            "score": 0,
+            "ssgVersion": "0.14.2",
+          },
+          Object {
+            "compliant": false,
+            "lastScanned": "2019-11-21T14:32:19Z",
+            "name": "United States Government Configuration Baseline",
+            "rules": Array [
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
+                "title": "Ensure Software Patches Installed",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg User Ownership",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
+                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
+                "title": "Record Attempts to Alter Logon and Logout Events",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
+                "title": "Record Attempts to Alter Time Through stime",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
+                "title": "Record attempts to alter time through settimeofday",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                "title": "Record Attempts to Alter the localtime File",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                "title": "Record Attempts to Alter Time Through clock_settime",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
+                "title": "Record Events that Modify the System's Network Environment",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
+                "title": "Record Events that Modify User/Group Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
+                "title": "Record Attempts to Alter Process and Session Initiation Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
+                "title": "Make the auditd Configuration Immutable",
+              },
+            ],
+            "score": 0,
+          },
+          Object {
+            "compliant": false,
+            "lastScanned": "2019-11-21T14:32:19Z",
+            "name": "C2S for Red Hat Enterprise Linux 7",
+            "rules": Array [
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
+                "title": "Ensure Software Patches Installed",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg User Ownership",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
+                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
+                "title": "Record Attempts to Alter Logon and Logout Events",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
+                "title": "Record Attempts to Alter Time Through stime",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
+                "title": "Record attempts to alter time through settimeofday",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                "title": "Record Attempts to Alter the localtime File",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                "title": "Record Attempts to Alter Time Through clock_settime",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
+                "title": "Record Events that Modify the System's Network Environment",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
+                "title": "Record Events that Modify User/Group Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
+                "title": "Record Attempts to Alter Process and Session Initiation Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
+                "title": "Make the auditd Configuration Immutable",
+              },
+            ],
+            "score": 0,
+          },
+        ],
         "rules_failed": Object {
           "title": <Link
             to={
@@ -388,7 +684,6 @@ Array [
         },
         "rules_failed_text": 28,
         "rules_passed": 24,
-        "ssg_version": "0.14.3, 0.14.2",
       },
       "inventory": Object {
         "hostname": undefined,


### PR DESCRIPTION
This introduces a `UnsupportedSSGVersion` component to show as a warning in various places:

![Screenshot 2020-11-17 at 04 33 39](https://user-images.githubusercontent.com/7757/99344308-09380500-2890-11eb-97f4-dca2dd9b3ce5.png)

![Screenshot 2020-11-17 at 04 29 35](https://user-images.githubusercontent.com/7757/99344287-fde4d980-288f-11eb-8544-1c365677aba1.png)

![Screenshot 2020-11-17 at 04 29 55](https://user-images.githubusercontent.com/7757/99344299-03422400-2890-11eb-8bab-faa5ccf9a464.png)

