### PR TITLE
chore(docker): Use RedHat UBI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
-FROM fedora:29
-RUN dnf install -y npm git
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
-RUN mkdir /frontend
-WORKDIR /frontend
+ENV WORKDIR /compliance/
+RUN mkdir -p $WORKDIR
+WORKDIR $WORKDIR
 
-COPY package*.json /frontend/
-RUN npm install
-
+COPY package*.json $WORKDIR
 COPY ./entrypoint.sh /
-ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["npm", "run", "start"]
+RUN dnf -y --disableplugin=subscription-manager module enable nodejs:10 && \
+    dnf -y --disableplugin=subscription-manager module enable python27:2.7 && \
+    dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
+       npm nodejs \
+       python2 \
+       make gcc-c++ git && \
+    dnf --disableplugin=subscription-manager clean all
+
+RUN npm install
+RUN npm rebuild node-sass
 
 EXPOSE 8002
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["npm", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
         ports:
             - 8002:8002
         volumes:
-            - .:/frontend:z
-            - /frontend/node_modules
+            - .:/compliance:z
+            - /compliance/node_modules
 
     # Enable/uncomment this if you want to run chrome locally
     # chrome:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-if [[ ! -d "/frontend/node_modules/@redhat-cloud-services" ]]; then
+if [[ ! -d "/compliance/node_modules/@redhat-cloud-services" ]]; then
     echo "No modules installed! Installing..."
-    cd /frontend; /usr/bin/npm install;
+    cd /compliance; /usr/bin/npm install;
 fi
 
 exec "$@"


### PR DESCRIPTION
This replaces the Fedora image with the RHEL 8 UBI image as the base for docker.

(Shamelessly stolen from https://github.com/RedHatInsights/sources-ui)