### PR TITLE
feat: Implement unsupported SSG version warning

### DIFF
--- a/src/PresentationalComponents/ComplianceScore/ComplianceScore.js
+++ b/src/PresentationalComponents/ComplianceScore/ComplianceScore.js
@@ -18,7 +18,9 @@ const CompliantIcon = (system) => {
 };
 
 export const complianceScoreString = (system) => {
-    if ((system.rulesPassed + system.rulesFailed) === 0) {
+    if (system.supported === false) {
+        return ' Unsupported';
+    } else if ((system.rulesPassed + system.rulesFailed) === 0) {
         return ' N/A';
     }
 
@@ -27,13 +29,16 @@ export const complianceScoreString = (system) => {
 
 const ComplianceScore = (system) => (
     <React.Fragment>
-        <Tooltip content={
-            'The system compliance score is calculated by OpenSCAP and ' +
-            'is a normalized weighted sum of rules selected for this policy.'
-        }>
-            <CompliantIcon key={ `system-compliance-icon-${system.id}` } { ...system } />
-            { complianceScoreString(system) }
-        </Tooltip>
+        { system.supported ?
+            <Tooltip content={
+                'The system compliance score is calculated by OpenSCAP and ' +
+                'is a normalized weighted sum of rules selected for this policy.'
+            }>
+                <CompliantIcon key={ `system-compliance-icon-${system.id}` } { ...system } />
+                { complianceScoreString(system) }
+            </Tooltip>
+            :
+            complianceScoreString(system) }
     </React.Fragment>
 );
 

--- a/src/PresentationalComponents/ComplianceScore/ComplianceScore.test.js
+++ b/src/PresentationalComponents/ComplianceScore/ComplianceScore.test.js
@@ -6,6 +6,7 @@ describe('auxiliary functions to reducer', () => {
             rulesPassed: 30,
             rulesFailed: 300,
             score: 10,
+            supported: true,
             compliant: false
         };
 

--- a/src/PresentationalComponents/ComplianceScore/__snapshots__/ComplianceScore.test.js.snap
+++ b/src/PresentationalComponents/ComplianceScore/__snapshots__/ComplianceScore.test.js.snap
@@ -6,6 +6,7 @@ exports[`auxiliary functions to reducer should show a danger icon if the host is
   rulesFailed={300}
   rulesPassed={30}
   score={10}
+  supported={true}
 >
   <Tooltip
     content="The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy."
@@ -71,6 +72,7 @@ exports[`auxiliary functions to reducer should show a danger icon if the host is
             rulesFailed={300}
             rulesPassed={30}
             score={10}
+            supported={true}
           />,
           " 10%",
         ]
@@ -86,6 +88,7 @@ exports[`auxiliary functions to reducer should show a danger icon if the host is
           rulesFailed={300}
           rulesPassed={30}
           score={10}
+          supported={true}
         >
           <ExclamationCircleIcon
             color="currentColor"
@@ -129,116 +132,7 @@ exports[`auxiliary functions to reducer should show a question mark icon if the 
   rulesFailed={0}
   rulesPassed={0}
 >
-  <Tooltip
-    content="The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy."
-  >
-    <Popper
-      appendTo={[Function]}
-      distance={15}
-      enableFlip={true}
-      flipBehavior={
-        Array [
-          "top",
-          "right",
-          "bottom",
-          "left",
-          "top",
-          "right",
-          "bottom",
-        ]
-      }
-      isVisible={false}
-      onBlur={[Function]}
-      onDocumentClick={false}
-      onDocumentKeyDown={[Function]}
-      onFocus={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onTriggerEnter={[Function]}
-      placement="top"
-      popper={
-        <div
-          className="pf-c-tooltip"
-          id="pf-tooltip-3"
-          role="tooltip"
-          style={
-            Object {
-              "maxWidth": null,
-              "opacity": 0,
-              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-            }
-          }
-        >
-          <TooltipArrow />
-          <TooltipContent
-            isLeftAligned={false}
-          >
-            The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy.
-          </TooltipContent>
-        </div>
-      }
-      popperMatchesTriggerWidth={false}
-      positionModifiers={
-        Object {
-          "bottom": "pf-m-bottom",
-          "left": "pf-m-left",
-          "right": "pf-m-right",
-          "top": "pf-m-top",
-        }
-      }
-      trigger={
-        Array [
-          <CompliantIcon
-            rulesFailed={0}
-            rulesPassed={0}
-          />,
-          " N/A",
-        ]
-      }
-      zIndex={9999}
-    >
-      <FindRefWrapper
-        onFoundRef={[Function]}
-      >
-        <CompliantIcon
-          key="system-compliance-icon-undefined"
-          rulesFailed={0}
-          rulesPassed={0}
-        >
-          <QuestionCircleIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-            style={
-              Object {
-                "color": "var(--pf-global--disabled-color--100)",
-              }
-            }
-          >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "color": "var(--pf-global--disabled-color--100)",
-                }
-              }
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              />
-            </svg>
-          </QuestionCircleIcon>
-        </CompliantIcon>
-         N/A
-      </FindRefWrapper>
-    </Popper>
-  </Tooltip>
+   N/A
 </ComplianceScore>
 `;
 
@@ -258,137 +152,6 @@ exports[`auxiliary functions to reducer should show a success icon if the host i
   rulesPassed={30}
   score={91}
 >
-  <Tooltip
-    content="The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy."
-  >
-    <Popper
-      appendTo={[Function]}
-      distance={15}
-      enableFlip={true}
-      flipBehavior={
-        Array [
-          "top",
-          "right",
-          "bottom",
-          "left",
-          "top",
-          "right",
-          "bottom",
-        ]
-      }
-      isVisible={false}
-      onBlur={[Function]}
-      onDocumentClick={false}
-      onDocumentKeyDown={[Function]}
-      onFocus={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onTriggerEnter={[Function]}
-      placement="top"
-      popper={
-        <div
-          className="pf-c-tooltip"
-          id="pf-tooltip-2"
-          role="tooltip"
-          style={
-            Object {
-              "maxWidth": null,
-              "opacity": 0,
-              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-            }
-          }
-        >
-          <TooltipArrow />
-          <TooltipContent
-            isLeftAligned={false}
-          >
-            The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy.
-          </TooltipContent>
-        </div>
-      }
-      popperMatchesTriggerWidth={false}
-      positionModifiers={
-        Object {
-          "bottom": "pf-m-bottom",
-          "left": "pf-m-left",
-          "right": "pf-m-right",
-          "top": "pf-m-top",
-        }
-      }
-      trigger={
-        Array [
-          <CompliantIcon
-            profiles={
-              Array [
-                Object {
-                  "compliant": true,
-                },
-                Object {
-                  "compliant": true,
-                },
-              ]
-            }
-            rulesFailed={3}
-            rulesPassed={30}
-            score={91}
-          />,
-          " 91%",
-        ]
-      }
-      zIndex={9999}
-    >
-      <FindRefWrapper
-        onFoundRef={[Function]}
-      >
-        <CompliantIcon
-          key="system-compliance-icon-undefined"
-          profiles={
-            Array [
-              Object {
-                "compliant": true,
-              },
-              Object {
-                "compliant": true,
-              },
-            ]
-          }
-          rulesFailed={3}
-          rulesPassed={30}
-          score={91}
-        >
-          <ExclamationCircleIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-            style={
-              Object {
-                "color": "var(--pf-global--danger-color--100)",
-              }
-            }
-          >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "color": "var(--pf-global--danger-color--100)",
-                }
-              }
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-              />
-            </svg>
-          </ExclamationCircleIcon>
-        </CompliantIcon>
-         91%
-      </FindRefWrapper>
-    </Popper>
-  </Tooltip>
+   91%
 </ComplianceScore>
 `;

--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { Label, TextContent, Progress } from '@patternfly/react-core';
+import { Label, TextContent, Text, Progress } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { PolicyPopover, GreySmallText } from 'PresentationalComponents';
+import { PolicyPopover, GreySmallText, UnsupportedSSGVersion } from 'PresentationalComponents';
 
 export const Name = (profile) => (
     <TextContent>
@@ -21,33 +21,52 @@ export const Name = (profile) => (
 );
 
 Name.propTypes = {
-    id: propTypes.string,
-    name: propTypes.string,
-    policy: propTypes.object
+    profile: propTypes.object
 };
 
-export const rhelColorMap = {
-    7: 'cyan',
-    8: 'purple'
+export const OperatingSystem = ({ majorOsVersion, ssgVersion, unsupported }) => {
+    const rhelColorMap = {
+        7: 'cyan',
+        8: 'purple',
+        default: 'var(--pf-global--disabled-color--200)'
+    };
+    const color = rhelColorMap[majorOsVersion] || rhelColorMap.default;
+
+    return <React.Fragment>
+        <Label { ...{ color } }>RHEL { majorOsVersion }</Label>
+        { ssgVersion && <Text>
+            <GreySmallText>
+                { unsupported ? <UnsupportedSSGVersion>{ ssgVersion }</UnsupportedSSGVersion> : ssgVersion }
+            </GreySmallText>
+        </Text> }
+    </React.Fragment>;
 };
-export const OperatingSystem = ({ majorOsVersion }) => (
-    <Label color={ rhelColorMap[majorOsVersion] }>RHEL { majorOsVersion }</Label>
-);
 
 OperatingSystem.propTypes = {
-    majorOsVersion: propTypes.string
+    majorOsVersion: propTypes.string,
+    ssgVersion: propTypes.string,
+    unsupported: propTypes.bool
 };
 
-export const CompliantSystems = ({ testResultHostCount = 0, compliantHostCount = 0 }) => (
-    <React.Fragment>
+export const CompliantSystems = ({ testResultHostCount = 0, compliantHostCount = 0, unsupportedSystems = 0 }) => {
+    const tooltipText = 'Insights cannot provide a compliance score for systems running an unsupported ' +
+        'version of the SSG at the time this report was created, as the SSG version was not supported by RHEL.';
+    return <React.Fragment>
         <Progress
             measureLocation={ 'outside' }
             value={ (100 / testResultHostCount) * compliantHostCount } />
-        <GreySmallText>{ `${ compliantHostCount } of ${ testResultHostCount } systems` }</GreySmallText>
-    </React.Fragment>
-);
+        <GreySmallText>
+            { `${ compliantHostCount } of ${ testResultHostCount } systems ` }
+
+            { unsupportedSystems > 0 && <UnsupportedSSGVersion { ...{ tooltipText } } style={ { marginLeft: '.5em' } }>
+                <strong className='ins-u-warning'>{ unsupportedSystems } unsupported</strong>
+            </UnsupportedSSGVersion> }
+        </GreySmallText>
+    </React.Fragment>;
+};
 
 CompliantSystems.propTypes = {
     testResultHostCount: propTypes.number,
-    compliantHostCount: propTypes.number
+    compliantHostCount: propTypes.number,
+    unsupportedSystems: propTypes.number
 };

--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -24,19 +24,21 @@ Name.propTypes = {
     profile: propTypes.object
 };
 
-export const OperatingSystem = ({ majorOsVersion, ssgVersion, unsupported }) => {
+export const OperatingSystem = ({ majorOsVersion, ssgVersion, totalHostCount, policy }) => {
     const rhelColorMap = {
         7: 'cyan',
         8: 'purple',
         default: 'var(--pf-global--disabled-color--200)'
     };
     const color = rhelColorMap[majorOsVersion] || rhelColorMap.default;
+    const supported = totalHostCount > 0;
+    ssgVersion = 'SSG: ' + ssgVersion;
 
     return <React.Fragment>
         <Label { ...{ color } }>RHEL { majorOsVersion }</Label>
-        { ssgVersion && <Text>
+        { policy === null && ssgVersion && <Text>
             <GreySmallText>
-                { unsupported ? <UnsupportedSSGVersion>{ ssgVersion }</UnsupportedSSGVersion> : ssgVersion }
+                { supported ? <UnsupportedSSGVersion>{ ssgVersion }</UnsupportedSSGVersion> : ssgVersion }
             </GreySmallText>
         </Text> }
     </React.Fragment>;
@@ -45,21 +47,22 @@ export const OperatingSystem = ({ majorOsVersion, ssgVersion, unsupported }) => 
 OperatingSystem.propTypes = {
     majorOsVersion: propTypes.string,
     ssgVersion: propTypes.string,
-    unsupported: propTypes.bool
+    totalHostCount: propTypes.number,
+    policy: propTypes.object
 };
 
-export const CompliantSystems = ({ testResultHostCount = 0, compliantHostCount = 0, unsupportedSystems = 0 }) => {
+export const CompliantSystems = ({ testResultHostCount = 0, compliantHostCount = 0, unsupportedHostCount = 0 }) => {
     const tooltipText = 'Insights cannot provide a compliance score for systems running an unsupported ' +
         'version of the SSG at the time this report was created, as the SSG version was not supported by RHEL.';
     return <React.Fragment>
         <Progress
             measureLocation={ 'outside' }
-            value={ (100 / testResultHostCount) * compliantHostCount } />
+            value={ testResultHostCount ? (100 / testResultHostCount) * compliantHostCount : 0 } />
         <GreySmallText>
             { `${ compliantHostCount } of ${ testResultHostCount } systems ` }
 
-            { unsupportedSystems > 0 && <UnsupportedSSGVersion { ...{ tooltipText } } style={ { marginLeft: '.5em' } }>
-                <strong className='ins-u-warning'>{ unsupportedSystems } unsupported</strong>
+            { unsupportedHostCount > 0 && <UnsupportedSSGVersion { ...{ tooltipText } } style={ { marginLeft: '.5em' } }>
+                <strong className='ins-u-warning'>{ unsupportedHostCount } unsupported</strong>
             </UnsupportedSSGVersion> }
         </GreySmallText>
     </React.Fragment>;
@@ -68,5 +71,5 @@ export const CompliantSystems = ({ testResultHostCount = 0, compliantHostCount =
 CompliantSystems.propTypes = {
     testResultHostCount: propTypes.number,
     compliantHostCount: propTypes.number,
-    unsupportedSystems: propTypes.number
+    unsupportedHostCount: propTypes.number
 };

--- a/src/PresentationalComponents/ReportsTable/Cells.test.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.test.js
@@ -19,9 +19,29 @@ describe('Name', () => {
 });
 
 describe('OperatingSystem', () => {
+    const defaultProps = {
+        majorOsVersion: 7
+    };
+
     it('expect to render without error', () => {
         const wrapper = shallow(
-            <OperatingSystem majorOsVersion="7" />
+            <OperatingSystem { ...defaultProps } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render with SSG version', () => {
+        const wrapper = shallow(
+            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render with unsupported warning', () => {
+        const wrapper = shallow(
+            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' unsupported={ true } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -29,9 +49,22 @@ describe('OperatingSystem', () => {
 });
 
 describe('CompliantSystems', () => {
+    const deftaultProps = {
+        testResultHostCount: 10,
+        compliantHostCount: 9
+    };
+
     it('expect to render without error', () => {
         const wrapper = shallow(
-            <CompliantSystems testResultHostCount={ 10 } compliantHostCount={ 9 } />
+            <CompliantSystems { ...deftaultProps } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render with unsupported hosts', () => {
+        const wrapper = shallow(
+            <CompliantSystems { ...deftaultProps } unsupportedSystems={ 42 } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/PresentationalComponents/ReportsTable/Cells.test.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.test.js
@@ -41,7 +41,7 @@ describe('OperatingSystem', () => {
 
     it('expect to render with unsupported warning', () => {
         const wrapper = shallow(
-            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' unsupported={ true } />
+            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' supported={ false } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -64,7 +64,7 @@ describe('CompliantSystems', () => {
 
     it('expect to render with unsupported hosts', () => {
         const wrapper = shallow(
-            <CompliantSystems { ...deftaultProps } unsupportedSystems={ 42 } />
+            <CompliantSystems { ...deftaultProps } unsupportedHostCount={ 42 } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/PresentationalComponents/ReportsTable/ReportsTable.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { Table, TableBody, TableHeader, sortable } from '@patternfly/react-table';
+import { Table, TableBody, TableHeader, sortable, fitContent } from '@patternfly/react-table';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
 import { emptyRows } from 'PresentationalComponents';
 import useFilterConfig from 'Utilities/hooks/useFilterConfig';
@@ -24,7 +24,7 @@ const ReportsTable = ({ profiles }) => {
         },
         {
             title: 'Systems meeting compliance',
-            transforms: [sortable],
+            transforms: [sortable, fitContent],
             sortByFunction: ({ testResultHostCount, compliantHostCount }) => (
                 (100 / testResultHostCount) * compliantHostCount
             )

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -1,8 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CompliantSystems expect to render with unsupported hosts 1`] = `""`;
+exports[`CompliantSystems expect to render with unsupported hosts 1`] = `
+<Fragment>
+  <Progress
+    className=""
+    id=""
+    label={null}
+    max={100}
+    measureLocation="outside"
+    min={0}
+    size={null}
+    title=""
+    value={90}
+    valueText={null}
+    variant={null}
+  />
+  <GreySmallText>
+    9 of 10 systems 
+    <UnsupportedSSGVersion
+      style={
+        Object {
+          "marginLeft": ".5em",
+        }
+      }
+      tooltipText="Insights cannot provide a compliance score for systems running an unsupported version of the SSG at the time this report was created, as the SSG version was not supported by RHEL."
+    >
+      <strong
+        className="ins-u-warning"
+      >
+        42
+         unsupported
+      </strong>
+    </UnsupportedSSGVersion>
+  </GreySmallText>
+</Fragment>
+`;
 
-exports[`CompliantSystems expect to render without error 1`] = `""`;
+exports[`CompliantSystems expect to render without error 1`] = `
+<Fragment>
+  <Progress
+    className=""
+    id=""
+    label={null}
+    max={100}
+    measureLocation="outside"
+    min={0}
+    size={null}
+    title=""
+    value={90}
+    valueText={null}
+    variant={null}
+  />
+  <GreySmallText>
+    9 of 10 systems 
+  </GreySmallText>
+</Fragment>
+`;
 
 exports[`Name expect to render without error 1`] = `
 <TextContent>
@@ -44,11 +97,6 @@ exports[`OperatingSystem expect to render with SSG version 1`] = `
     RHEL 
     7
   </Label>
-  <Text>
-    <GreySmallText>
-      1.2.3
-    </GreySmallText>
-  </Text>
 </Fragment>
 `;
 
@@ -60,13 +108,6 @@ exports[`OperatingSystem expect to render with unsupported warning 1`] = `
     RHEL 
     7
   </Label>
-  <Text>
-    <GreySmallText>
-      <UnsupportedSSGVersion>
-        1.2.3
-      </UnsupportedSSGVersion>
-    </GreySmallText>
-  </Text>
 </Fragment>
 `;
 

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -1,25 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CompliantSystems expect to render without error 1`] = `
-<Fragment>
-  <Progress
-    className=""
-    id=""
-    label={null}
-    max={100}
-    measureLocation="outside"
-    min={0}
-    size={null}
-    title=""
-    value={90}
-    valueText={null}
-    variant={null}
-  />
-  <GreySmallText>
-    9 of 10 systems
-  </GreySmallText>
-</Fragment>
-`;
+exports[`CompliantSystems expect to render with unsupported hosts 1`] = `""`;
+
+exports[`CompliantSystems expect to render without error 1`] = `""`;
 
 exports[`Name expect to render without error 1`] = `
 <TextContent>
@@ -53,11 +36,47 @@ exports[`Name expect to render without error 1`] = `
 </TextContent>
 `;
 
+exports[`OperatingSystem expect to render with SSG version 1`] = `
+<Fragment>
+  <Label
+    color="cyan"
+  >
+    RHEL 
+    7
+  </Label>
+  <Text>
+    <GreySmallText>
+      1.2.3
+    </GreySmallText>
+  </Text>
+</Fragment>
+`;
+
+exports[`OperatingSystem expect to render with unsupported warning 1`] = `
+<Fragment>
+  <Label
+    color="cyan"
+  >
+    RHEL 
+    7
+  </Label>
+  <Text>
+    <GreySmallText>
+      <UnsupportedSSGVersion>
+        1.2.3
+      </UnsupportedSSGVersion>
+    </GreySmallText>
+  </Text>
+</Fragment>
+`;
+
 exports[`OperatingSystem expect to render without error 1`] = `
-<Label
-  color="cyan"
->
-  RHEL 
-  7
-</Label>
+<Fragment>
+  <Label
+    color="cyan"
+  >
+    RHEL 
+    7
+  </Label>
+</Fragment>
 `;

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
@@ -112,6 +112,7 @@ exports[`ReportsTable expect to render without error 1`] = `
           "title": "Systems meeting compliance",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
       ]

