### PR TITLE
fix(unsupported text): RHICOMPL-1207 Darker yellow

### DIFF
--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -62,7 +62,7 @@ export const CompliantSystems = ({ testResultHostCount = 0, compliantHostCount =
             { `${ compliantHostCount } of ${ testResultHostCount } systems ` }
 
             { unsupportedHostCount > 0 && <UnsupportedSSGVersion { ...{ tooltipText } } style={ { marginLeft: '.5em' } }>
-                <strong className='ins-u-warning'>{ unsupportedHostCount } unsupported</strong>
+                <strong className='ins-c-warning-text'>{ unsupportedHostCount } unsupported</strong>
             </UnsupportedSSGVersion> }
         </GreySmallText>
     </React.Fragment>;

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -28,7 +28,7 @@ exports[`CompliantSystems expect to render with unsupported hosts 1`] = `
       tooltipText="Insights cannot provide a compliance score for systems running an unsupported version of the SSG at the time this report was created, as the SSG version was not supported by RHEL."
     >
       <strong
-        className="ins-u-warning"
+        className="ins-c-warning-text"
       >
         42
          unsupported

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -187,7 +187,7 @@ export const ReportDetails = ({ route }) => {
                         </div>
                         {  profile.unsupportedHostCount > 0 && <Text>
                             <UnsupportedSSGVersion showHelpIcon>
-                                <strong className='ins-u-warning'>
+                                <strong className='ins-c-warning-text'>
                                     { profile.unsupportedHostCount } systems not supported
                                 </strong>
                             </UnsupportedSSGVersion>

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -8490,7 +8490,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                                     </WarningWithPopover>
                                   </TooltipOrPopover>
                                   <strong
-                                    className="ins-u-warning"
+                                    className="ins-c-warning-text"
                                   >
                                     5
                                      systems not supported
@@ -9150,7 +9150,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
               showHelpIcon={true}
             >
               <strong
-                className="ins-u-warning"
+                className="ins-c-warning-text"
               >
                 5
                  systems not supported
@@ -9445,7 +9445,7 @@ exports[`ReportDetails expect to render without ssg version for external profile
               showHelpIcon={true}
             >
               <strong
-                className="ins-u-warning"
+                className="ins-c-warning-text"
               >
                 5
                  systems not supported


### PR DESCRIPTION
Unsupported text next to the warning icon should be
--pf-global--warning-color--200 to match the mocks

Reports:
![image](https://user-images.githubusercontent.com/761923/102373713-7f628100-3f8e-11eb-9678-231ea1c05866.png)
![image](https://user-images.githubusercontent.com/761923/102373749-88ebe900-3f8e-11eb-8f73-12fcd7a5eabf.png)
Policies: (no changes)
Systems: (see [frontend-components PR](https://github.com/RedHatInsights/frontend-components/pull/847))

Signed-off-by: Andrew Kofink <akofink@redhat.com>