### PR TITLE
fix(SystemsTable): RHICOMPL-1137 show reported SSG version(s)

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -44,7 +44,7 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
                 name
                 osMajorVersion
                 osMinorVersion
-                profiles(policyId: $policyId) {
+                testResultProfiles(policyId: $policyId) {
                     id
                     name
                     refId
@@ -80,7 +80,7 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
                 name
                 osMajorVersion
                 osMinorVersion
-                profiles(policyId: $policyId) {
+                testResultProfiles(policyId: $policyId) {
                     id
                     name
                     lastScanned

--- a/src/__fixtures__/systems.js
+++ b/src/__fixtures__/systems.js
@@ -4,7 +4,7 @@ export const systems = [
         node: {
             id: 'd5bc2459-21ce-4d11-bc0b-03ea7513dfa6',
             name: 'demo.lobatolan.home',
-            profiles: [
+            testResultProfiles: [
                 {
                     name: 'Standard System Security Profile for Red Hat Enterprise Linux 7',
                     lastScanned: '2019-11-21T14:32:19Z',
@@ -309,7 +309,7 @@ export const systems = [
         node: {
             id: 'c1f0aef3-66fd-4abc-aa33-ec6755dd39d9',
             name: 'hellofromlobatolan',
-            profiles: [
+            testResultProfiles: [
                 {
                     name: 'Standard System Security Profile for Red Hat Enterprise Linux 7',
                     lastScanned: 'Never',

--- a/src/store/Reducers/SystemStore.test.js
+++ b/src/store/Reducers/SystemStore.test.js
@@ -49,7 +49,7 @@ describe('mapping systems to inventory entities', () => {
 describe('.lastScanned', () => {
     it('should find the latest scan date', () => {
         const system = {
-            profiles: [
+            testResultProfiles: [
                 { lastScanned: '2019-10-25T15:59:49Z' },
                 { lastScanned: '2019-10-23T15:59:49Z' },
                 { lastScanned: '2018-12-23T17:59:49Z' }
@@ -60,7 +60,7 @@ describe('.lastScanned', () => {
 
     it('should print the latest scan date even if one profile was never scanned', () => {
         const system = {
-            profiles: [
+            testResultProfiles: [
                 { lastScanned: '2019-10-25T15:59:49Z' },
                 { lastScanned: 'Never' }
             ]
@@ -69,15 +69,15 @@ describe('.lastScanned', () => {
     });
 
     it('should print Never if the scan date cannot be ascertained', () => {
-        expect(lastScanned({ profiles: [] })).toEqual('Never');
-        expect(lastScanned({ profiles: [{ lastScanned: 'Never' }] })).toEqual('Never');
+        expect(lastScanned({ testResultProfiles: [] })).toEqual('Never');
+        expect(lastScanned({ testResultProfiles: [{ lastScanned: 'Never' }] })).toEqual('Never');
     });
 });
 
 describe('.compliant', () => {
     it('should set false if there is one non-compliant profile', () => {
         const system = {
-            profiles: [
+            testResultProfiles: [
                 { compliant: true },
                 { compliant: false }
             ]
@@ -87,7 +87,7 @@ describe('.compliant', () => {
 
     it('should set true if all profiles are compliant', () => {
         const system = {
-            profiles: [
+            testResultProfiles: [
                 { compliant: true },
                 { compliant: true }
             ]
@@ -99,7 +99,7 @@ describe('.compliant', () => {
 describe('.policyNames', () => {
     it('should return all system policies', () => {
         const system = {
-            profiles: [
+            testResultProfiles: [
                 { name: 'HIPAA Profile', policy: {} },
                 { name: 'PCI-DSS Profile', policy: {} },
                 { name: 'CIS', policy: null }

--- a/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
+++ b/src/store/Reducers/__snapshots__/SystemStore.test.js.snap
@@ -26,7 +26,10 @@ Array [
                 ]
               }
               policyNames="HIPAA Policy, (External) Standard System Security Profile for Red Hat Enterprise Linux 7, (External) DISA STIG for Red Hat Enterprise Linux 7, (External) United States Government Configuration Baseline, (External) C2S for Red Hat Enterprise Linux 7"
-              profiles={
+              rulesFailed={28}
+              rulesPassed={24}
+              score={10}
+              testResultProfiles={
                 Array [
                   Object {
                     "compliant": false,
@@ -324,9 +327,6 @@ Array [
                   },
                 ]
               }
-              rulesFailed={28}
-              rulesPassed={24}
-              score={10}
             />
              10%
           </Tooltip>


### PR DESCRIPTION
**Requires backend RedHatInsights/compliance-backend#670**

Fixes showing only reported SSG versions in the table by pulling testResultProfiles out of backend, instead of combined
`profiles` field (assigned and test result profiles).