--- a/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.js
+++ b/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Popover, Tooltip } from '@patternfly/react-core';
+import { ExclamationTriangleIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+
+const WarningWithPopup = ({ children }) => {
+    const headerContent = 'Unsupported SSG versions';
+    const bodyContent = 'This system is running an unsupported version of the SCAP Security Guide (SSG).' +
+        'This information is based on the last report uploaded for this system to the Compliance service.';
+    const footerContent = <a href="#">Supported SSG versions</a>;
+
+    return <Popover { ...{ headerContent, bodyContent, footerContent } }>
+        { children }
+    </Popover>;
+};
+
+WarningWithPopup.propTypes = {
+    children: propTypes.node
+};;
+
+const WarningWithTooltip = ({ children, content }) => (
+    <Tooltip content={ content } position='bottom'>
+        { children }
+    </Tooltip>
+);
+
+WarningWithTooltip.propTypes = {
+    content: propTypes.string,
+    children: propTypes.node
+};;
+
+const TooltipOrPopover = ({ variant, children, tooltipProps }) => (
+    variant === 'tooltip' ? <WarningWithTooltip { ...tooltipProps }>
+        { children }
+    </WarningWithTooltip> : <WarningWithPopup>{ children }</WarningWithPopup>
+);
+
+TooltipOrPopover.propTypes = {
+    children: propTypes.node,
+    variant: propTypes.string,
+    tooltipProps: propTypes.object
+};
+
+const UnsupportedSSGVersion = ({
+    children, showWarningIcon = true, showHelpIcon = false, style, tooltipText
+}) => {
+    const tooltipProps = {
+        content: <div>{ tooltipText }</div>
+    };
+    const variant = tooltipText ? 'tooltip' : 'popover';
+    const iconProps = {
+        variant,
+        tooltipProps
+    };
+    const defaultStyle = {
+        ...!tooltipText ? {
+            cursor: 'pointer'
+        } : {}
+    };
+
+    return <span style={ { ...style, display: 'inline-block' } }>
+        { showWarningIcon && <TooltipOrPopover { ...iconProps }>
+            <ExclamationTriangleIcon
+                className='ins-u-warning'
+                style={ {
+                    ...defaultStyle,
+                    marginRight: '.25em'
+                } }
+            />
+        </TooltipOrPopover> }
+
+        { children }
+
+        { showHelpIcon &&  <TooltipOrPopover { ...iconProps }>
+            <QuestionCircleIcon
+                style={ {
+                    ...defaultStyle,
+                    marginLeft: '.25em'
+                } }
+            />
+        </TooltipOrPopover> }
+    </span>;
+};
+
+UnsupportedSSGVersion.propTypes = {
+    showWarningIcon: propTypes.bool,
+    showHelpIcon: propTypes.bool,
+    style: propTypes.object,
+    tooltipText: propTypes.string,
+    children: propTypes.node
+};
+
+export default UnsupportedSSGVersion;

--- a/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.js
+++ b/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Popover, Tooltip } from '@patternfly/react-core';
-import { ExclamationTriangleIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+import { ExclamationTriangleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 const WarningWithPopup = ({ children }) => {
     const headerContent = 'Unsupported SSG versions';
     const bodyContent = 'This system is running an unsupported version of the SCAP Security Guide (SSG).' +
         'This information is based on the last report uploaded for this system to the Compliance service.';
-    const footerContent = <a href="#">Supported SSG versions</a>;
+    const supportedConfigsLink = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/' +
+        'html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/' +
+        'compl-assess-overview-con#compl-assess-supported-configurations-con';
+    const footerContent = <a target='_blank' rel='noopener noreferrer' href={ supportedConfigsLink }>Supported SSG versions</a>;
 
-    return <Popover { ...{ headerContent, bodyContent, footerContent } }>
+    return <Popover id='unsupported-popover' { ...{ headerContent, bodyContent, footerContent } }>
         { children }
     </Popover>;
 };
@@ -52,11 +55,7 @@ const UnsupportedSSGVersion = ({
         variant,
         tooltipProps
     };
-    const defaultStyle = {
-        ...!tooltipText ? {
-            cursor: 'pointer'
-        } : {}
-    };
+    const defaultStyle = !tooltipText ? { cursor: 'pointer' } : {};
 
     return <span style={ { ...style, display: 'inline-block' } }>
         { showWarningIcon && <TooltipOrPopover { ...iconProps }>
@@ -72,7 +71,7 @@ const UnsupportedSSGVersion = ({
         { children }
 
         { showHelpIcon &&  <TooltipOrPopover { ...iconProps }>
-            <QuestionCircleIcon
+            <OutlinedQuestionCircleIcon
                 style={ {
                     ...defaultStyle,
                     marginLeft: '.25em'

--- a/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.test.js
+++ b/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.test.js
@@ -1,0 +1,47 @@
+import UnsupportedSSGVersion from './UnsupportedSSGVersion';
+
+describe('UnsupportedSSGVersion', () => {
+    const defaultProps = {
+        style: { margin: '1em' }
+    };
+
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <UnsupportedSSGVersion { ...defaultProps }>
+                Unsupported text
+            </UnsupportedSSGVersion>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render no warning sign', () => {
+        const wrapper = shallow(
+            <UnsupportedSSGVersion { ...defaultProps } showWarningIcon={ false }>
+                Unsupported text
+            </UnsupportedSSGVersion>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render tooltip', () => {
+        const wrapper = shallow(
+            <UnsupportedSSGVersion { ...defaultProps } tooltipText='TOOLTIP TEXT'>
+                Unsupported text
+            </UnsupportedSSGVersion>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render help sign', () => {
+        const wrapper = shallow(
+            <UnsupportedSSGVersion { ...defaultProps } showHelpIcon={ true }>
+                Unsupported text
+            </UnsupportedSSGVersion>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/UnsupportedSSGVersion/__snapshots__/UnsupportedSSGVersion.test.js.snap
+++ b/src/PresentationalComponents/UnsupportedSSGVersion/__snapshots__/UnsupportedSSGVersion.test.js.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UnsupportedSSGVersion expect to render help sign 1`] = `
+<span
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1em",
+    }
+  }
+>
+  <TooltipOrPopover
+    tooltipProps={
+      Object {
+        "content": <div />,
+      }
+    }
+    variant="popover"
+  >
+    <ExclamationTriangleIcon
+      className="ins-u-warning"
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      style={
+        Object {
+          "cursor": "pointer",
+          "marginRight": ".25em",
+        }
+      }
+    />
+  </TooltipOrPopover>
+  Unsupported text
+  <TooltipOrPopover
+    tooltipProps={
+      Object {
+        "content": <div />,
+      }
+    }
+    variant="popover"
+  >
+    <QuestionCircleIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      style={
+        Object {
+          "cursor": "pointer",
+          "marginLeft": ".25em",
+        }
+      }
+    />
+  </TooltipOrPopover>
+</span>
+`;
+
+exports[`UnsupportedSSGVersion expect to render no warning sign 1`] = `
+<span
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1em",
+    }
+  }
+>
+  Unsupported text
+</span>
+`;
+
+exports[`UnsupportedSSGVersion expect to render tooltip 1`] = `
+<span
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1em",
+    }
+  }
+>
+  <TooltipOrPopover
+    tooltipProps={
+      Object {
+        "content": <div>
+          TOOLTIP TEXT
+        </div>,
+      }
+    }
+    variant="tooltip"
+  >
+    <ExclamationTriangleIcon
+      className="ins-u-warning"
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      style={
+        Object {
+          "marginRight": ".25em",
+        }
+      }
+    />
+  </TooltipOrPopover>
+  Unsupported text
+</span>
+`;
+
+exports[`UnsupportedSSGVersion expect to render without error 1`] = `
+<span
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1em",
+    }
+  }
+>
+  <TooltipOrPopover
+    tooltipProps={
+      Object {
+        "content": <div />,
+      }
+    }
+    variant="popover"
+  >
+    <ExclamationTriangleIcon
+      className="ins-u-warning"
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      style={
+        Object {
+          "cursor": "pointer",
+          "marginRight": ".25em",
+        }
+      }
+    />
+  </TooltipOrPopover>
+  Unsupported text
+</span>
+`;

--- a/src/PresentationalComponents/UnsupportedSSGVersion/__snapshots__/UnsupportedSSGVersion.test.js.snap
+++ b/src/PresentationalComponents/UnsupportedSSGVersion/__snapshots__/UnsupportedSSGVersion.test.js.snap
@@ -39,7 +39,7 @@ exports[`UnsupportedSSGVersion expect to render help sign 1`] = `
     }
     variant="popover"
   >
-    <QuestionCircleIcon
+    <OutlinedQuestionCircleIcon
       color="currentColor"
       noVerticalAlign={false}
       size="sm"

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -25,3 +25,4 @@ export { default as PolicyPopover } from './PolicyPopover/PolicyPopover';
 export { default as NoResultsTable, emptyRows } from './NoResultsTable/NoResultsTable';
 export { default as PoliciesTable } from './PoliciesTable/PoliciesTable';
 export { default as ProfileThresholdField } from './ProfileThresholdField/ProfileThresholdField';
+export { default as UnsupportedSSGVersion } from './UnsupportedSSGVersion/UnsupportedSSGVersion';

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -1,9 +1,13 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 import propTypes from 'prop-types';
-import { SystemsTable } from 'SmartComponents';
+import SystemsTable, { Cells } from '@/SmartComponents/SystemsTable/SystemsTable';
+import useFeature from 'Utilities/hooks/useFeature';
 
-const PolicySystemsTab = ({ policy, systemTableProps }) => (
-    <SystemsTable
+const PolicySystemsTab = ({ policy, systemTableProps }) => {
+    let showSsgVersions = useFeature('showSsgVersions');
+
+    return <SystemsTable
         policyId={ policy.id }
         showActions={ false }
         remediationsEnabled={ false }
@@ -13,11 +17,17 @@ const PolicySystemsTab = ({ policy, systemTableProps }) => (
             props: {
                 width: 40, isStatic: true
             }
-        }]}
+        }, ...showSsgVersions ? [{
+            key: 'facts.compliance.profiles',
+            title: 'SSG version',
+            renderFunc: (profiles) => (
+                <Cells.SSGVersion { ...{ profiles } } />
+            )
+        }] : []]}
         complianceThreshold={ policy.complianceThreshold }
         { ...systemTableProps }
-    />
-);
+    />;
+};
 
 PolicySystemsTab.propTypes = {
     policy: propTypes.shape({

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -18,10 +18,10 @@ const PolicySystemsTab = ({ policy, systemTableProps }) => {
                 width: 40, isStatic: true
             }
         }, ...showSsgVersions ? [{
-            key: 'facts.compliance.profiles',
+            key: 'facts.compliance',
             title: 'SSG version',
-            renderFunc: (profiles) => (
-                <Cells.SSGVersion { ...{ profiles } } />
+            renderFunc: (profile) => (
+                <Cells.SSGVersion { ...{ profile } } />
             )
         }] : []]}
         complianceThreshold={ policy.complianceThreshold }

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -31,6 +31,7 @@ query Profile($policyId: String!){
         refId
         testResultHostCount
         compliantHostCount
+        unsupportedHostCount
         complianceThreshold
         majorOsVersion
         lastScanned
@@ -79,8 +80,8 @@ export const ReportDetails = () => {
             { name: donutValues[0].y + ' ' + pluralize(donutValues[0].y, 'system') + ' compliant' },
             { name: donutValues[1].y + ' ' + pluralize(donutValues[1].y, 'system') + ' non-compliant' }
         ];
-        compliancePercentage = fixedPercentage(Math.floor(100 *
-                (donutValues[0].y / (donutValues[0].y + donutValues[1].y))));
+        compliancePercentage = testResultHostCount ? fixedPercentage(Math.floor(100 *
+                (donutValues[0].y / (donutValues[0].y + donutValues[1].y)))) : 0;
     }
 
     const columns = [{
@@ -96,13 +97,13 @@ export const ReportDetails = () => {
             width: 5
         }
     }, ...showSsgVersions ? [{
-        key: 'facts.compliance.profiles',
+        key: 'facts.compliance',
         title: 'SSG version',
         props: {
             width: 5
         },
-        renderFunc: (profiles) => (
-            <Cells.SSGVersion { ...{ profiles } } />
+        renderFunc: (profile) => (
+            profile && <Cells.SSGVersion { ...{ profile } } />
         )
     }] : [], {
         key: 'facts.compliance.compliance_score',
@@ -168,10 +169,10 @@ export const ReportDetails = () => {
                                 />
                             </div>
                         </div>
-                        {  profile.unsupportedSystems > 0 && <Text>
-                            <UnsupportedSSGVersion>
+                        {  profile.unsupportedHostCount > 0 && <Text>
+                            <UnsupportedSSGVersion showHelpIcon>
                                 <strong className='ins-u-warning'>
-                                    { profile.unsupportedSystems } systems not supported
+                                    { profile.unsupportedHostCount } systems not supported
                                 </strong>
                             </UnsupportedSSGVersion>
                         </Text> }

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -5,7 +6,7 @@ import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 
 import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
-import { Breadcrumb, BreadcrumbItem, Button, Grid, GridItem } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Button, Grid, GridItem, Text } from '@patternfly/react-core';
 
 import {
     PageHeader, PageHeaderTitle, Main, EmptyTable, Spinner
@@ -15,9 +16,9 @@ import { fixedPercentage, pluralize } from 'Utilities/TextHelper';
 import useFeature from 'Utilities/hooks/useFeature';
 import {
     BackgroundLink, BreadcrumbLinkItem, ReportDetailsContentLoader, ReportDetailsDescription,
-    StateViewWithError, StateViewPart
+    StateViewWithError, StateViewPart, UnsupportedSSGVersion
 } from 'PresentationalComponents';
-import { SystemsTable } from 'SmartComponents';
+import SystemsTable, { Cells } from '@/SmartComponents/SystemsTable/SystemsTable';
 
 import '@/Charts.scss';
 import './ReportDetails.scss';
@@ -95,11 +96,14 @@ export const ReportDetails = () => {
             width: 5
         }
     }, ...showSsgVersions ? [{
-        key: 'facts.compliance.ssg_version',
+        key: 'facts.compliance.profiles',
         title: 'SSG version',
         props: {
             width: 5
-        }
+        },
+        renderFunc: (profiles) => (
+            <Cells.SSGVersion { ...{ profiles } } />
+        )
     }] : [], {
         key: 'facts.compliance.compliance_score',
         title: 'Compliance score',
@@ -164,6 +168,13 @@ export const ReportDetails = () => {
                                 />
                             </div>
                         </div>
+                        {  profile.unsupportedSystems > 0 && <Text>
+                            <UnsupportedSSGVersion>
+                                <strong className='ins-u-warning'>
+                                    { profile.unsupportedSystems } systems not supported
+                                </strong>
+                            </UnsupportedSSGVersion>
+                        </Text> }
                     </GridItem>
                     <GridItem sm={12} md={12} lg={12} xl={6}>
                         <ReportDetailsDescription profile={profile} />

--- a/src/SmartComponents/ReportDetails/ReportDetails.test.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.test.js
@@ -26,9 +26,10 @@ const mocks = [
                     policyType: 'policy type',
                     description: 'profile description',
                     external: false,
-                    testResultHostCount: 1,
+                    testResultHostCount: 10,
                     complianceThreshold: 1,
-                    compliantHostCount: 1,
+                    compliantHostCount: 5,
+                    unsupported: 5,
                     policy: {
                         id: 'thepolicyid',
                         name: 'the policy name'

--- a/src/SmartComponents/ReportDetails/ReportDetails.test.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.test.js
@@ -29,7 +29,7 @@ const mocks = [
                     testResultHostCount: 10,
                     complianceThreshold: 1,
                     compliantHostCount: 5,
-                    unsupported: 5,
+                    unsupportedHostCount: 5,
                     policy: {
                         id: 'thepolicyid',
                         name: 'the policy name'

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -69,7 +69,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                   "policyType": "policy type",
                   "refId": "121212",
                   "testResultHostCount": 10,
-                  "unsupported": 5,
+                  "unsupportedHostCount": 5,
                 },
               },
               "error": false,
@@ -102,7 +102,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                     "policyType": "policy type",
                     "refId": "121212",
                     "testResultHostCount": 10,
-                    "unsupported": 5,
+                    "unsupportedHostCount": 5,
                   },
                 },
                 "error": false,
@@ -285,7 +285,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                   "policyType": "policy type",
                                   "refId": "121212",
                                   "testResultHostCount": 10,
-                                  "unsupported": 5,
+                                  "unsupportedHostCount": 5,
                                 },
                               }
                             }
@@ -324,7 +324,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                       "policyType": "policy type",
                                       "refId": "121212",
                                       "testResultHostCount": 10,
-                                      "unsupported": 5,
+                                      "unsupportedHostCount": 5,
                                     },
                                   },
                                 }
