### PR TITLE
feat(CreatePolicy): RHICOMPL-701 filter systems by OS major version 

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -13,7 +13,7 @@ import FinishedCreatePolicy from './FinishedCreatePolicy';
 import { validateFirstPage, validateSecondPage, validateThirdPage } from './validate';
 
 export const CreatePolicy = ({
-    benchmark, complianceThreshold, name, profile, refId, selectedRuleRefIds
+    benchmark, osMajorVersion, complianceThreshold, name, profile, refId, selectedRuleRefIds
 }) => {
     const history = useHistory();
     const [stepIdReached, setStepIdReached] = useState(1);
@@ -30,7 +30,7 @@ export const CreatePolicy = ({
             id: 1,
             name: 'Create SCAP policy',
             component: <CreateSCAPPolicy/>,
-            enableNext: validateFirstPage(benchmark, profile)
+            enableNext: validateFirstPage(benchmark, osMajorVersion, profile)
         },
         {
             id: 2,
@@ -84,6 +84,7 @@ export const CreatePolicy = ({
 
 CreatePolicy.propTypes = {
     benchmark: propTypes.string,
+    osMajorVersion: propTypes.string,
     complianceThreshold: propTypes.string,
     businessObjective: propTypes.object,
     dispatch: propTypes.func,
@@ -103,6 +104,7 @@ const selector = formValueSelector('policyForm');
 export default connect(
     state => ({
         benchmark: selector(state, 'benchmark'),
+        osMajorVersion: selector(state, 'osMajorVersion'),
         businessObjective: selector(state, 'businessObjective'),
         complianceThreshold: selector(state, 'complianceThreshold') || 100.0,
         name: selector(state, 'name'),

--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
@@ -72,6 +72,11 @@ const CreateSCAPPolicy = ({ change, selectedBenchmarkId }) => {
         }));
     }
 
+    const setBenchmark = ({ id, osMajorVersion }) => {
+        change('benchmark', id);
+        change('osMajorVersion', osMajorVersion);
+    };
+
     return (
         <React.Fragment>
             <TextContent>
@@ -91,7 +96,7 @@ const CreateSCAPPolicy = ({ change, selectedBenchmarkId }) => {
                     { benchmarks && benchmarks.sort((a, b) => a.refId.localeCompare(b.refId)).map((benchmark) => {
                         const { id, osMajorVersion } = benchmark;
                         return (
-                            <Button key={id} onClick={ () => { change('benchmark', id); } }
+                            <Button key={id} onClick={ () => setBenchmark(benchmark) }
                                 className={`wizard-os-button ${selectedBenchmarkId === id ? 'active-wizard-os-button' : ''}`}
                                 variant="tertiary">
                                 { `RHEL ${osMajorVersion}` }

--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
@@ -26,6 +26,7 @@ query benchmarksAndProfiles {
         title
         refId
         version
+        osMajorVersion
         profiles {
             id
             name
@@ -88,12 +89,12 @@ const CreateSCAPPolicy = ({ change, selectedBenchmarkId }) => {
                     fieldId="benchmark">
                     <br/>
                     { benchmarks && benchmarks.sort((a, b) => a.refId.localeCompare(b.refId)).map((benchmark) => {
-                        const { refId, id } = benchmark;
+                        const { id, osMajorVersion } = benchmark;
                         return (
                             <Button key={id} onClick={ () => { change('benchmark', id); } }
                                 className={`wizard-os-button ${selectedBenchmarkId === id ? 'active-wizard-os-button' : ''}`}
                                 variant="tertiary">
-                                { refId && refId.split('xccdf_org.ssgproject.content_benchmark_')[1].replace('-', ' ') }
+                                { `RHEL ${osMajorVersion}` }
                             </Button>
                         );
                     })}

--- a/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
@@ -76,6 +76,7 @@ export default compose(
                 refId: `${JSON.parse(selector(state, 'profile')).refId}`,
                 description: `${JSON.parse(selector(state, 'profile')).description}`,
                 benchmark: selector(state, 'benchmark'),
+                osMajorVersion: selector(state, 'osMajorVersion'),
                 profile: selector(state, 'profile')
             }
         })

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -1,13 +1,14 @@
 import React, { useEffect } from 'react';
-import { propTypes as reduxFormPropTypes, reduxForm } from 'redux-form';
+import { propTypes as reduxFormPropTypes, reduxForm, formValueSelector } from 'redux-form';
 import { Form, FormGroup, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { InventoryTable, SystemsTable } from 'SmartComponents';
+import { GET_SYSTEMS_WITHOUT_FAILED_RULES } from '../SystemsTable/constants';
 import { compose } from 'redux';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import useFeature from 'Utilities/hooks/useFeature';
 
-const EditPolicySystems = ({ change, selectedSystemIds }) => {
+const EditPolicySystems = ({ change, osMajorVersion, selectedSystemIds }) => {
     const newInventory = useFeature('newInventory');
     const columns = [{
         composed: ['facts.os_release', 'display_name'],
@@ -55,7 +56,8 @@ const EditPolicySystems = ({ change, selectedSystemIds }) => {
                         remediationsEnabled={false}
                         compact
                         showActions={ false }
-                        showAllSystems
+                        query={ GET_SYSTEMS_WITHOUT_FAILED_RULES }
+                        defaultFilter={ osMajorVersion && `os_major_version = ${osMajorVersion}` }
                         enableExport={ false }/>
                 </FormGroup>
             </Form>
@@ -64,6 +66,7 @@ const EditPolicySystems = ({ change, selectedSystemIds }) => {
 };
 
 EditPolicySystems.propTypes = {
+    osMajorVersion: propTypes.string,
     selectedSystemIds: propTypes.array,
     change: reduxFormPropTypes.change
 };
@@ -72,8 +75,10 @@ EditPolicySystems.defaultProps = {
     selectedSystemIds: []
 };
 
-const mapStateToProps = ({ entities }) => ({
-    selectedSystemIds: (entities?.selectedEntities || []).map((e) => (e.id))
+const selector = formValueSelector('policyForm');
+const mapStateToProps = (state) => ({
+    osMajorVersion: selector(state, 'osMajorVersion'),
+    selectedSystemIds: (state.entities?.selectedEntities || []).map((e) => (e.id))
 });
 
 export default compose(

--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
@@ -24,6 +24,7 @@ query review($benchmarkId: String!) {
         id
         title
         refId
+        osMajorVersion
         version
     }
 }
@@ -51,7 +52,7 @@ const ReviewCreatedPolicy = ({
             <TextList component={TextListVariants.dl}>
                 <TextListItem component={TextListItemVariants.dt}>Operating system</TextListItem>
                 <TextListItem component={TextListItemVariants.dd}>
-                    { benchmark.refId.split('xccdf_org.ssgproject.content_benchmark_')[1].replace('-', ' ') }
+                    { `RHEL ${benchmark.osMajorVersion}` }
                 </TextListItem>
                 <TextListItem component={TextListItemVariants.dt}>Security guide</TextListItem>
                 <TextListItem component={TextListItemVariants.dd}>

--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.test.js
@@ -20,6 +20,7 @@ describe('ReviewCreatedPolicy', () => {
             benchmark: {
                 title: 'SCAP security guide for RHEL7',
                 refId: 'xccdf_org.ssgproject.content_benchmark_RHEL-7',
+                osMajorVersion: '7',
                 version: '0.1.40'  }
         }, error: false, loading: false }));
         component = mount(

--- a/src/SmartComponents/CreatePolicy/validate.js
+++ b/src/SmartComponents/CreatePolicy/validate.js
@@ -1,8 +1,8 @@
-export const validateFirstPage = (benchmark, profile) => {
-    if (!benchmark || !profile) {
-        return false;
-    } else {
+export const validateFirstPage = (benchmark, osMajorVersion, profile) => {
+    if (benchmark && osMajorVersion && profile) {
         return true;
+    } else {
+        return false;
     }
 };
 

--- a/src/SmartComponents/CreatePolicy/validate.test.js
+++ b/src/SmartComponents/CreatePolicy/validate.test.js
@@ -9,7 +9,7 @@ describe('validations', () => {
     });
 
     it('expect to validate the first page if benchmark and profile are set', () => {
-        expect(validateFirstPage('a', 'b')).toBe(true);
+        expect(validateFirstPage('a', 'b', 'c')).toBe(true);
     });
 
     it('expect not to validate the first page if one of benchmark and profile are not set', () => {

--- a/src/__fixtures__/benchmarks_rules.js
+++ b/src/__fixtures__/benchmarks_rules.js
@@ -4,6 +4,7 @@ export const policyFormValues = {
     benchmark: 'a5e7f1ea-e63c-40be-a17a-c2a247c11e10',
     description: 'This profile demonstrates compliance against the U.S. Government Commercial Cloud Services (C2S)',
     name: 'C2S for Red Hat Enterprise Linux 6',
+    osMajorVersion: '6',
     profile: JSON.stringify({
         complianceThreshold: 100,
         description: 'This profile demonstrates compliance against the U.S. Government Commercial Cloud Services (C2S)',
@@ -21,6 +22,7 @@ export const benchmarksQuery = [
         id: 'f1dff140-6649-4060-b0f6-7b1548f9e901',
         title: 'Guide to the Secure Configuration of Red Hat Enterprise Linux 7',
         refId: 'xccdf_org.ssgproject.content_benchmark_RHEL-7',
+        osMajorVersion: '7',
         version: '0.1.40',
         profiles: [
             {
@@ -110,6 +112,7 @@ export const benchmarksQuery = [
         id: 'bdcc6b37-1d4a-489a-a38d-e9be7aef7051',
         title: 'Guide to the Secure Configuration of Red Hat Enterprise Linux 7',
         refId: 'xccdf_org.ssgproject.content_benchmark_RHEL-7',
+        osMajorVersion: '7',
         version: '0.1.43',
         profiles: [
             {
@@ -207,6 +210,7 @@ export const benchmarksQuery = [
         id: 'a5e7f1ea-e63c-40be-a17a-c2a247c11e10',
         title: 'Guide to the Secure Configuration of Red Hat Enterprise Linux 6',
         refId: 'xccdf_org.ssgproject.content_benchmark_RHEL-6',
+        osMajorVersion: '6',
         version: '0.1.28',
         profiles: [
             {
@@ -304,6 +308,7 @@ export const benchmarksQuery = [
         id: '6a02b217-c9e9-4a4d-93a9-c77b5ea7967a',
         title: 'Guide to the Secure Configuration of Red Hat Enterprise Linux 8',
         refId: 'xccdf_org.ssgproject.content_benchmark_RHEL-8',
+        osMajorVersion: '8',
         version: '0.1.42',
         profiles: [
             {


### PR DESCRIPTION
Uses new `osMajorVersion` state in the wizard form to keep track of the OS major version for Systems to be filtered on. The `InventoryTable` gets passed the query to trigger the use of the filter. This would be refactored to `getEntities` later.

Requires backend: https://github.com/RedHatInsights/compliance-backend/pull/742

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [x] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
