### PR TITLE
fix(donut): RHICOMPL-1197 Empty donuts are gray

### DIFF
--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -1,11 +1,16 @@
 /* eslint-disable react/display-name */
 import React from 'react';
+import {
+    global_palette_black_300 as black300,
+    chart_color_blue_200 as blue200,
+    chart_color_blue_300 as blue300
+} from '@patternfly/react-tokens';
 import propTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 
-import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { ChartDonut, ChartThemeVariant } from '@patternfly/react-charts';
 import { Breadcrumb, BreadcrumbItem, Button, Grid, GridItem, Text } from '@patternfly/react-core';
 
 import {
@@ -60,6 +65,7 @@ export const ReportDetails = ({ route }) => {
     });
     let donutValues = [];
     let donutId = 'loading-donut';
+    let chartColorScale;
     let profile = {};
     let policyName;
     let legendData;
@@ -73,9 +79,11 @@ export const ReportDetails = ({ route }) => {
         const testResultHostCount = profile.testResultHostCount;
         donutId = profile.name.replace(/ /g, '');
         donutValues = [
-            { x: 'Compliant', y: compliantHostCount },
+            { x: 'Compliant', y: testResultHostCount ? compliantHostCount : '0' },
             { x: 'Non-compliant', y: testResultHostCount - compliantHostCount }
         ];
+        chartColorScale = testResultHostCount === 0 && [black300.value] ||
+            [blue300.value, blue200.value];
         legendData = [
             { name: donutValues[0].y + ' ' + pluralize(donutValues[0].y, 'system') + ' compliant' },
             { name: donutValues[1].y + ' ' + pluralize(donutValues[1].y, 'system') + ' non-compliant' }
@@ -154,8 +162,8 @@ export const ReportDetails = ({ route }) => {
                                     identifier={donutId}
                                     title={compliancePercentage}
                                     subTitle="Compliant"
-                                    themeColor={ChartThemeColor.blue}
                                     themeVariant={ChartThemeVariant.light}
+                                    colorScale={chartColorScale}
                                     style={{ fontSize: 20 }}
                                     innerRadius={88}
                                     width={462}

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -385,6 +385,12 @@ exports[`ReportDetails expect to render without error 1`] = `
                               className="chart-container"
                             >
                               <ChartDonut
+                                colorScale={
+                                  Array [
+                                    "#06c",
+                                    "#519de9",
+                                  ]
+                                }
                                 data={
                                   Array [
                                     Object {
@@ -425,7 +431,6 @@ exports[`ReportDetails expect to render without error 1`] = `
                                   }
                                 }
                                 subTitle="Compliant"
-                                themeColor="blue"
                                 themeVariant="light"
                                 title="50%"
                                 width={462}
@@ -1370,6 +1375,12 @@ exports[`ReportDetails expect to render without error 1`] = `
                                       >
                                         <ChartPie
                                           allowTooltip={true}
+                                          colorScale={
+                                            Array [
+                                              "#06c",
+                                              "#519de9",
+                                            ]
+                                          }
                                           data={
                                             Array [
                                               Object {
@@ -1866,6 +1877,12 @@ exports[`ReportDetails expect to render without error 1`] = `
                                           width={462}
                                         >
                                           <VictoryPie
+                                            colorScale={
+                                              Array [
+                                                "#06c",
+                                                "#519de9",
+                                              ]
+                                            }
                                             containerComponent={
                                               <VictoryContainer
                                                 className="VictoryContainer"
@@ -3022,7 +3039,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                 }
                                                 style={
                                                   Object {
-                                                    "fill": "#8bc1f7",
+                                                    "fill": "#519de9",
                                                     "padding": 8,
                                                     "stroke": "transparent",
                                                     "strokeWidth": 1,
@@ -3041,7 +3058,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                   shapeRendering="auto"
                                                   style={
                                                     Object {
-                                                      "fill": "#8bc1f7",
+                                                      "fill": "#519de9",
                                                       "padding": 8,
                                                       "stroke": "transparent",
                                                       "strokeWidth": 1,
@@ -3061,7 +3078,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                                     shapeRendering="auto"
                                                     style={
                                                       Object {
-                                                        "fill": "#8bc1f7",
+                                                        "fill": "#519de9",
                                                         "padding": 8,
                                                         "stroke": "transparent",
                                                         "strokeWidth": 1,
@@ -8968,6 +8985,12 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
               className="chart-container"
             >
               <ChartDonut
+                colorScale={
+                  Array [
+                    "#06c",
+                    "#519de9",
+                  ]
+                }
                 data={
                   Array [
                     Object {
@@ -9008,7 +9031,6 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   }
                 }
                 subTitle="Compliant"
-                themeColor="blue"
                 themeVariant="light"
                 title="50%"
                 width={462}
@@ -9254,6 +9276,12 @@ exports[`ReportDetails expect to render without ssg version for external profile
               className="chart-container"
             >
               <ChartDonut
+                colorScale={
+                  Array [
+                    "#06c",
+                    "#519de9",
+                  ]
+                }
                 data={
                   Array [
                     Object {
@@ -9294,7 +9322,6 @@ exports[`ReportDetails expect to render without ssg version for external profile
                   }
                 }
                 subTitle="Compliant"
-                themeColor="blue"
                 themeVariant="light"
                 title="50%"
                 width={462}


### PR DESCRIPTION
So, the patternfly donut chart doesn't behave as expected (as shown in the patternfly demo/docs site). This hacks it to look as expected with 0 compliant hosts. The solution matches what we've done in the dashboard as well (copied from Advisor). I'm only fixing it here now because the dashboard folks wanted it fixed there before merging the supportability work.

Before:
![image](https://user-images.githubusercontent.com/761923/101515400-50279080-394c-11eb-864b-f1e354810fbe.png)

After:
![image](https://user-images.githubusercontent.com/761923/101515258-27070000-394c-11eb-977c-22d9cbfd2d29.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>