@@ -8230,6 +8230,358 @@ exports[`ReportDetails expect to render without error 1`] = `
                               </ChartDonut>
                             </div>
                           </div>
+                          <Text>
+                            <p
+                              className=""
+                              data-pf-content={true}
+                            >
+                              <UnsupportedSSGVersion
+                                showHelpIcon={true}
+                              >
+                                <span
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                    }
+                                  }
+                                >
+                                  <TooltipOrPopover
+                                    tooltipProps={
+                                      Object {
+                                        "content": <div />,
+                                      }
+                                    }
+                                    variant="popover"
+                                  >
+                                    <WarningWithPopup>
+                                      <Popover
+                                        bodyContent="This system is running an unsupported version of the SCAP Security Guide (SSG).This information is based on the last report uploaded for this system to the Compliance service."
+                                        footerContent={
+                                          <a
+                                            href="https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/compl-assess-overview-con#compl-assess-supported-configurations-con"
+                                            rel="noopener noreferrer"
+                                            target="_blank"
+                                          >
+                                            Supported SSG versions
+                                          </a>
+                                        }
+                                        headerContent="Unsupported SSG versions"
+                                        id="unsupported-popover"
+                                      >
+                                        <Popper
+                                          appendTo={[Function]}
+                                          distance={25}
+                                          enableFlip={true}
+                                          flipBehavior={
+                                            Array [
+                                              "top",
+                                              "right",
+                                              "bottom",
+                                              "left",
+                                              "top",
+                                              "right",
+                                              "bottom",
+                                            ]
+                                          }
+                                          isVisible={false}
+                                          onDocumentClick={[Function]}
+                                          onDocumentKeyDown={[Function]}
+                                          onTriggerClick={[Function]}
+                                          onTriggerEnter={[Function]}
+                                          placement="top"
+                                          popper={
+                                            <FocusTrap
+                                              active={false}
+                                              aria-describedby="popover-unsupported-popover-body"
+                                              aria-labelledby="popover-unsupported-popover-header"
+                                              aria-modal="true"
+                                              className="pf-c-popover"
+                                              focusTrapOptions={
+                                                Object {
+                                                  "clickOutsideDeactivates": true,
+                                                  "returnFocusOnDeactivate": true,
+                                                }
+                                              }
+                                              onMouseDown={[Function]}
+                                              paused={false}
+                                              role="dialog"
+                                              style={
+                                                Object {
+                                                  "maxWidth": null,
+                                                  "minWidth": null,
+                                                  "opacity": 0,
+                                                  "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                                }
+                                              }
+                                            >
+                                              <PopoverArrow />
+                                              <PopoverContent>
+                                                <PopoverCloseButton
+                                                  aria-label="Close"
+                                                  onClose={[Function]}
+                                                />
+                                                <PopoverHeader
+                                                  id="popover-unsupported-popover-header"
+                                                >
+                                                  Unsupported SSG versions
+                                                </PopoverHeader>
+                                                <PopoverBody
+                                                  id="popover-unsupported-popover-body"
+                                                >
+                                                  This system is running an unsupported version of the SCAP Security Guide (SSG).This information is based on the last report uploaded for this system to the Compliance service.
+                                                </PopoverBody>
+                                                <PopoverFooter
+                                                  id="popover-unsupported-popover-footer"
+                                                >
+                                                  <a
+                                                    href="https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/compl-assess-overview-con#compl-assess-supported-configurations-con"
+                                                    rel="noopener noreferrer"
+                                                    target="_blank"
+                                                  >
+                                                    Supported SSG versions
+                                                  </a>
+                                                </PopoverFooter>
+                                              </PopoverContent>
+                                            </FocusTrap>
+                                          }
+                                          popperMatchesTriggerWidth={false}
+                                          positionModifiers={
+                                            Object {
+                                              "bottom": "pf-m-bottom",
+                                              "left": "pf-m-left",
+                                              "right": "pf-m-right",
+                                              "top": "pf-m-top",
+                                            }
+                                          }
+                                          trigger={
+                                            <ExclamationTriangleIcon
+                                              className="ins-u-warning"
+                                              color="currentColor"
+                                              noVerticalAlign={false}
+                                              size="sm"
+                                              style={
+                                                Object {
+                                                  "cursor": "pointer",
+                                                  "marginRight": ".25em",
+                                                }
+                                              }
+                                            />
+                                          }
+                                          zIndex={9999}
+                                        >
+                                          <FindRefWrapper
+                                            onFoundRef={[Function]}
+                                          >
+                                            <ExclamationTriangleIcon
+                                              className="ins-u-warning"
+                                              color="currentColor"
+                                              noVerticalAlign={false}
+                                              size="sm"
+                                              style={
+                                                Object {
+                                                  "cursor": "pointer",
+                                                  "marginRight": ".25em",
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                aria-labelledby={null}
+                                                className="ins-u-warning"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                style={
+                                                  Object {
+                                                    "cursor": "pointer",
+                                                    "marginRight": ".25em",
+                                                  }
+                                                }
+                                                viewBox="0 0 576 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </ExclamationTriangleIcon>
+                                          </FindRefWrapper>
+                                        </Popper>
+                                      </Popover>
+                                    </WarningWithPopup>
+                                  </TooltipOrPopover>
+                                  <strong
+                                    className="ins-u-warning"
+                                  >
+                                    5
+                                     systems not supported
+                                  </strong>
+                                  <TooltipOrPopover
+                                    tooltipProps={
+                                      Object {
+                                        "content": <div />,
+                                      }
+                                    }
+                                    variant="popover"
+                                  >
+                                    <WarningWithPopup>
+                                      <Popover
+                                        bodyContent="This system is running an unsupported version of the SCAP Security Guide (SSG).This information is based on the last report uploaded for this system to the Compliance service."
+                                        footerContent={
+                                          <a
+                                            href="https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/compl-assess-overview-con#compl-assess-supported-configurations-con"
+                                            rel="noopener noreferrer"
+                                            target="_blank"
+                                          >
+                                            Supported SSG versions
+                                          </a>
+                                        }
+                                        headerContent="Unsupported SSG versions"
+                                        id="unsupported-popover"
+                                      >
+                                        <Popper
+                                          appendTo={[Function]}
+                                          distance={25}
+                                          enableFlip={true}
+                                          flipBehavior={
+                                            Array [
+                                              "top",
+                                              "right",
+                                              "bottom",
+                                              "left",
+                                              "top",
+                                              "right",
+                                              "bottom",
+                                            ]
+                                          }
+                                          isVisible={false}
+                                          onDocumentClick={[Function]}
+                                          onDocumentKeyDown={[Function]}
+                                          onTriggerClick={[Function]}
+                                          onTriggerEnter={[Function]}
+                                          placement="top"
+                                          popper={
+                                            <FocusTrap
+                                              active={false}
+                                              aria-describedby="popover-unsupported-popover-body"
+                                              aria-labelledby="popover-unsupported-popover-header"
+                                              aria-modal="true"
+                                              className="pf-c-popover"
+                                              focusTrapOptions={
+                                                Object {
+                                                  "clickOutsideDeactivates": true,
+                                                  "returnFocusOnDeactivate": true,
+                                                }
+                                              }
+                                              onMouseDown={[Function]}
+                                              paused={false}
+                                              role="dialog"
+                                              style={
+                                                Object {
+                                                  "maxWidth": null,
+                                                  "minWidth": null,
+                                                  "opacity": 0,
+                                                  "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                                }
+                                              }
+                                            >
+                                              <PopoverArrow />
+                                              <PopoverContent>
+                                                <PopoverCloseButton
+                                                  aria-label="Close"
+                                                  onClose={[Function]}
+                                                />
+                                                <PopoverHeader
+                                                  id="popover-unsupported-popover-header"
+                                                >
+                                                  Unsupported SSG versions
+                                                </PopoverHeader>
+                                                <PopoverBody
+                                                  id="popover-unsupported-popover-body"
+                                                >
+                                                  This system is running an unsupported version of the SCAP Security Guide (SSG).This information is based on the last report uploaded for this system to the Compliance service.
+                                                </PopoverBody>
+                                                <PopoverFooter
+                                                  id="popover-unsupported-popover-footer"
+                                                >
+                                                  <a
+                                                    href="https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/compl-assess-overview-con#compl-assess-supported-configurations-con"
+                                                    rel="noopener noreferrer"
+                                                    target="_blank"
+                                                  >
+                                                    Supported SSG versions
+                                                  </a>
+                                                </PopoverFooter>
+                                              </PopoverContent>
+                                            </FocusTrap>
+                                          }
+                                          popperMatchesTriggerWidth={false}
+                                          positionModifiers={
+                                            Object {
+                                              "bottom": "pf-m-bottom",
+                                              "left": "pf-m-left",
+                                              "right": "pf-m-right",
+                                              "top": "pf-m-top",
+                                            }
+                                          }
+                                          trigger={
+                                            <OutlinedQuestionCircleIcon
+                                              color="currentColor"
+                                              noVerticalAlign={false}
+                                              size="sm"
+                                              style={
+                                                Object {
+                                                  "cursor": "pointer",
+                                                  "marginLeft": ".25em",
+                                                }
+                                              }
+                                            />
+                                          }
+                                          zIndex={9999}
+                                        >
+                                          <FindRefWrapper
+                                            onFoundRef={[Function]}
+                                          >
+                                            <OutlinedQuestionCircleIcon
+                                              color="currentColor"
+                                              noVerticalAlign={false}
+                                              size="sm"
+                                              style={
+                                                Object {
+                                                  "cursor": "pointer",
+                                                  "marginLeft": ".25em",
+                                                }
+                                              }
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                aria-labelledby={null}
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                style={
+                                                  Object {
+                                                    "cursor": "pointer",
+                                                    "marginLeft": ".25em",
+                                                  }
+                                                }
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                                />
+                                              </svg>
+                                            </OutlinedQuestionCircleIcon>
+                                          </FindRefWrapper>
+                                        </Popper>
+                                      </Popover>
+                                    </WarningWithPopup>
+                                  </TooltipOrPopover>
+                                </span>
+                              </UnsupportedSSGVersion>
+                            </p>
+                          </Text>
                         </div>
                       </GridItem>
                       <GridItem
@@ -8264,7 +8616,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                 "policyType": "policy type",
                                 "refId": "121212",
                                 "testResultHostCount": 10,
-                                "unsupported": 5,
+                                "unsupportedHostCount": 5,
                               }
                             }
                           >
@@ -8503,7 +8855,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
           "policyType": "policy type",
           "refId": "121212",
           "testResultHostCount": 10,
-          "unsupported": 5,
+          "unsupportedHostCount": 5,
         },
       },
       "error": false,
@@ -8583,7 +8935,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "policyType": "policy type",
                   "refId": "121212",
                   "testResultHostCount": 10,
-                  "unsupported": 5,
+                  "unsupportedHostCount": 5,
                 },
               }
             }
@@ -8661,6 +9013,18 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
               />
             </div>
           </div>
+          <Text>
+            <UnsupportedSSGVersion
+              showHelpIcon={true}
+            >
+              <strong
+                className="ins-u-warning"
+              >
+                5
+                 systems not supported
+              </strong>
+            </UnsupportedSSGVersion>
+          </Text>
         </GridItem>
         <GridItem
           lg={12}
@@ -8691,7 +9055,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 "policyType": "policy type",
                 "refId": "121212",
                 "testResultHostCount": 10,
-                "unsupported": 5,
+                "unsupportedHostCount": 5,
               }
             }
           />
@@ -8723,7 +9087,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "title": "Rules failed",
                 },
                 Object {
-                  "key": "facts.compliance.profiles",
+                  "key": "facts.compliance",
                   "props": Object {
                     "width": 5,
                   },
@@ -8780,7 +9144,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
           "policyType": "policy type",
           "refId": "121212",
           "testResultHostCount": 10,
-          "unsupported": 5,
+          "unsupportedHostCount": 5,
         },
       },
       "error": false,
@@ -8857,7 +9221,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
                   "policyType": "policy type",
                   "refId": "121212",
                   "testResultHostCount": 10,
-                  "unsupported": 5,
+                  "unsupportedHostCount": 5,
                 },
               }
             }
@@ -8935,6 +9299,18 @@ exports[`ReportDetails expect to render without ssg version for external profile
               />
             </div>
           </div>
