### PR TITLE
fix(ReportsTable): RHICOMPL-1206 Properly indicate unsupported

### DIFF
--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -24,21 +24,21 @@ Name.propTypes = {
     profile: propTypes.object
 };
 
-export const OperatingSystem = ({ majorOsVersion, ssgVersion, totalHostCount, policy }) => {
+export const OperatingSystem = ({ majorOsVersion, ssgVersion, unsupportedHostCount, policy }) => {
     const rhelColorMap = {
         7: 'cyan',
         8: 'purple',
         default: 'var(--pf-global--disabled-color--200)'
     };
     const color = rhelColorMap[majorOsVersion] || rhelColorMap.default;
-    const supported = totalHostCount > 0;
+    const supported = unsupportedHostCount === 0;
     ssgVersion = 'SSG: ' + ssgVersion;
 
     return <React.Fragment>
         <Label { ...{ color } }>RHEL { majorOsVersion }</Label>
         { policy === null && ssgVersion && <Text>
             <GreySmallText>
-                { supported ? <UnsupportedSSGVersion>{ ssgVersion }</UnsupportedSSGVersion> : ssgVersion }
+                { supported ? ssgVersion : <UnsupportedSSGVersion>{ ssgVersion }</UnsupportedSSGVersion> }
             </GreySmallText>
         </Text> }
     </React.Fragment>;
@@ -47,7 +47,7 @@ export const OperatingSystem = ({ majorOsVersion, ssgVersion, totalHostCount, po
 OperatingSystem.propTypes = {
     majorOsVersion: propTypes.string,
     ssgVersion: propTypes.string,
-    totalHostCount: propTypes.number,
+    unsupportedHostCount: propTypes.number,
     policy: propTypes.object
 };
 

--- a/src/PresentationalComponents/ReportsTable/Cells.test.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.test.js
@@ -33,7 +33,7 @@ describe('OperatingSystem', () => {
 
     it('expect to render with SSG version', () => {
         const wrapper = shallow(
-            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' />
+            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' policy={ null } unsupportedHostCount={ 0 } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -41,7 +41,7 @@ describe('OperatingSystem', () => {
 
     it('expect to render with unsupported warning', () => {
         const wrapper = shallow(
-            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' supported={ false } />
+            <OperatingSystem { ...defaultProps } ssgVersion='1.2.3' unsupportedHostCount={ 3 } policy={ null } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -101,6 +101,11 @@ exports[`OperatingSystem expect to render with SSG version 1`] = `
     RHEL 
     7
   </Label>
+  <Text>
+    <GreySmallText>
+      SSG: 1.2.3
+    </GreySmallText>
+  </Text>
 </Fragment>
 `;
 
@@ -112,6 +117,13 @@ exports[`OperatingSystem expect to render with unsupported warning 1`] = `
     RHEL 
     7
   </Label>
+  <Text>
+    <GreySmallText>
+      <UnsupportedSSGVersion>
+        SSG: 1.2.3
+      </UnsupportedSSGVersion>
+    </GreySmallText>
+  </Text>
 </Fragment>
 `;
 


### PR DESCRIPTION
The external policy should show unsupported beneath the operating system
label only if there are any unsupported hosts results reporting against
the policy.

Note for screenshots below, SSG version 0.1.43 is supported on RHEL 7.7

Before:
![image](https://user-images.githubusercontent.com/761923/101676878-c8b04f00-3a29-11eb-9801-7d92e9c1da87.png)

After:
![image](https://user-images.githubusercontent.com/761923/101688970-c3a7cb80-3a3a-11eb-9147-375535e796d4.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>