### PR TITLE
fix(Reports): RHICOMPL-1189 remediation button

### DIFF
--- a/src/Utilities/__snapshots__/ruleHelpers.test.js.snap
+++ b/src/Utilities/__snapshots__/ruleHelpers.test.js.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`simulate ruleObjectsFailed creates a system with ruleObjectsFailed based on profile failing rules 1`] = `
+Array [
+  Object {
+    "profiles": Array [
+      Object {
+        "rules": Array [
+          Object {
+            "compliant": true,
+            "title": "a",
+          },
+          Object {
+            "compliant": false,
+            "title": "b",
+          },
+        ],
+      },
+      Object {
+        "rules": Array [
+          Object {
+            "compliant": false,
+            "title": "c",
+          },
+          Object {
+            "compliant": false,
+            "title": "d",
+          },
+          Object {
+            "compliant": true,
+            "title": "e",
+          },
+        ],
+      },
+    ],
+    "ruleObjectsFailed": Array [
+      Object {
+        "compliant": false,
+        "title": "b",
+      },
+      Object {
+        "compliant": false,
+        "title": "c",
+      },
+      Object {
+        "compliant": false,
+        "title": "d",
+      },
+    ],
+    "testResultProfiles": Array [
+      Object {
+        "rules": Array [
+          Object {
+            "compliant": true,
+            "title": "a",
+          },
+          Object {
+            "compliant": false,
+            "title": "b",
+          },
+        ],
+      },
+      Object {
+        "rules": Array [
+          Object {
+            "compliant": false,
+            "title": "c",
+          },
+          Object {
+            "compliant": false,
+            "title": "d",
+          },
+          Object {
+            "compliant": true,
+            "title": "e",
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
+exports[`simulate ruleObjectsFailed should set rule objects failed even if some have no profiles or rules 1`] = `
+Array [
+  Object {
+    "profiles": Array [],
+    "ruleObjectsFailed": Array [],
+    "testResultProfiles": Array [],
+  },
+  Object {
+    "profiles": Array [
+      Object {
+        "rules": Array [],
+      },
+    ],
+    "ruleObjectsFailed": Array [],
+    "testResultProfiles": Array [
+      Object {
+        "rules": Array [],
+      },
+    ],
+  },
+  Object {
+    "profiles": Array [
+      Object {
+        "rules": Array [
+          Object {
+            "compliant": true,
+            "title": "a",
+          },
+          Object {
+            "compliant": false,
+            "title": "b",
+          },
+        ],
+      },
+    ],
+    "ruleObjectsFailed": Array [
+      Object {
+        "compliant": false,
+        "title": "b",
+      },
+    ],
+    "testResultProfiles": Array [
+      Object {
+        "rules": Array [
+          Object {
+            "compliant": true,
+            "title": "a",
+          },
+          Object {
+            "compliant": false,
+            "title": "b",
+          },
+        ],
+      },
+    ],
+  },
+]
+`;

--- a/src/Utilities/ruleHelpers.js
+++ b/src/Utilities/ruleHelpers.js
@@ -7,15 +7,19 @@ export const profilesRulesPassed = (profiles) => (
 );
 
 export const systemRulesPassed = (system) => (
-    system.profiles ? profilesRulesPassed(system.profiles) : []
+    system.testResultProfiles ? profilesRulesPassed(system.testResultProfiles) : []
 );
 
 export const systemRulesFailed = (system) => (
-    system.profiles ? profilesRulesFailed(system.profiles) : []
+    system.testResultProfiles ? profilesRulesFailed(system.testResultProfiles) : []
 );
 
 export const systemsWithRuleObjectsFailed = (systems) => (
     systems.map(system => (
-        { ruleObjectsFailed: systemRulesFailed(system), ...system }
+        {
+            ...system,
+            ruleObjectsFailed: systemRulesFailed(system),
+            profiles: system.testResultProfiles
+        }
     ))
 );

--- a/src/Utilities/ruleHelpers.test.js
+++ b/src/Utilities/ruleHelpers.test.js
@@ -9,18 +9,18 @@ import {
 describe('passed count', () => {
     it('should set rules passed as the sum over all profiles', () => {
         const system = {
-            profiles: [
+            testResultProfiles: [
                 { rules: [{ compliant: false }, { compliant: true }] },
                 { rules: [{ compliant: false }, { compliant: true }, { compliant: true }] }
             ]
         };
         expect(systemRulesPassed(system).length).toEqual(3);
-        expect(profilesRulesPassed([system.profiles[0]]).length).toEqual(1);
-        expect(profilesRulesPassed([system.profiles[1]]).length).toEqual(2);
+        expect(profilesRulesPassed([system.testResultProfiles[0]]).length).toEqual(1);
+        expect(profilesRulesPassed([system.testResultProfiles[1]]).length).toEqual(2);
     });
 
     it('should set rules count even if profiles is an empty array', () => {
-        const system = { profiles: [] };
+        const system = { testResultProfiles: [] };
         expect(systemRulesPassed(system).length).toEqual(0);
     });
 });
@@ -28,18 +28,18 @@ describe('passed count', () => {
 describe('fail count', () => {
     it('should set rules passed as the sum over all profiles', () => {
         const system = {
-            profiles: [
+            testResultProfiles: [
                 { rules: [{ compliant: false }, { compliant: false }] },
                 { rules: [{ compliant: false }, { compliant: false }, { compliant: true }] }
             ]
         };
         expect(systemRulesFailed(system).length).toEqual(4);
-        expect(profilesRulesFailed([system.profiles[0]]).length).toEqual(2);
-        expect(profilesRulesFailed([system.profiles[1]]).length).toEqual(2);
+        expect(profilesRulesFailed([system.testResultProfiles[0]]).length).toEqual(2);
+        expect(profilesRulesFailed([system.testResultProfiles[1]]).length).toEqual(2);
     });
 
     it('should set rules count even if profiles is an empty array', () => {
-        const system = { profiles: [] };
+        const system = { testResultProfiles: [] };
         expect(systemRulesFailed(system).length).toEqual(0);
     });
 });
@@ -47,65 +47,21 @@ describe('fail count', () => {
 describe('simulate ruleObjectsFailed', () => {
     it('creates a system with ruleObjectsFailed based on profile failing rules', () => {
         const system = {
-            profiles: [
+            testResultProfiles: [
                 { rules: [{ title: 'a', compliant: true }, { title: 'b', compliant: false }] },
                 { rules: [{ title: 'c', compliant: false }, { title: 'd', compliant: false }, { title: 'e', compliant: true }] }
             ]
         };
-        expect(systemsWithRuleObjectsFailed([system])).toEqual(
-            [{
-                profiles: system.profiles,
-                ruleObjectsFailed: [
-                    { compliant: false, title: 'b' }, { compliant: false, title: 'c' }, { compliant: false, title: 'd' }
-                ]
-            }]
-        );
+        expect(systemsWithRuleObjectsFailed([system])).toMatchSnapshot();
     });
 
     it('should set rule objects failed even if some have no profiles or rules', () => {
         const systems = [
-            { profiles: [] },
-            { profiles: [{ rules: [] }] },
-            { profiles: [{ rules: [{ title: 'a', compliant: true }, { title: 'b', compliant: false }] }] }
+            { testResultProfiles: [] },
+            { testResultProfiles: [{ rules: [] }] },
+            { testResultProfiles: [{ rules: [{ title: 'a', compliant: true }, { title: 'b', compliant: false }] }] }
         ];
-        expect(systemsWithRuleObjectsFailed(systems)).toEqual(
-            [
-                {
-                    profiles: [],
-                    ruleObjectsFailed: []
-                },
-                {
-                    profiles: [
-                        {
-                            rules: []
-                        }
-                    ],
-                    ruleObjectsFailed: []
-                },
-                {
-                    profiles: [
-                        {
-                            rules: [
-                                {
-                                    compliant: true,
-                                    title: 'a'
-                                },
-                                {
-                                    compliant: false,
-                                    title: 'b'
-                                }
-                            ]
-                        }
-                    ],
-                    ruleObjectsFailed: [
-                        {
-                            compliant: false,
-                            title: 'b'
-                        }
-                    ]
-                }
-            ]
-        );
+        expect(systemsWithRuleObjectsFailed(systems)).toMatchSnapshot();
     });
 });
 


### PR DESCRIPTION
The remediation button on Report detail page was not working due to
incorrect read from the system's data.  Instead of `profiles` the
rules passed to the remediation button should be collected from
`testResultProfiles`.