+          <Text>
+            <UnsupportedSSGVersion
+              showHelpIcon={true}
+            >
+              <strong
+                className="ins-u-warning"
+              >
+                5
+                 systems not supported
+              </strong>
+            </UnsupportedSSGVersion>
+          </Text>
         </GridItem>
         <GridItem
           lg={12}
@@ -8962,7 +9338,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
                 "policyType": "policy type",
                 "refId": "121212",
                 "testResultHostCount": 10,
-                "unsupported": 5,
+                "unsupportedHostCount": 5,
               }
             }
           />

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -57,7 +57,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                     "title": "BO 1",
                   },
                   "complianceThreshold": 1,
-                  "compliantHostCount": 1,
+                  "compliantHostCount": 5,
                   "description": "profile description",
                   "external": false,
                   "id": "1",
@@ -68,7 +68,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                   },
                   "policyType": "policy type",
                   "refId": "121212",
-                  "testResultHostCount": 1,
+                  "testResultHostCount": 10,
+                  "unsupported": 5,
                 },
               },
               "error": false,
@@ -89,7 +90,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                       "title": "BO 1",
                     },
                     "complianceThreshold": 1,
-                    "compliantHostCount": 1,
+                    "compliantHostCount": 5,
                     "description": "profile description",
                     "external": false,
                     "id": "1",
