### PR TITLE
feat(reports): RHICOMPL-1179 Update external support message

### DIFF
--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -73,8 +73,9 @@ const ReportsHeader = () => (
                 <a href="https://access.redhat.com/solutions/5249481">Learn more</a>
             }>
             <Text variant="p">
-                As of December 2020 users will no longer be able to upload reports for SCAP policies not defined within Insights.
-                Create a SCAP policy within Insights to continue reporting on your systems.
+                Support for SCAP policies NOT defined within Compliance has been removed. The associated reports for
+                these policies will be removed from Insights by Jan 11th, 2020. Create a policy within the Compliance
+                service for compliance reporting.
             </Text>
         </Alert>
     </PageHeader>


### PR DESCRIPTION
With the next deployment, reports are no longer parsed. Warn the user
that this is the case and that external reports will eventually be
removed.

Signed-off-by: Andrew Kofink <akofink@redhat.com>