### PR TITLE
fix(SystemsTable): RHICOMPL-1096 show unique policy names in the column 

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -60,6 +60,10 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
                         remediationAvailable
                     }
                 }
+                policies(policyId: $policyId) {
+                    id
+                    name
+                }
             }
         }
     }
@@ -86,6 +90,10 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
                     policy {
                         id
                     }
+                }
+                policies(policyId: $policyId) {
+                    id
+                    name
                 }
             }
         }

--- a/src/__fixtures__/systems.js
+++ b/src/__fixtures__/systems.js
@@ -299,6 +299,9 @@ export const systems = [
                     ],
                     score: 0
                 }
+            ],
+            policies: [
+                { name: 'HIPAA Policy' }
             ]
         }
     },
@@ -315,6 +318,9 @@ export const systems = [
                     compliant: false,
                     ssgVersion: '0.14.5'
                 }
+            ],
+            policies: [
+                { name: 'Standard System Security Profile Policy' }
             ]
         }
     }

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -46,19 +46,21 @@ export const score = ({ profiles = [] }) => {
     return 0;
 };
 
-export const profileNames = (system) => {
+export const policyNames = (system) => {
     if (system === {}) { return ''; }
 
-    return system.profiles.map(
-        (profile) => `${profile.policy ? '' : '(External) ' }${profile.name}`
-    ).join(', ');
+    let policyNames = system.policies.map(({ name }) => name);
+    let externalPolicyNames = system.profiles.filter(p => !p.policy).map(({ name }) => (
+        `(External) ${name}`
+    ));
+    return [...policyNames, ...externalPolicyNames].join(', ');
 };
 
 export const policiesCell = (system) => {
     let title;
-    if (system.profileNames) {
-        title = <Tooltip content={system.profileNames}>
-            <Truncate lines={2} width={540}>{system.profileNames}</Truncate>
+    if (system.policyNames) {
+        title = <Tooltip content={system.policyNames}>
+            <Truncate lines={2} width={540}>{system.policyNames}</Truncate>
         </Tooltip>;
     } else {
         title = <Text className='grey-icon'>No policies</Text>;
@@ -66,7 +68,7 @@ export const policiesCell = (system) => {
 
     return {
         title,
-        exportValue: system.profileNames
+        exportValue: system.policyNames
     };
 };
 
@@ -107,10 +109,10 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, se
         if (matchingSystem === undefined) {
             if (!showAllSystems) { return; }
 
-            matchingSystem = { profiles: [] };
+            matchingSystem = { profiles: [], policies: [] };
         }
 
-        matchingSystem.profileNames = profileNames(matchingSystem);
+        matchingSystem.policyNames = policyNames(matchingSystem);
         matchingSystem.rulesPassed = profilesRulesPassed(matchingSystem.profiles).length;
         matchingSystem.rulesFailed = profilesRulesFailed(matchingSystem.profiles).length;
         matchingSystem.lastScanned = lastScanned(matchingSystem);
@@ -149,7 +151,7 @@ export const systemsToInventoryEntities = (systems, entities, showAllSystems, se
                 compliance: {
                     display_name: displayNameCell(entity, matchingSystem),
                     policies: policiesCell(matchingSystem),
-                    details_link: matchingSystem.profileNames && {
+                    details_link: matchingSystem.profiles && matchingSystem.profiles.length > 0 && {
                         title: <Link to={{ pathname: `/systems/${matchingSystem.id}` }}>
                             View report
                         </Link>

--- a/src/store/Reducers/SystemStore.test.js
+++ b/src/store/Reducers/SystemStore.test.js
@@ -2,7 +2,7 @@ import {
     compliant,
     hasOsInfo,
     lastScanned,
-    profileNames,
+    policyNames,
     systemsToInventoryEntities
 } from './SystemStore';
 import { systems, entities } from '@/__fixtures__/systems.js';
@@ -96,15 +96,20 @@ describe('.compliant', () => {
     });
 });
 
-describe('.profileNames', () => {
-    it('should include external if profile is external', () => {
+describe('.policyNames', () => {
+    it('should return all system policies', () => {
         const system = {
             profiles: [
+                { name: 'HIPAA Profile', policy: {} },
+                { name: 'PCI-DSS Profile', policy: {} },
+                { name: 'CIS', policy: null }
+            ],
+            policies: [
                 { name: 'HIPAA' },
-                { policy: {}, name: 'PCI' }
+                { name: 'PCI Policy' }
             ]
         };
-        expect(profileNames(system)).toEqual('(External) HIPAA, PCI');
+        expect(policyNames(system)).toEqual('HIPAA, PCI Policy, (External) CIS');
     });
 });
 

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -18,6 +18,13 @@ Array [
               id="d5bc2459-21ce-4d11-bc0b-03ea7513dfa6"
               lastScanned={2019-11-21T14:32:19.000Z}
               name="demo.lobatolan.home"
+              policies={
+                Array [
+                  Object {
+                    "name": "HIPAA Policy",
+                  },
+                ]
+              }
               profileNames="(External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7"
               profiles={
                 Array [

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -25,7 +25,7 @@ Array [
                   },
                 ]
               }
-              profileNames="(External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7"
+              policyNames="HIPAA Policy, (External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7"
               profiles={
                 Array [
                   Object {
@@ -365,9 +365,9 @@ Array [
         },
         "last_scanned_text": 2019-11-21T14:32:19.000Z,
         "policies": Object {
-          "exportValue": "(External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7",
+          "exportValue": "HIPAA Policy, (External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7",
           "title": <Tooltip
-            content="(External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7"
+            content="HIPAA Policy, (External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7"
           >
             <Truncate
               ellipsis="…"
@@ -375,7 +375,7 @@ Array [
               trimWhitespace={false}
               width={540}
             >
-              (External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7
+              HIPAA Policy, (External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7
             </Truncate>
           </Tooltip>,
         },


### PR DESCRIPTION
**Requires backend RedHatInsights/compliance-backend#670**

Fixes duplicate policy names on the "Policies" table column by using fetched policy names from backend.

External policies are temporary, taken from the list of profiles.

![Screenshot_2020-12-01 Compliance](https://user-images.githubusercontent.com/7695766/100733498-9326b880-33ce-11eb-8fd5-3db7a9ecc6b6.png)