@@ -100,7 +101,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                     },
                     "policyType": "policy type",
                     "refId": "121212",
-                    "testResultHostCount": 1,
+                    "testResultHostCount": 10,
+                    "unsupported": 5,
                   },
                 },
                 "error": false,
@@ -271,7 +273,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                     "title": "BO 1",
                                   },
                                   "complianceThreshold": 1,
-                                  "compliantHostCount": 1,
+                                  "compliantHostCount": 5,
                                   "description": "profile description",
                                   "external": false,
                                   "id": "1",
@@ -282,7 +284,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                                   },
                                   "policyType": "policy type",
                                   "refId": "121212",
-                                  "testResultHostCount": 1,
+                                  "testResultHostCount": 10,
+                                  "unsupported": 5,
                                 },
                               }
                             }
@@ -309,7 +312,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                         "title": "BO 1",
                                       },
                                       "complianceThreshold": 1,
-                                      "compliantHostCount": 1,
+                                      "compliantHostCount": 5,
                                       "description": "profile description",
                                       "external": false,
                                       "id": "1",
@@ -320,7 +323,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                                       },
                                       "policyType": "policy type",
                                       "refId": "121212",
-                                      "testResultHostCount": 1,
+                                      "testResultHostCount": 10,
+                                      "unsupported": 5,
                                     },
                                   },
                                 }
@@ -385,11 +389,11 @@ exports[`ReportDetails expect to render without error 1`] = `
                                   Array [
                                     Object {
                                       "x": "Compliant",
-                                      "y": 1,
+                                      "y": 5,
                                     },
                                     Object {
                                       "x": "Non-compliant",
-                                      "y": 0,
+                                      "y": 5,
                                     },
                                   ]
                                 }
@@ -398,10 +402,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                 legendData={
                                   Array [
                                     Object {
-                                      "name": "1 system compliant",
+                                      "name": "5 systems compliant",
                                     },
                                     Object {
-                                      "name": "0 systems non-compliant",
+                                      "name": "5 systems non-compliant",
                                     },
                                   ]
                                 }
@@ -423,7 +427,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                 subTitle="Compliant"
                                 themeColor="blue"
                                 themeVariant="light"
-                                title="100%"
+                                title="50%"
                                 width={462}
                               >
                                 <ChartContainer
@@ -1369,11 +1373,11 @@ exports[`ReportDetails expect to render without error 1`] = `
                                             Array [
                                               Object {
                                                 "x": "Compliant",
-                                                "y": 1,
+                                                "y": 5,
                                               },
                                               Object {
                                                 "x": "Non-compliant",
-                                                "y": 0,
+                                                "y": 5,
                                               },
                                             ]
                                           }
@@ -1384,10 +1388,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                           legendData={
                                             Array [
                                               Object {
-                                                "name": "1 system compliant",
+                                                "name": "5 systems compliant",
                                               },
                                               Object {
-                                                "name": "0 systems non-compliant",
+                                                "name": "5 systems non-compliant",
                                               },
                                             ]
                                           }
