### PR TITLE
feat(FinishedCreatePolicy): RHICOMPL-1147 show errors

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -39,6 +39,14 @@
     color: var(--pf-global--danger-color--100);
     font-weight: bold;
     text-align: left;
+    width: var(--pf-global--breakpoint--sm);
+}
+
+.wizard-failed-errors {
+    color: var(--pf-global--danger-color--100);
+    font-weight: normal;
+    text-align: left;
+    width: var(--pf-global--breakpoint--sm);
 }
 
 .grey-icon {

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
@@ -2,7 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import {
     Title, Button, Bullseye, EmptyState, EmptyStateBody, EmptyStateSecondaryActions,
-    EmptyStateVariant, EmptyStateIcon
+    EmptyStateVariant, EmptyStateIcon, List, ListItem
 } from '@patternfly/react-core';
 import { ProgressBar } from 'PresentationalComponents';
 import { WrenchIcon } from '@patternfly/react-icons';
@@ -18,6 +18,7 @@ class FinishedCreatePolicy extends React.Component {
     state = {
         percent: 0,
         message: 'This usually takes a minute or two.',
+        errors: null,
         failed: false
     };
 
@@ -30,6 +31,7 @@ class FinishedCreatePolicy extends React.Component {
         }).catch((error) => {
             this.setState({
                 message: error.networkError.message,
+                errors: error.networkError.result.errors,
                 failed: true
             });
         });
@@ -83,14 +85,23 @@ class FinishedCreatePolicy extends React.Component {
         }).catch((error) => {
             this.setState({
                 message: error.networkError.message,
+                errors: error.networkError.result.errors,
                 failed: true
             });
         });;
     }
 
     render() {
-        const { percent, message, failed } = this.state;
+        const { percent, message, failed, errors } = this.state;
         const { onWizardFinish } = this.props;
+
+        let listErrors;
+        if (errors && Array.isArray(errors) && errors.length > 0) {
+            listErrors = errors.map((error) => (
+                <ListItem key={ error }>{ error }</ListItem>
+            ));
+        }
+
         return (
             <Bullseye>
                 <EmptyState variant={EmptyStateVariant.full}>
@@ -105,6 +116,11 @@ class FinishedCreatePolicy extends React.Component {
                     <EmptyStateBody className={failed && 'wizard-failed-message'}>
                         { message }
                     </EmptyStateBody>
+                    { listErrors &&
+                        <EmptyStateBody className='wizard-failed-errors'>
+                            <List>{ listErrors }</List>
+                        </EmptyStateBody>
+                    }
                     <EmptyStateSecondaryActions>
                         { percent === 100 ?
                             <Button

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.test.js
@@ -1,7 +1,8 @@
 import FinishedCreatePolicy from './FinishedCreatePolicy.js';
 import configureStore from 'redux-mock-store';
 import {
-    policyFormValues, mutateCreateProfileMock, mutateAssociateSystemsToProfile
+    policyFormValues, mutateCreateProfileMock, mutateAssociateSystemsToProfile,
+    mutateCreateProfileErrorMock
 } from '@/__fixtures__/benchmarks_rules.js';
 
 import renderer from 'react-test-renderer';
@@ -11,7 +12,6 @@ const mockStore = configureStore();
 
 describe('FinishedCreatePolicy', () => {
     let store;
-    let component;
 
     beforeEach(() => {
         store = mockStore({ form: { policyForm: { values: policyFormValues } } });
@@ -20,15 +20,27 @@ describe('FinishedCreatePolicy', () => {
     it('expect to render without error', async () => {
         const onClose = () => {};
 
-        component = renderer.create(
+        let component = renderer.create(
             <MockedProvider mocks={[mutateCreateProfileMock, mutateAssociateSystemsToProfile]}
                 addTypename={false} >
                 <FinishedCreatePolicy store={store} onClose={onClose} />
             </MockedProvider>
         );
 
-        await new Promise(resolve => setTimeout(resolve, 0)); // wait for response
-        await new Promise(resolve => setTimeout(resolve, 0)); // wait for response
+        await new Promise(resolve => setTimeout(resolve, 100)); // wait for response
+        expect(component.toJSON()).toMatchSnapshot();
+    });
+
+    it('expect to render finished error state', async () => {
+        const onClose = () => {};
+
+        let component = renderer.create(
+            <MockedProvider mocks={[mutateCreateProfileErrorMock]} addTypename={false} >
+                <FinishedCreatePolicy store={store} onClose={onClose} />
+            </MockedProvider>
+        );
+
+        await new Promise(resolve => setTimeout(resolve, 100)); // wait for response
         expect(component.toJSON()).toMatchSnapshot();
     });
 });

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.test.js
@@ -1,6 +1,8 @@
 import FinishedCreatePolicy from './FinishedCreatePolicy.js';
 import configureStore from 'redux-mock-store';
-import { policyFormValues, mutateCreateProfileMock } from '@/__fixtures__/benchmarks_rules.js';
+import {
+    policyFormValues, mutateCreateProfileMock, mutateAssociateSystemsToProfile
+} from '@/__fixtures__/benchmarks_rules.js';
 
 import renderer from 'react-test-renderer';
 import { MockedProvider } from '@apollo/react-testing';
@@ -15,14 +17,18 @@ describe('FinishedCreatePolicy', () => {
         store = mockStore({ form: { policyForm: { values: policyFormValues } } });
     });
 
-    it('expect to render without error', () => {
+    it('expect to render without error', async () => {
         const onClose = () => {};
 
         component = renderer.create(
-            <MockedProvider mocks={[mutateCreateProfileMock]} addTypename={false} >
+            <MockedProvider mocks={[mutateCreateProfileMock, mutateAssociateSystemsToProfile]}
+                addTypename={false} >
                 <FinishedCreatePolicy store={store} onClose={onClose} />
             </MockedProvider>
         );
+
+        await new Promise(resolve => setTimeout(resolve, 0)); // wait for response
+        await new Promise(resolve => setTimeout(resolve, 0)); // wait for response
         expect(component.toJSON()).toMatchSnapshot();
     });
 });

--- a/src/SmartComponents/CreatePolicy/__snapshots__/FinishedCreatePolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/FinishedCreatePolicy.test.js.snap
@@ -27,6 +27,7 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
       >
         <path
           d="M507.73 109.1c-2.24-9.03-13.54-12.09-20.12-5.51l-74.36 74.36-67.88-11.31-11.31-67.88 74.36-74.36c6.62-6.62 3.43-17.9-5.66-20.16-47.38-11.74-99.55.91-136.58 37.93-39.64 39.64-50.55 97.1-34.05 147.2L18.74 402.76c-24.99 24.99-24.99 65.51 0 90.5 24.99 24.99 65.51 24.99 90.5 0l213.21-213.21c50.12 16.71 107.47 5.68 147.37-34.22 37.07-37.07 49.7-89.32 37.91-136.73zM64 472c-13.25 0-24-10.75-24-24 0-13.26 10.75-24 24-24s24 10.74 24 24c0 13.25-10.75 24-24 24z"
+          transform=""
         />
       </svg>
       <br />
@@ -39,7 +40,7 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
         className="pf-c-empty-state__body"
       >
         <div
-          className="pf-c-progress wizard-progress-bar"
+          className="pf-c-progress pf-m-success wizard-progress-bar"
           id="finished-create-policy"
         >
           <div
@@ -47,7 +48,7 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
             className="pf-c-progress__description"
             id="finished-create-policy-description"
           >
-            Progress
+            Success
           </div>
           <div
             aria-hidden="true"
@@ -56,14 +57,37 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
             <span
               className="pf-c-progress__measure"
             >
-              0%
+              100%
+            </span>
+            <span
+              className="pf-c-progress__status-icon"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                  transform=""
+                />
+              </svg>
             </span>
           </div>
           <div
             aria-labelledby="finished-create-policy-description"
             aria-valuemax={100}
             aria-valuemin={0}
-            aria-valuenow={0}
+            aria-valuenow={100}
             className="pf-c-progress__bar"
             role="progressbar"
           >
@@ -71,7 +95,7 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
               className="pf-c-progress__indicator"
               style={
                 Object {
-                  "width": "0%",
+                  "width": "100%",
                 }
               }
             >
@@ -85,12 +109,24 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
       <div
         className="pf-c-empty-state__body"
       >
-        This usually takes a minute or two.
+        
       </div>
       <div
         className="pf-c-empty-state__secondary"
       >
-        
+        <button
+          aria-disabled={false}
+          aria-label={null}
+          className="pf-c-button pf-m-primary"
+          data-ouia-component-id={0}
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe={true}
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Return to application
+        </button>
       </div>
     </div>
   </div>

--- a/src/SmartComponents/CreatePolicy/__snapshots__/FinishedCreatePolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/FinishedCreatePolicy.test.js.snap
@@ -1,5 +1,136 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FinishedCreatePolicy expect to render finished error state 1`] = `
+<div
+  className="pf-l-bullseye"
+>
+  <div
+    className="pf-c-empty-state"
+  >
+    <div
+      className="pf-c-empty-state__content"
+    >
+      <svg
+        aria-hidden="true"
+        aria-labelledby={null}
+        className="pf-c-empty-state__icon"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style={
+          Object {
+            "verticalAlign": "-0.125em",
+          }
+        }
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M507.73 109.1c-2.24-9.03-13.54-12.09-20.12-5.51l-74.36 74.36-67.88-11.31-11.31-67.88 74.36-74.36c6.62-6.62 3.43-17.9-5.66-20.16-47.38-11.74-99.55.91-136.58 37.93-39.64 39.64-50.55 97.1-34.05 147.2L18.74 402.76c-24.99 24.99-24.99 65.51 0 90.5 24.99 24.99 65.51 24.99 90.5 0l213.21-213.21c50.12 16.71 107.47 5.68 147.37-34.22 37.07-37.07 49.7-89.32 37.91-136.73zM64 472c-13.25 0-24-10.75-24-24 0-13.26 10.75-24 24-24s24 10.74 24 24c0 13.25-10.75 24-24 24z"
+        />
+      </svg>
+      <br />
+      <h1
+        className="pf-c-title pf-m-lg"
+      >
+        Creating policy
+      </h1>
+      <div
+        className="pf-c-empty-state__body"
+      >
+        <div
+          className="pf-c-progress pf-m-danger wizard-progress-bar"
+          id="finished-create-policy"
+        >
+          <div
+            aria-hidden="true"
+            className="pf-c-progress__description"
+            id="finished-create-policy-description"
+          >
+            Error
+          </div>
+          <div
+            aria-hidden="true"
+            className="pf-c-progress__status"
+          >
+            <span
+              className="pf-c-progress__measure"
+            >
+              0%
+            </span>
+            <span
+              className="pf-c-progress__status-icon"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                  transform=""
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            aria-labelledby="finished-create-policy-description"
+            aria-valuemax={100}
+            aria-valuemin={0}
+            aria-valuenow={0}
+            className="pf-c-progress__bar"
+            role="progressbar"
+          >
+            <div
+              className="pf-c-progress__indicator"
+              style={
+                Object {
+                  "width": "0%",
+                }
+              }
+            >
+              <span
+                className="pf-c-progress__measure"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pf-c-empty-state__body wizard-failed-message"
+      >
+        Response not successful: Received status code 406
+      </div>
+      <div
+        className="pf-c-empty-state__body wizard-failed-errors"
+      >
+        <ul
+          className="pf-c-list"
+        >
+          <li>
+            Error reason
+          </li>
+        </ul>
+      </div>
+      <div
+        className="pf-c-empty-state__secondary"
+      >
+        
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`FinishedCreatePolicy expect to render without error 1`] = `
 <div
   className="pf-l-bullseye"
@@ -27,7 +158,6 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
       >
         <path
           d="M507.73 109.1c-2.24-9.03-13.54-12.09-20.12-5.51l-74.36 74.36-67.88-11.31-11.31-67.88 74.36-74.36c6.62-6.62 3.43-17.9-5.66-20.16-47.38-11.74-99.55.91-136.58 37.93-39.64 39.64-50.55 97.1-34.05 147.2L18.74 402.76c-24.99 24.99-24.99 65.51 0 90.5 24.99 24.99 65.51 24.99 90.5 0l213.21-213.21c50.12 16.71 107.47 5.68 147.37-34.22 37.07-37.07 49.7-89.32 37.91-136.73zM64 472c-13.25 0-24-10.75-24-24 0-13.26 10.75-24 24-24s24 10.74 24 24c0 13.25-10.75 24-24 24z"
-          transform=""
         />
       </svg>
       <br />

--- a/src/__fixtures__/benchmarks_rules.js
+++ b/src/__fixtures__/benchmarks_rules.js
@@ -1,4 +1,4 @@
-import { CREATE_PROFILE } from 'Utilities/graphql/mutations';
+import { CREATE_PROFILE, ASSOCIATE_SYSTEMS_TO_PROFILES } from 'Utilities/graphql/mutations';
 
 export const policyFormValues = {
     benchmark: 'a5e7f1ea-e63c-40be-a17a-c2a247c11e10',
@@ -499,6 +499,7 @@ export const mutateCreateProfileMock =  {
                 refId: 'xccdf_org.ssgproject.content_profile_C2S',
                 name: 'C2S for Red Hat Enterprise Linux 6',
                 description: 'This profile demonstrates compliance against the U.S. Government Commercial Cloud Services (C2S)',
+                selectedRuleRefIds: ['myrulefrefid'],
                 complianceThreshold: 100
             }
         }
@@ -507,12 +508,33 @@ export const mutateCreateProfileMock =  {
         data: {
             createProfile: {
                 profile: {
-                    id: 'foo'
+                    id: 'aeb578f9-c8e8-4d26-add7-e5017c9ec79a'
                 }
             }
         }
     }
 };
+
+export const mutateAssociateSystemsToProfile = {
+    request: {
+        query: ASSOCIATE_SYSTEMS_TO_PROFILES,
+        variables: {
+            input: {
+                id: 'aeb578f9-c8e8-4d26-add7-e5017c9ec79a',
+                systemIds: []
+            }
+        }
+    },
+    result: {
+        data: {
+            associateSystems: {
+                profile: {
+                    id: 'aeb578f9-c8e8-4d26-add7-e5017c9ec79a'
+                }
+            }
+        }
+    }
+}
 
 export const profileRefIdsQuery = {
     edges: [

--- a/src/__fixtures__/benchmarks_rules.js
+++ b/src/__fixtures__/benchmarks_rules.js
@@ -536,6 +536,29 @@ export const mutateAssociateSystemsToProfile = {
     }
 }
 
+export const mutateCreateProfileErrorMock =  {
+    request: {
+        query: CREATE_PROFILE,
+        variables: {
+            input: {
+                benchmarkId: 'a5e7f1ea-e63c-40be-a17a-c2a247c11e10',
+                description: 'This profile demonstrates compliance against the U.S. Government Commercial Cloud Services (C2S)',
+                name: 'C2S for Red Hat Enterprise Linux 6',
+                refId: 'xccdf_org.ssgproject.content_profile_C2S',
+                selectedRuleRefIds: ['myrulefrefid'],
+                cloneFromProfileId: '197eb783-7bca-45c5-978d-c1e89b0118da',
+                complianceThreshold:100
+            }
+        }
+    },
+    error: {
+        message: 'Response not successful: Received status code 406',
+        result: {
+            errors: ['Error reason']
+        }
+    }
+};
+
 export const profileRefIdsQuery = {
     edges: [
         {


### PR DESCRIPTION
Adds reasons list on create policy wizard in case there is an error.

![Screenshot_2020-11-24 Compliance](https://user-images.githubusercontent.com/7695766/100107201-b2bb5f80-2e69-11eb-8726-94ff55fb9e88.png)

Set width of messages and reasons container ensures that the text will
wrap at the with of the progress bar.