### PR TITLE
fix(InventoryTable): RHICOMPL-1396 - Combine filters properly

### DIFF
--- a/src/SmartComponents/SystemsTable/InventoryTable.js
+++ b/src/SmartComponents/SystemsTable/InventoryTable.js
@@ -65,17 +65,19 @@ const InventoryTable = ({
     const fetchSystems = (perPage = 50, page = 1) => {
         setIsLoaded(false);
 
-        const filter = buildFilterString();
+        const filterString = buildFilterString();
+        const combindedFilter = [
+            ...showOnlySystemsWithTestResults ? ['has_test_results = true'] : [],
+            ...filterString?.length > 0 ? [filterString] : []
+        ].join(' and ');
+        const filter = defaultFilter ? `(${ defaultFilter }) and (${ combindedFilter })` : combindedFilter;
+
         return client.query({
             query,
             fetchResults: true,
             fetchPolicy: 'no-cache',
             variables: {
-                filter: [
-                    ...defaultFilter ? [defaultFilter] : [],
-                    ...showOnlySystemsWithTestResults ? ['has_test_results = true'] : [],
-                    ...filter?.length > 0 ? [filter] : []
-                ].join(' and '),
+                filter,
                 perPage,
                 page,
                 ...policyId && { policyId }


### PR DESCRIPTION
When using the default filter it can happen that `or` and `and` get not evaluated as expected, grouping the filters will fix that.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