@@ -1873,11 +1877,11 @@ exports[`ReportDetails expect to render without error 1`] = `
                                               Array [
                                                 Object {
                                                   "x": "Compliant",
-                                                  "y": 1,
+                                                  "y": 5,
                                                 },
                                                 Object {
                                                   "x": "Non-compliant",
-                                                  "y": 0,
+                                                  "y": 5,
                                                 },
                                               ]
                                             }
@@ -2823,30 +2827,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Array [
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                   ]
                                                 }
                                                 datum={
                                                   Object {
                                                     "_x": 1,
-                                                    "_y": 1,
-                                                    "endAngle": 359,
+                                                    "_y": 5,
+                                                    "endAngle": 180,
                                                     "padAngle": 1,
                                                     "startAngle": 0,
                                                     "x": "Compliant",
                                                     "xName": "Compliant",
-                                                    "y": 1,
+                                                    "y": 5,
                                                   }
                                                 }
                                                 events={
@@ -2878,16 +2882,16 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Object {
                                                     "data": Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
-                                                    "endAngle": 6.265732014659643,
+                                                    "endAngle": 3.141592653589793,
                                                     "index": 0,
                                                     "padAngle": 0.017453292519943295,
                                                     "startAngle": 0,
-                                                    "value": 1,
+                                                    "value": 5,
                                                   }
                                                 }
                                                 style={
@@ -2900,7 +2904,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 }
                                               >
                                                 <Path
-                                                  d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
+                                                  d="M1.130044229770525,-94.99327870980537A95,95,0,0,1,1.130044229770525,94.99327870980537L1.1300442297705258,87.99274401925855A88,88,0,0,0,1.1300442297705258,-87.99274401925855Z"
                                                   onBlur={[Function]}
                                                   onFocus={[Function]}
                                                   onMouseOut={[Function]}
@@ -2920,7 +2924,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   transform="translate(106, 115)"
                                                 >
                                                   <path
-                                                    d="M1.130044229770525,-94.99327870980537A95,95,0,1,1,-2.787733427414506,-94.95908878215752L-2.6655572507167618,-87.95962030695193A88,88,0,1,0,1.1300442297705258,-87.99274401925855Z"
+                                                    d="M1.130044229770525,-94.99327870980537A95,95,0,0,1,1.130044229770525,94.99327870980537L1.1300442297705258,87.99274401925855A88,88,0,0,0,1.1300442297705258,-87.99274401925855Z"
                                                     onBlur={[Function]}
                                                     onFocus={[Function]}
                                                     onMouseOut={[Function]}
@@ -2947,30 +2951,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Array [
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                   ]
                                                 }
                                                 datum={
                                                   Object {
                                                     "_x": 2,
-                                                    "_y": 0,
+                                                    "_y": 5,
                                                     "endAngle": 360,
                                                     "padAngle": 1,
-                                                    "startAngle": 359,
+                                                    "startAngle": 180,
                                                     "x": "Non-compliant",
                                                     "xName": "Non-compliant",
-                                                    "y": 0,
+                                                    "y": 5,
                                                   }
                                                 }
                                                 events={
@@ -3002,16 +3006,16 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Object {
                                                     "data": Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                     "endAngle": 6.283185307179586,
                                                     "index": 1,
                                                     "padAngle": 0.017453292519943295,
-                                                    "startAngle": 6.265732014659643,
-                                                    "value": 0,
+                                                    "startAngle": 3.141592653589793,
+                                                    "value": 5,
                                                   }
                                                 }
                                                 style={
@@ -3024,7 +3028,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 }
                                               >
                                                 <Path
-                                                  d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
+                                                  d="M-1.1300442297705133,94.99327870980537A95,95,0,0,1,-1.1300442297705369,-94.99327870980537L-1.1300442297705169,-87.99274401925855A88,88,0,0,0,-1.1300442297705149,87.99274401925855Z"
                                                   onBlur={[Function]}
                                                   onFocus={[Function]}
                                                   onMouseOut={[Function]}
@@ -3044,7 +3048,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   transform="translate(106, 115)"
                                                 >
                                                   <path
-                                                    d="M-0.8290208723454897,-94.99638269109627L-0.7679351238568747,-87.99664922964708Z"
+                                                    d="M-1.1300442297705133,94.99327870980537A95,95,0,0,1,-1.1300442297705369,-94.99327870980537L-1.1300442297705169,-87.99274401925855A88,88,0,0,0,-1.1300442297705149,87.99274401925855Z"
                                                     onBlur={[Function]}
                                                     onFocus={[Function]}
                                                     onMouseOut={[Function]}
@@ -3073,30 +3077,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Array [
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                   ]
                                                 }
                                                 datum={
                                                   Object {
                                                     "_x": 1,
-                                                    "_y": 1,
-                                                    "endAngle": 359,
+                                                    "_y": 5,
+                                                    "endAngle": 180,
                                                     "padAngle": 1,
                                                     "startAngle": 0,
                                                     "x": "Compliant",
                                                     "xName": "Compliant",
-                                                    "y": 1,
+                                                    "y": 5,
                                                   }
                                                 }
                                                 events={Object {}}
@@ -3114,23 +3118,23 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 id="pie-labels-0"
                                                 index={0}
                                                 key="pie-labels-0"
-                                                orientation="bottom"
+                                                orientation="right"
                                                 pointerLength={10}
                                                 pointerWidth={20}
                                                 slice={
                                                   Object {
                                                     "data": Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
-                                                    "endAngle": 6.265732014659643,
+                                                    "endAngle": 3.141592653589793,
                                                     "index": 0,
                                                     "padAngle": 0.017453292519943295,
                                                     "startAngle": 0,
-                                                    "value": 1,
+                                                    "value": 5,
                                                   }
                                                 }
                                                 style={
@@ -3145,7 +3149,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   }
                                                 }
                                                 text="Compliant"
-                                                textAnchor="middle"
+                                                textAnchor="start"
                                                 theme={
                                                   Object {
                                                     "area": Object {
@@ -3596,10 +3600,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     },
                                                   }
                                                 }
-                                                verticalAnchor="start"
+                                                verticalAnchor="middle"
                                                 width={462}
-                                                x={107}
-                                                y={218}
+                                                x={209}
+                                                y={115}
                                               >
                                                 <VictoryTooltip
                                                   active={false}
@@ -3610,30 +3614,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Array [
                                                       Object {
                                                         "_x": 1,
-                                                        "_y": 1,
+                                                        "_y": 5,
                                                         "x": "Compliant",
                                                         "xName": "Compliant",
-                                                        "y": 1,
+                                                        "y": 5,
                                                       },
                                                       Object {
                                                         "_x": 2,
-                                                        "_y": 0,
+                                                        "_y": 5,
                                                         "x": "Non-compliant",
                                                         "xName": "Non-compliant",
-                                                        "y": 0,
+                                                        "y": 5,
                                                       },
                                                     ]
                                                   }
                                                   datum={
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
-                                                      "endAngle": 359,
+                                                      "_y": 5,
+                                                      "endAngle": 180,
                                                       "padAngle": 1,
                                                       "startAngle": 0,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     }
                                                   }
                                                   events={Object {}}
@@ -4112,7 +4116,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       }
                                                     />
                                                   }
-                                                  orientation="bottom"
+                                                  orientation="right"
                                                   pointerLength={10}
                                                   pointerWidth={20}
                                                   renderInPortal={true}
@@ -4120,16 +4124,16 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "data": Object {
                                                         "_x": 1,
-                                                        "_y": 1,
+                                                        "_y": 5,
                                                         "x": "Compliant",
                                                         "xName": "Compliant",
-                                                        "y": 1,
+                                                        "y": 5,
                                                       },
-                                                      "endAngle": 6.265732014659643,
+                                                      "endAngle": 3.141592653589793,
                                                       "index": 0,
                                                       "padAngle": 0.017453292519943295,
                                                       "startAngle": 0,
-                                                      "value": 1,
+                                                      "value": 5,
                                                     }
                                                   }
                                                   style={
@@ -4144,7 +4148,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     }
                                                   }
                                                   text="Compliant"
-                                                  textAnchor="middle"
+                                                  textAnchor="start"
                                                   theme={
                                                     Object {
                                                       "area": Object {
@@ -4595,10 +4599,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       },
                                                     }
                                                   }
-                                                  verticalAnchor="start"
+                                                  verticalAnchor="middle"
                                                   width={462}
-                                                  x={107}
-                                                  y={218}
+                                                  x={209}
+                                                  y={115}
                                                 >
                                                   <VictoryPortal
                                                     groupComponent={<g />}
@@ -4613,30 +4617,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   Array [
                                                     Object {
                                                       "_x": 1,
-                                                      "_y": 1,
+                                                      "_y": 5,
                                                       "x": "Compliant",
                                                       "xName": "Compliant",
-                                                      "y": 1,
+                                                      "y": 5,
                                                     },
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                   ]
                                                 }
                                                 datum={
                                                   Object {
                                                     "_x": 2,
-                                                    "_y": 0,
+                                                    "_y": 5,
                                                     "endAngle": 360,
                                                     "padAngle": 1,
-                                                    "startAngle": 359,
+                                                    "startAngle": 180,
                                                     "x": "Non-compliant",
                                                     "xName": "Non-compliant",
-                                                    "y": 0,
+                                                    "y": 5,
                                                   }
                                                 }
                                                 events={Object {}}
@@ -4654,23 +4658,23 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 id="pie-labels-1"
                                                 index={1}
                                                 key="pie-labels-1"
-                                                orientation="top"
+                                                orientation="left"
                                                 pointerLength={10}
                                                 pointerWidth={20}
                                                 slice={
                                                   Object {
                                                     "data": Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     },
                                                     "endAngle": 6.283185307179586,
                                                     "index": 1,
                                                     "padAngle": 0.017453292519943295,
-                                                    "startAngle": 6.265732014659643,
-                                                    "value": 0,
+                                                    "startAngle": 3.141592653589793,
+                                                    "value": 5,
                                                   }
                                                 }
                                                 style={
@@ -4685,7 +4689,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   }
                                                 }
                                                 text="Non-compliant"
-                                                textAnchor="middle"
+                                                textAnchor="end"
                                                 theme={
                                                   Object {
                                                     "area": Object {
@@ -5136,10 +5140,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     },
                                                   }
                                                 }
-                                                verticalAnchor="end"
+                                                verticalAnchor="middle"
                                                 width={462}
-                                                x={105}
-                                                y={12}
+                                                x={3}
+                                                y={115}
                                               >
                                                 <VictoryTooltip
                                                   active={false}
@@ -5150,30 +5154,30 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Array [
                                                       Object {
                                                         "_x": 1,
-                                                        "_y": 1,
+                                                        "_y": 5,
                                                         "x": "Compliant",
                                                         "xName": "Compliant",
-                                                        "y": 1,
+                                                        "y": 5,
                                                       },
                                                       Object {
                                                         "_x": 2,
-                                                        "_y": 0,
+                                                        "_y": 5,
                                                         "x": "Non-compliant",
                                                         "xName": "Non-compliant",
-                                                        "y": 0,
+                                                        "y": 5,
                                                       },
                                                     ]
                                                   }
                                                   datum={
                                                     Object {
                                                       "_x": 2,
-                                                      "_y": 0,
+                                                      "_y": 5,
                                                       "endAngle": 360,
                                                       "padAngle": 1,
-                                                      "startAngle": 359,
+                                                      "startAngle": 180,
                                                       "x": "Non-compliant",
                                                       "xName": "Non-compliant",
-                                                      "y": 0,
+                                                      "y": 5,
                                                     }
                                                   }
                                                   events={Object {}}
@@ -5652,7 +5656,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       }
                                                     />
                                                   }
-                                                  orientation="top"
+                                                  orientation="left"
                                                   pointerLength={10}
                                                   pointerWidth={20}
                                                   renderInPortal={true}
@@ -5660,16 +5664,16 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "data": Object {
                                                         "_x": 2,
-                                                        "_y": 0,
+                                                        "_y": 5,
                                                         "x": "Non-compliant",
                                                         "xName": "Non-compliant",
-                                                        "y": 0,
+                                                        "y": 5,
                                                       },
                                                       "endAngle": 6.283185307179586,
                                                       "index": 1,
                                                       "padAngle": 0.017453292519943295,
-                                                      "startAngle": 6.265732014659643,
-                                                      "value": 0,
+                                                      "startAngle": 3.141592653589793,
+                                                      "value": 5,
                                                     }
                                                   }
                                                   style={
@@ -5684,7 +5688,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     }
                                                   }
                                                   text="Non-compliant"
-                                                  textAnchor="middle"
+                                                  textAnchor="end"
                                                   theme={
                                                     Object {
                                                       "area": Object {
@@ -6135,10 +6139,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       },
                                                     }
                                                   }
-                                                  verticalAnchor="end"
+                                                  verticalAnchor="middle"
                                                   width={462}
-                                                  x={105}
-                                                  y={12}
+                                                  x={3}
+                                                  y={115}
                                                 >
                                                   <VictoryPortal
                                                     groupComponent={<g />}
@@ -6151,10 +6155,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                             data={
                                               Array [
                                                 Object {
-                                                  "name": "1 system compliant",
+                                                  "name": "5 systems compliant",
                                                 },
                                                 Object {
-                                                  "name": "0 systems non-compliant",
+                                                  "name": "5 systems non-compliant",
                                                 },
                                               ]
                                             }
@@ -7080,10 +7084,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                               data={
                                                 Array [
                                                   Object {
-                                                    "name": "1 system compliant",
+                                                    "name": "5 systems compliant",
                                                   },
                                                   Object {
-                                                    "name": "0 systems non-compliant",
+                                                    "name": "5 systems non-compliant",
                                                   },
                                                 ]
                                               }
@@ -7597,10 +7601,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   data={
                                                     Array [
                                                       Object {
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                       },
                                                       Object {
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                       },
                                                     ]
                                                   }
@@ -7608,13 +7612,13 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "column": 0,
                                                       "fontSize": 14,
-                                                      "name": "1 system compliant",
+                                                      "name": "5 systems compliant",
                                                       "row": 0,
                                                       "size": 5.6,
                                                       "symbolSpacer": 14,
                                                       "textSize": Object {
                                                         "height": 16.904999999999998,
-                                                        "width": 119.70000000000002,
+                                                        "width": 126.70000000000002,
                                                       },
                                                     }
                                                   }
@@ -7668,10 +7672,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   data={
                                                     Array [
                                                       Object {
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                       },
                                                       Object {
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                       },
                                                     ]
                                                   }
@@ -7679,7 +7683,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "column": 0,
                                                       "fontSize": 14,
-                                                      "name": "0 systems non-compliant",
+                                                      "name": "5 systems non-compliant",
                                                       "row": 1,
                                                       "size": 5.6,
                                                       "symbolSpacer": 14,
@@ -7739,10 +7743,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   data={
                                                     Array [
                                                       Object {
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                       },
                                                       Object {
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                       },
                                                     ]
                                                   }
@@ -7750,13 +7754,13 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "column": 0,
                                                       "fontSize": 14,
-                                                      "name": "1 system compliant",
+                                                      "name": "5 systems compliant",
                                                       "row": 0,
                                                       "size": 5.6,
                                                       "symbolSpacer": 14,
                                                       "textSize": Object {
                                                         "height": 16.904999999999998,
-                                                        "width": 119.70000000000002,
+                                                        "width": 126.70000000000002,
                                                       },
                                                     }
                                                   }
@@ -7772,7 +7776,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       "stroke": "transparent",
                                                     }
                                                   }
-                                                  text="1 system compliant"
+                                                  text="5 systems compliant"
                                                   x={239.8}
                                                   y={100.095}
                                                 >
@@ -7782,10 +7786,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     data={
                                                       Array [
                                                         Object {
-                                                          "name": "1 system compliant",
+                                                          "name": "5 systems compliant",
                                                         },
                                                         Object {
-                                                          "name": "0 systems non-compliant",
+                                                          "name": "5 systems non-compliant",
                                                         },
                                                       ]
                                                     }
@@ -7793,13 +7797,13 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       Object {
                                                         "column": 0,
                                                         "fontSize": 14,
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                         "row": 0,
                                                         "size": 5.6,
                                                         "symbolSpacer": 14,
                                                         "textSize": Object {
                                                           "height": 16.904999999999998,
-                                                          "width": 119.70000000000002,
+                                                          "width": 126.70000000000002,
                                                         },
                                                       }
                                                     }
@@ -7818,7 +7822,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                         "textAnchor": undefined,
                                                       }
                                                     }
-                                                    text="1 system compliant"
+                                                    text="5 systems compliant"
                                                     textComponent={<Text />}
                                                     tspanComponent={<TSpan />}
                                                     x={239.8}
@@ -7874,7 +7878,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                             textAnchor="start"
                                                             x={239.8}
                                                           >
-                                                            1 system compliant
+                                                            5 systems compliant
                                                           </tspan>
                                                         </TSpan>
                                                       </text>
@@ -7885,10 +7889,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   data={
                                                     Array [
                                                       Object {
-                                                        "name": "1 system compliant",
+                                                        "name": "5 systems compliant",
                                                       },
                                                       Object {
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                       },
                                                     ]
                                                   }
@@ -7896,7 +7900,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     Object {
                                                       "column": 0,
                                                       "fontSize": 14,
-                                                      "name": "0 systems non-compliant",
+                                                      "name": "5 systems non-compliant",
                                                       "row": 1,
                                                       "size": 5.6,
                                                       "symbolSpacer": 14,
@@ -7918,7 +7922,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       "stroke": "transparent",
                                                     }
                                                   }
-                                                  text="0 systems non-compliant"
+                                                  text="5 systems non-compliant"
                                                   x={239.8}
                                                   y={131}
                                                 >
@@ -7928,10 +7932,10 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     data={
                                                       Array [
                                                         Object {
-                                                          "name": "1 system compliant",
+                                                          "name": "5 systems compliant",
                                                         },
                                                         Object {
-                                                          "name": "0 systems non-compliant",
+                                                          "name": "5 systems non-compliant",
                                                         },
                                                       ]
                                                     }
@@ -7939,7 +7943,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                       Object {
                                                         "column": 0,
                                                         "fontSize": 14,
-                                                        "name": "0 systems non-compliant",
+                                                        "name": "5 systems non-compliant",
                                                         "row": 1,
                                                         "size": 5.6,
                                                         "symbolSpacer": 14,
@@ -7964,7 +7968,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                         "textAnchor": undefined,
                                                       }
                                                     }
-                                                    text="0 systems non-compliant"
+                                                    text="5 systems non-compliant"
                                                     textComponent={<Text />}
                                                     tspanComponent={<TSpan />}
                                                     x={239.8}
@@ -8020,7 +8024,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                             textAnchor="start"
                                                             x={239.8}
                                                           >
-                                                            0 systems non-compliant
+                                                            5 systems non-compliant
                                                           </tspan>
                                                         </TSpan>
                                                       </text>
@@ -8047,7 +8051,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                           }
                                           text={
                                             Array [
-                                              "100%",
+                                              "50%",
                                               "Compliant",
                                             ]
                                           }
@@ -8081,7 +8085,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                             }
                                             text={
                                               Array [
-                                                "100%",
+                                                "50%",
                                                 "Compliant",
                                               ]
                                             }
@@ -8138,7 +8142,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     textAnchor="middle"
                                                     x={106}
                                                   >
-                                                    100%
+                                                    50%
                                                   </tspan>
                                                 </TSpan>
                                                 <TSpan
@@ -8248,7 +8252,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                   "title": "BO 1",
                                 },
                                 "complianceThreshold": 1,
-                                "compliantHostCount": 1,
+                                "compliantHostCount": 5,
                                 "description": "profile description",
                                 "external": false,
                                 "id": "1",
@@ -8259,7 +8263,8 @@ exports[`ReportDetails expect to render without error 1`] = `
                                 },
                                 "policyType": "policy type",
                                 "refId": "121212",
