### PR TITLE
fix(SSGVersion): RHICOMPL-1233 Handle unknown SSGs

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -32,8 +32,8 @@ const PolicySystemsTab = ({ policy, systemTableProps }) => {
             }, ...showSsgVersions ? [{
                 key: 'facts.compliance',
                 title: 'SSG version',
-                renderFunc: (_name, _id, profile) => (
-                    <Cells.SSGVersion { ...{ profile } } />
+                renderFunc: (profile) => (
+                    <Cells.SSGVersion supported={ profile.supported } ssgVersion={ profile.ssg_version } />
                 )
             }] : []]}
             complianceThreshold={ policy.complianceThreshold }

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -117,8 +117,8 @@ export const ReportDetails = ({ route }) => {
         props: {
             width: 5
         },
-        renderFunc: (_name, _id, profile) => (
-            profile && <Cells.SSGVersion { ...{ profile } } />
+        renderFunc: (profile) => (
+            profile && <Cells.SSGVersion supported={ profile.supported } ssgVersion={ profile.ssg_version } />
         )
     }] : [], {
         key: 'facts.compliance.rules_failed',

--- a/src/SmartComponents/SystemsTable/Cells.js
+++ b/src/SmartComponents/SystemsTable/Cells.js
@@ -2,15 +2,17 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { UnsupportedSSGVersion } from 'PresentationalComponents';
 
-const SSGVersion = ({ profile }) => (
-    profile.supported && profile.ssgVersion ||
-    <UnsupportedSSGVersion messageVariant='singular'>
-        { profile.ssgVersion }
-    </UnsupportedSSGVersion>
-);
+const SSGVersion = ({ supported, ssgVersion }) => {
+    ssgVersion ||= 'Not available';
+    return supported ? ssgVersion :
+        <UnsupportedSSGVersion messageVariant='singular'>
+            { ssgVersion }
+        </UnsupportedSSGVersion>;
+};
 
 SSGVersion.propTypes = {
-    profile: propTypes.object
+    supported: propTypes.bool,
+    ssgVersion: propTypes.string
 };
 
 export default {


### PR DESCRIPTION
Before a system has uploaded any reports, the SSG version returned from
the API is a blank string. The SSGVersion component should render
'Not available' in that case.

![image](https://user-images.githubusercontent.com/761923/102381174-e71cca00-3f96-11eb-9ea4-6d595db591c2.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>