### PR TITLE
fix(CompliancePolicies): RHICOMPL-1128 Apollo error on refetch

### DIFF
--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -31,6 +31,7 @@ const QUERY = gql`
                 majorOsVersion
                 policyType
                 policy {
+                    id
                     name
                 }
                 benchmark {


### PR DESCRIPTION
Essential identifier seemed to be missing.

Here is the error:
```
Error writing result to store for query:
Store error: the application attempted to write an object with no provided id
but the store already contains an id of Profile:UUID for this object.
The selectionSet that was trying to be written is: ...
```