-                                "testResultHostCount": 1,
+                                "testResultHostCount": 10,
+                                "unsupported": 5,
                               }
                             }
                           >
@@ -8486,7 +8491,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
             "title": "BO 1",
           },
           "complianceThreshold": 1,
-          "compliantHostCount": 1,
+          "compliantHostCount": 5,
           "description": "profile description",
           "external": false,
           "id": "1",
@@ -8497,7 +8502,8 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
           },
           "policyType": "policy type",
           "refId": "121212",
-          "testResultHostCount": 1,
+          "testResultHostCount": 10,
+          "unsupported": 5,
         },
       },
       "error": false,
@@ -8565,7 +8571,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                     "title": "BO 1",
                   },
                   "complianceThreshold": 1,
-                  "compliantHostCount": 1,
+                  "compliantHostCount": 5,
                   "description": "profile description",
                   "external": false,
                   "id": "1",
@@ -8576,7 +8582,8 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   },
                   "policyType": "policy type",
                   "refId": "121212",
-                  "testResultHostCount": 1,
+                  "testResultHostCount": 10,
+                  "unsupported": 5,
                 },
               }
             }
@@ -8611,11 +8618,11 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   Array [
                     Object {
                       "x": "Compliant",
-                      "y": 1,
+                      "y": 5,
                     },
                     Object {
                       "x": "Non-compliant",
-                      "y": 0,
+                      "y": 5,
                     },
                   ]
                 }
@@ -8624,10 +8631,10 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 legendData={
                   Array [
                     Object {
-                      "name": "1 system compliant",
+                      "name": "5 systems compliant",
                     },
                     Object {
-                      "name": "0 systems non-compliant",
+                      "name": "5 systems non-compliant",
                     },
                   ]
                 }
@@ -8649,7 +8656,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 subTitle="Compliant"
                 themeColor="blue"
                 themeVariant="light"
-                title="100%"
+                title="50%"
                 width={462}
               />
             </div>
@@ -8672,7 +8679,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "title": "BO 1",
                 },
                 "complianceThreshold": 1,
-                "compliantHostCount": 1,
+                "compliantHostCount": 5,
                 "description": "profile description",
                 "external": false,
                 "id": "1",
@@ -8683,7 +8690,8 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 },
                 "policyType": "policy type",
                 "refId": "121212",
-                "testResultHostCount": 1,
+                "testResultHostCount": 10,
+                "unsupported": 5,
               }
             }
           />
@@ -8715,10 +8723,11 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "title": "Rules failed",
                 },
                 Object {
-                  "key": "facts.compliance.ssg_version",
+                  "key": "facts.compliance.profiles",
                   "props": Object {
                     "width": 5,
                   },
+                  "renderFunc": [Function],
                   "title": "SSG version",
                 },
                 Object {
@@ -8762,7 +8771,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
             "title": "BO 1",
           },
           "complianceThreshold": 1,
-          "compliantHostCount": 1,
+          "compliantHostCount": 5,
           "description": "profile description",
           "external": false,
           "id": "1",
@@ -8770,7 +8779,8 @@ exports[`ReportDetails expect to render without ssg version for external profile
           "policy": null,
           "policyType": "policy type",
           "refId": "121212",
-          "testResultHostCount": 1,
+          "testResultHostCount": 10,
+          "unsupported": 5,
         },
       },
       "error": false,
@@ -8838,7 +8848,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
                     "title": "BO 1",
                   },
                   "complianceThreshold": 1,
-                  "compliantHostCount": 1,
+                  "compliantHostCount": 5,
                   "description": "profile description",
                   "external": false,
                   "id": "1",
@@ -8846,7 +8856,8 @@ exports[`ReportDetails expect to render without ssg version for external profile
                   "policy": null,
                   "policyType": "policy type",
                   "refId": "121212",
-                  "testResultHostCount": 1,
+                  "testResultHostCount": 10,
+                  "unsupported": 5,
                 },
               }
             }
@@ -8881,11 +8892,11 @@ exports[`ReportDetails expect to render without ssg version for external profile
                   Array [
                     Object {
                       "x": "Compliant",
-                      "y": 1,
+                      "y": 5,
                     },
                     Object {
                       "x": "Non-compliant",
-                      "y": 0,
+                      "y": 5,
                     },
                   ]
                 }
@@ -8894,10 +8905,10 @@ exports[`ReportDetails expect to render without ssg version for external profile
                 legendData={
                   Array [
                     Object {
-                      "name": "1 system compliant",
+                      "name": "5 systems compliant",
                     },
                     Object {
-                      "name": "0 systems non-compliant",
+                      "name": "5 systems non-compliant",
                     },
                   ]
                 }
@@ -8919,7 +8930,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
                 subTitle="Compliant"
                 themeColor="blue"
                 themeVariant="light"
-                title="100%"
+                title="50%"
                 width={462}
               />
             </div>
@@ -8942,7 +8953,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
                   "title": "BO 1",
                 },
                 "complianceThreshold": 1,
-                "compliantHostCount": 1,
+                "compliantHostCount": 5,
                 "description": "profile description",
                 "external": false,
                 "id": "1",
