### PR TITLE
feat(reports): RHICOMPL-1117 - Enable table view by default

### DIFF
--- a/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
+++ b/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
@@ -19,7 +19,9 @@ exports[`Reports expect to render emptystate 1`] = `
   >
     <ReportsHeader />
     <Connect(Main)>
-      <LoadingView />
+      <LoadingView
+        showTableView={true}
+      />
     </Connect(Main)>
   </StateViewPart>
   <StateViewPart
@@ -48,7 +50,9 @@ exports[`Reports expect to render loading 1`] = `
   >
     <ReportsHeader />
     <Connect(Main)>
-      <LoadingView />
+      <LoadingView
+        showTableView={true}
+      />
     </Connect(Main)>
   </StateViewPart>
   <StateViewPart
@@ -97,7 +101,9 @@ exports[`Reports expect to render without error 1`] = `
   >
     <ReportsHeader />
     <Connect(Main)>
-      <LoadingView />
+      <LoadingView
+        showTableView={true}
+      />
     </Connect(Main)>
   </StateViewPart>
   <StateViewPart
@@ -105,7 +111,7 @@ exports[`Reports expect to render without error 1`] = `
   >
     <ReportsHeader />
     <Connect(Main)>
-      <ReportCardGrid
+      <ReportsTable
         profiles={
           Array [
             Object {

--- a/src/Utilities/hooks/useFeature.js
+++ b/src/Utilities/hooks/useFeature.js
@@ -30,7 +30,7 @@ const setFlagsFromUrl = () => {
 
 // Queries the local storage for feature flag values
 const getLocatStateFlag = (feature) => (
-    localStorage.getItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`)
+    !!localStorage.getItem(`${LOCAL_STORE_FEATURE_PREFIX}:${feature}`)
 );
 
 // A hook to query feature values
@@ -50,4 +50,3 @@ const useFeature = (feature) => {
 };
 
 export default useFeature;
-

--- a/src/constants.js
+++ b/src/constants.js
@@ -72,8 +72,7 @@ export const COMPLIANT_SYSTEMS_FILTER_CONFIGURATION = [
 ];
 
 export const features = {
-    // Enable via /insights/compliance/reports?reportsTableView=enable (or disable)
-    reportTableView: false,
+    reportsTableView: true,
     multiversionTabs: false,
     showSsgVersions: false
 };


### PR DESCRIPTION
This enables the the `ReportsTable` to be the default view for the Reports page.