@@ -8950,7 +8961,8 @@ exports[`ReportDetails expect to render without ssg version for external profile
                 "policy": null,
                 "policyType": "policy type",
                 "refId": "121212",
-                "testResultHostCount": 1,
+                "testResultHostCount": 10,
+                "unsupported": 5,
               }
             }
           />

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -23,7 +23,9 @@ query Profiles($filter: String!) {
                 totalHostCount
                 testResultHostCount
                 compliantHostCount
+                unsupportedHostCount
                 majorOsVersion
+                ssgVersion
                 complianceThreshold
                 businessObjective {
                     id

--- a/src/SmartComponents/SystemsTable/Cells.js
+++ b/src/SmartComponents/SystemsTable/Cells.js
@@ -2,16 +2,15 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { UnsupportedSSGVersion } from 'PresentationalComponents';
 
-const SSGVersion = ({ profiles }) => (
-    profiles.map((p) => (
-        p.unsupported ? <UnsupportedSSGVersion>
-            { p.ssgVersion }
-        </UnsupportedSSGVersion> : p.ssgVersion
-    )).filter((version) => (!!version)).reduce((prev, curr) => [prev, ', ', curr], [])
+const SSGVersion = ({ profile }) => (
+    profile.supported && profile.ssg_version ||
+    <UnsupportedSSGVersion>
+        { profile.ssg_version }
+    </UnsupportedSSGVersion>
 );
 
 SSGVersion.propTypes = {
-    profiles: propTypes.array
+    profile: propTypes.object
 };
 
 export default {

--- a/src/SmartComponents/SystemsTable/Cells.js
+++ b/src/SmartComponents/SystemsTable/Cells.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { UnsupportedSSGVersion } from 'PresentationalComponents';
+
+const SSGVersion = ({ profiles }) => (
+    profiles.map((p) => (
+        p.unsupported ? <UnsupportedSSGVersion>
+            { p.ssgVersion }
+        </UnsupportedSSGVersion> : p.ssgVersion
+    )).filter((version) => (!!version)).reduce((prev, curr) => [prev, ', ', curr], [])
+);
+
+SSGVersion.propTypes = {
+    profiles: propTypes.array
+};
+
+export default {
+    SSGVersion
+};

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -499,6 +499,7 @@ const ConnectedSystemsTable = (props) => {
     return <SystemsTable {...props} store={ReactRedux.useStore()} />;
 };
 
+export { default as Cells } from './Cells';
 export { SystemsTable };
 export const SystemsTableWithApollo = withApollo(ConnectedSystemsTable);
 export default connect(

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -52,6 +52,7 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
                     compliant
                     external
                     score
+                    supported
                     ssgVersion
                     rules {
                         refId
@@ -87,6 +88,8 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
                     external
                     compliant
                     score
+                    supported
+                    ssgVersion
                     policy {
                         id
                     }

--- a/src/__fixtures__/systems.js
+++ b/src/__fixtures__/systems.js
@@ -8,6 +8,7 @@ export const systems = [
                 {
                     name: 'Standard System Security Profile for Red Hat Enterprise Linux 7',
                     lastScanned: '2019-11-21T14:32:19Z',
+                    supported: true,
                     compliant: false,
                     ssgVersion: '0.14.3',
                     rules: [
@@ -82,6 +83,7 @@ export const systems = [
                 {
                     name: 'DISA STIG for Red Hat Enterprise Linux 7',
                     lastScanned: '2019-11-21T14:32:19Z',
+                    supported: true,
                     compliant: false,
                     ssgVersion: '0.14.2',
                     rules: [
@@ -156,6 +158,7 @@ export const systems = [
                 {
                     name: 'United States Government Configuration Baseline',
                     lastScanned: '2019-11-21T14:32:19Z',
+                    supported: true,
                     compliant: false,
                     rules: [
                         {
@@ -229,6 +232,7 @@ export const systems = [
                 {
                     name: 'C2S for Red Hat Enterprise Linux 7',
                     lastScanned: '2019-11-21T14:32:19Z',
+                    supported: true,
                     compliant: false,
                     rules: [
                         {
@@ -316,7 +320,8 @@ export const systems = [
                     rules: [],
                     score: 0,
                     compliant: false,
-                    ssgVersion: '0.14.5'
+                    ssgVersion: '0.14.5',
+                    supported: true
                 }
             ],
             policies: [

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -178,7 +178,8 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, se
                         { title: <DateFormat date={Date.parse(matchingSystem.lastScanned)} type='relative' /> } :
                         matchingSystem.lastScanned,
                     last_scanned_text: matchingSystem.lastScanned,
-                    ssg_version: profilesSsgVersions(matchingSystem)
+                    ssg_version: profilesSsgVersions(matchingSystem),
+                    profiles: matchingSystem.profiles
                 }
             }
             /* eslint-enable camelcase */

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -46,6 +46,10 @@ export const score = ({ testResultProfiles: profiles = [] }) => {
     return 0;
 };
 
+export const supported = ({ testResultProfiles: profiles = [] }) => (
+    profiles.reduce((acc, profile) => acc && profile.supported, true)
+);
+
 export const policyNames = (system) => {
     if (system === {}) { return ''; }
 
@@ -130,6 +134,7 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, se
         matchingSystem.lastScanned = lastScanned(matchingSystem);
         matchingSystem.compliant = compliant(matchingSystem);
         matchingSystem.score = score(matchingSystem);
+        matchingSystem.supported = supported(matchingSystem);
 
         return {
             /* eslint-disable camelcase */
@@ -179,7 +184,7 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, se
                         matchingSystem.lastScanned,
                     last_scanned_text: matchingSystem.lastScanned,
                     ssg_version: profilesSsgVersions(matchingSystem),
-                    profiles: matchingSystem.profiles
+                    supported: matchingSystem.supported
                 }
             }
             /* eslint-enable camelcase */

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -29,6 +29,7 @@ Array [
               rulesFailed={28}
               rulesPassed={24}
               score={10}
+              supported={true}
               testResultProfiles={
                 Array [
                   Object {
@@ -104,6 +105,7 @@ Array [
                     ],
                     "score": 40,
                     "ssgVersion": "0.14.3",
+                    "supported": true,
                   },
                   Object {
                     "compliant": false,
@@ -178,6 +180,7 @@ Array [
                     ],
                     "score": 0,
                     "ssgVersion": "0.14.2",
+                    "supported": true,
                   },
                   Object {
                     "compliant": false,
@@ -251,6 +254,7 @@ Array [
                       },
                     ],
                     "score": 0,
+                    "supported": true,
                   },
                   Object {
                     "compliant": false,
@@ -324,6 +328,7 @@ Array [
                       },
                     ],
                     "score": 0,
+                    "supported": true,
                   },
                 ]
               }
@@ -379,302 +384,6 @@ Array [
             </Truncate>
           </Tooltip>,
         },
-        "profiles": Array [
-          Object {
-            "compliant": false,
-            "lastScanned": "2019-11-21T14:32:19Z",
-            "name": "Standard System Security Profile for Red Hat Enterprise Linux 7",
-            "rules": Array [
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
-                "title": "Ensure Software Patches Installed",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
-                "title": "Verify /boot/grub2/grub.cfg User Ownership",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
-                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
-                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
-                "title": "Record Attempts to Alter Logon and Logout Events",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
-                "title": "Record Attempts to Alter Time Through stime",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
-                "title": "Record attempts to alter time through settimeofday",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                "title": "Record Attempts to Alter the localtime File",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                "title": "Record Attempts to Alter Time Through clock_settime",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
-                "title": "Record Events that Modify the System's Network Environment",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
-                "title": "Record Events that Modify User/Group Information",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
-                "title": "Record Attempts to Alter Process and Session Initiation Information",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
-                "title": "Make the auditd Configuration Immutable",
-              },
-            ],
-            "score": 40,
-            "ssgVersion": "0.14.3",
-          },
-          Object {
-            "compliant": false,
-            "lastScanned": "2019-11-21T14:32:19Z",
-            "name": "DISA STIG for Red Hat Enterprise Linux 7",
-            "rules": Array [
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
-                "title": "Ensure Software Patches Installed",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
-                "title": "Verify /boot/grub2/grub.cfg User Ownership",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
-                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
-                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
-                "title": "Record Attempts to Alter Logon and Logout Events",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
-                "title": "Record Attempts to Alter Time Through stime",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
-                "title": "Record attempts to alter time through settimeofday",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                "title": "Record Attempts to Alter the localtime File",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                "title": "Record Attempts to Alter Time Through clock_settime",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
-                "title": "Record Events that Modify the System's Network Environment",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
-                "title": "Record Events that Modify User/Group Information",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
-                "title": "Record Attempts to Alter Process and Session Initiation Information",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
-                "title": "Make the auditd Configuration Immutable",
-              },
-            ],
-            "score": 0,
-            "ssgVersion": "0.14.2",
-          },
-          Object {
-            "compliant": false,
-            "lastScanned": "2019-11-21T14:32:19Z",
-            "name": "United States Government Configuration Baseline",
-            "rules": Array [
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
-                "title": "Ensure Software Patches Installed",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
-                "title": "Verify /boot/grub2/grub.cfg User Ownership",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
-                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
-                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
-                "title": "Record Attempts to Alter Logon and Logout Events",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
-                "title": "Record Attempts to Alter Time Through stime",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
-                "title": "Record attempts to alter time through settimeofday",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                "title": "Record Attempts to Alter the localtime File",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                "title": "Record Attempts to Alter Time Through clock_settime",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
-                "title": "Record Events that Modify the System's Network Environment",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
-                "title": "Record Events that Modify User/Group Information",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
-                "title": "Record Attempts to Alter Process and Session Initiation Information",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
-                "title": "Make the auditd Configuration Immutable",
-              },
-            ],
-            "score": 0,
-          },
-          Object {
-            "compliant": false,
-            "lastScanned": "2019-11-21T14:32:19Z",
-            "name": "C2S for Red Hat Enterprise Linux 7",
-            "rules": Array [
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
-                "title": "Ensure Software Patches Installed",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
-                "title": "Verify /boot/grub2/grub.cfg User Ownership",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
-                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
-                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
-                "title": "Record Attempts to Alter Logon and Logout Events",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
-                "title": "Record Attempts to Alter Time Through stime",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
-                "title": "Record attempts to alter time through settimeofday",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                "title": "Record Attempts to Alter the localtime File",
-              },
-              Object {
-                "compliant": true,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                "title": "Record Attempts to Alter Time Through clock_settime",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
-                "title": "Record Events that Modify the System's Network Environment",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
-                "title": "Record Events that Modify User/Group Information",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
-                "title": "Record Attempts to Alter Process and Session Initiation Information",
-              },
-              Object {
-                "compliant": false,
-                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
-                "title": "Make the auditd Configuration Immutable",
-              },
-            ],
-            "score": 0,
-          },
-        ],
         "rules_failed": Object {
           "title": <Link
             to={
@@ -692,6 +401,7 @@ Array [
         "rules_failed_text": 28,
         "rules_passed": 24,
         "ssg_version": "0.14.3, 0.14.2",
+        "supported": true,
       },
       "inventory": Object {
         "hostname": undefined,

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -379,6 +379,302 @@ Array [
             </Truncate>
           </Tooltip>,
         },
+        "profiles": Array [
+          Object {
+            "compliant": false,
+            "lastScanned": "2019-11-21T14:32:19Z",
+            "name": "Standard System Security Profile for Red Hat Enterprise Linux 7",
+            "rules": Array [
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
+                "title": "Ensure Software Patches Installed",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg User Ownership",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
+                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
+                "title": "Record Attempts to Alter Logon and Logout Events",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
+                "title": "Record Attempts to Alter Time Through stime",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
+                "title": "Record attempts to alter time through settimeofday",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                "title": "Record Attempts to Alter the localtime File",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                "title": "Record Attempts to Alter Time Through clock_settime",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
+                "title": "Record Events that Modify the System's Network Environment",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
+                "title": "Record Events that Modify User/Group Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
+                "title": "Record Attempts to Alter Process and Session Initiation Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
+                "title": "Make the auditd Configuration Immutable",
+              },
+            ],
+            "score": 40,
+            "ssgVersion": "0.14.3",
+          },
+          Object {
+            "compliant": false,
+            "lastScanned": "2019-11-21T14:32:19Z",
+            "name": "DISA STIG for Red Hat Enterprise Linux 7",
+            "rules": Array [
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
+                "title": "Ensure Software Patches Installed",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg User Ownership",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
+                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
+                "title": "Record Attempts to Alter Logon and Logout Events",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
+                "title": "Record Attempts to Alter Time Through stime",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
+                "title": "Record attempts to alter time through settimeofday",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                "title": "Record Attempts to Alter the localtime File",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                "title": "Record Attempts to Alter Time Through clock_settime",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
+                "title": "Record Events that Modify the System's Network Environment",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
+                "title": "Record Events that Modify User/Group Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
+                "title": "Record Attempts to Alter Process and Session Initiation Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
+                "title": "Make the auditd Configuration Immutable",
+              },
+            ],
+            "score": 0,
+            "ssgVersion": "0.14.2",
+          },
+          Object {
+            "compliant": false,
+            "lastScanned": "2019-11-21T14:32:19Z",
+            "name": "United States Government Configuration Baseline",
+            "rules": Array [
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
+                "title": "Ensure Software Patches Installed",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg User Ownership",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
+                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
+                "title": "Record Attempts to Alter Logon and Logout Events",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
+                "title": "Record Attempts to Alter Time Through stime",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
+                "title": "Record attempts to alter time through settimeofday",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                "title": "Record Attempts to Alter the localtime File",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                "title": "Record Attempts to Alter Time Through clock_settime",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
+                "title": "Record Events that Modify the System's Network Environment",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
+                "title": "Record Events that Modify User/Group Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
+                "title": "Record Attempts to Alter Process and Session Initiation Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
+                "title": "Make the auditd Configuration Immutable",
+              },
+            ],
+            "score": 0,
+          },
+          Object {
+            "compliant": false,
+            "lastScanned": "2019-11-21T14:32:19Z",
+            "name": "C2S for Red Hat Enterprise Linux 7",
+            "rules": Array [
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_security_patches_up_to_date",
+                "title": "Ensure Software Patches Installed",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_owner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg User Ownership",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_file_groupowner_grub2_cfg",
+                "title": "Verify /boot/grub2/grub.cfg Group Ownership",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action",
+                "title": "Configure auditd max_log_file_action Upon Reaching Maximum Log Size",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_login_events",
+                "title": "Record Attempts to Alter Logon and Logout Events",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_stime",
+                "title": "Record Attempts to Alter Time Through stime",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday",
+                "title": "Record attempts to alter time through settimeofday",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                "title": "Record Attempts to Alter the localtime File",
+              },
+              Object {
+                "compliant": true,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                "title": "Record Attempts to Alter Time Through clock_settime",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification",
+                "title": "Record Events that Modify the System's Network Environment",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_usergroup_modification",
+                "title": "Record Events that Modify User/Group Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_session_events",
+                "title": "Record Attempts to Alter Process and Session Initiation Information",
+              },
+              Object {
+                "compliant": false,
+                "refId": "xccdf_org.ssgproject.content_rule_audit_rules_immutable",
+                "title": "Make the auditd Configuration Immutable",
+              },
+            ],
+            "score": 0,
+          },
+        ],
         "rules_failed": Object {
           "title": <Link
             to={


### PR DESCRIPTION
Copied from https://github.com/RedHatInsights/compliance-frontend/pull/829/files, rebased against master.

Backend requirement: https://github.com/RedHatInsights/compliance-backend/pull/672

RHICOMPL-690
RHICOMPL-682
RHICOMPL-685
RHICOMPL-683
RHICOMPL-1007

Reports:
![image](https://user-images.githubusercontent.com/761923/100905794-781f7b80-3496-11eb-96d4-56c503592aef.png)

Report details:
![image](https://user-images.githubusercontent.com/761923/100808574-6391a380-3402-11eb-99d9-0988c16da001.png)

Policy details -> Systems:
![image](https://user-images.githubusercontent.com/761923/100808620-76a47380-3402-11eb-89f6-6063ce8cf015.png)

Tooltips on warning icons:
![image](https://user-images.githubusercontent.com/761923/100808664-8e7bf780-3402-11eb-9bb3-f7ef0b70ff2e.png)
