### PR TITLE
fix(InventoryTable): RHICOMPL-1442 redux states

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/display-name */
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 import PageHeader, { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
@@ -30,6 +31,7 @@ const DEFAULT_FILTER = 'has_test_results = true or has_policy = true';
 export const ComplianceSystems = () => {
     const newInventory = useFeature('newInventory');
     const { data, error, loading } = useQuery(QUERY);
+    const dispatch = useDispatch();
     const columns = [{
         key: 'facts.compliance.display_name',
         title: 'Name',
@@ -68,6 +70,8 @@ export const ComplianceSystems = () => {
         }
     }];
     const policies = data?.profiles?.edges.map(({ node }) => node);
+
+    useLayoutEffect(() => { dispatch({ type: 'SELECT_ENTITIES', payload: { ids: [] } }); }, []);
 
     const InvComponent = newInventory ? InventoryTable : SystemsTable;
 

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.test.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.test.js
@@ -1,5 +1,10 @@
 import { ComplianceSystems } from './ComplianceSystems.js';
 
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useDispatch: jest.fn(() => ({}))
+}));
+
 jest.mock('@apollo/react-hooks', () => ({
     useQuery: () => (
         { data: [], error: undefined, loading: undefined }

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -98,11 +98,9 @@ export const EditPolicy = ({ route }) => {
                         compact
                         showActions={ false }
                         enableExport={ false }
-                        showAllSystems
                         remediationsEnabled={ false }
                         policyId={ policy.id }
                         query={GET_SYSTEMS_WITHOUT_FAILED_RULES}
-                        defaultFilter={`policy_id = ${policy.id}`}
                         columns={[{
                             key: 'facts.compliance.display_name',
                             title: 'Name',

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -102,7 +102,6 @@ exports[`EditPolicy expect to render with active tab open 1`] = `
             ]
           }
           compact={true}
-          defaultFilter="policy_id = POLICY_ID"
           enableExport={false}
           policyId="POLICY_ID"
           preselectedSystems={Array []}
@@ -553,7 +552,6 @@ exports[`EditPolicy expect to render with active tab open 1`] = `
           }
           remediationsEnabled={false}
           showActions={false}
-          showAllSystems={true}
         />
       </Tab>
     </RoutedTabs>
@@ -663,7 +661,6 @@ exports[`EditPolicy expect to render without error 1`] = `
             ]
           }
           compact={true}
-          defaultFilter="policy_id = POLICY_ID"
           enableExport={false}
           policyId="POLICY_ID"
           preselectedSystems={Array []}
@@ -1114,7 +1111,6 @@ exports[`EditPolicy expect to render without error 1`] = `
           }
           remediationsEnabled={false}
           showActions={false}
-          showAllSystems={true}
         />
       </Tab>
     </RoutedTabs>

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -1,4 +1,5 @@
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect, useLayoutEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import propTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { useParams, useLocation } from 'react-router-dom';
@@ -118,6 +119,7 @@ export const PolicyDetails = ({ route }) => {
     const { policy_id: policyId } = useParams();
     const location = useLocation();
     const anchor = useAnchor();
+    const dispatch = useDispatch();
     let { data, error, loading, refetch } = useQuery((multiversionTabs ? MULTIVERSION_QUERY : QUERY), {
         variables: { policyId }
     });
@@ -132,6 +134,8 @@ export const PolicyDetails = ({ route }) => {
     useEffect(() => {
         refetch();
     }, [location, refetch]);
+
+    useLayoutEffect(() => { dispatch({ type: 'SELECT_ENTITIES', payload: { ids: [] } }); }, []);
 
     useTitleEntity(route, policy?.name);
 

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.test.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.test.js
@@ -39,6 +39,11 @@ const mocks = [
     }
 ];
 
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useDispatch: jest.fn(() => ({}))
+}));
+
 jest.mock('@apollo/react-hooks', () => ({
     useQuery: () => (
         { data: mocks[0].result.data, error: undefined, loading: undefined }

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/display-name */
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 import black300 from '@patternfly/react-tokens/dist/esm/global_palette_black_300';
 import blue200 from '@patternfly/react-tokens/dist/esm/chart_color_blue_200';
@@ -70,6 +71,7 @@ export const ReportDetails = ({ route }) => {
     const { data, error, loading } = useQuery(QUERY, {
         variables: { policyId }
     });
+    const dispatch = useDispatch();
     let donutValues = [];
     let donutId = 'loading-donut';
     let chartColorScale;
@@ -160,6 +162,8 @@ export const ReportDetails = ({ route }) => {
                 : lastScanned
         }
     }];
+
+    useLayoutEffect(() => { dispatch({ type: 'SELECT_ENTITIES', payload: { ids: [] } }); }, []);
 
     const InvCmp = newInventory ? InventoryTable : SystemsTable;
     useTitleEntity(route, policyName);

--- a/src/SmartComponents/ReportDetails/ReportDetails.test.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.test.js
@@ -12,6 +12,11 @@ jest.mock('Utilities/hooks/useDocumentTitle', () => ({
     setTitle: () => ({})
 }));
 
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useDispatch: jest.fn(() => ({}))
+}));
+
 const mocks = [
     {
         request: {

--- a/src/SmartComponents/SystemsTable/InventoryTable.js
+++ b/src/SmartComponents/SystemsTable/InventoryTable.js
@@ -72,6 +72,7 @@ const InventoryTable = ({
         ].join(' and ');
         const filter = defaultFilter ? `(${ defaultFilter }) and (${ combindedFilter })` : combindedFilter;
 
+        dispatch({ type: 'GET_SYSTEMS_PENDING' });
         return client.query({
             query,
             fetchResults: true,
@@ -84,7 +85,7 @@ const InventoryTable = ({
             }
         }).then(({ data, loading }) => {
             dispatch({
-                type: 'UPDATE_SYSTEMS',
+                type: 'GET_SYSTEMS_FULFILLED',
                 systems: data.systems.edges,
                 systemsCount: data.systems.totalCount
             });


### PR DESCRIPTION
This change ensures the redux state stays set as intended. This includes
the rendered columns and rows as well as whether the table is loaded or
not.

It is **very important** to realize that the redux actions in our
SystemStore have (basically) no guarantee of any execution order. One
exception is the *_PENDING and *_FULFILLED actions, which always happen in
that order but still may have other actions happen in between.

This adds a GET_SYSTEMS_PENDING action to allow compliance to reset
columns and rows in addition to system information when our API
request begins. This is necessary to ensure old state is not persisted
into a new table, such as when viewing policy systems and then
immediately editing policy systems without refreshing.

Additionally, there was a bug in EditPolicy, which filtered the system list by
policy ID, even though we want to show all systems there.

Hopefully, this will be a good stop-gap measure until the proper InventoryTable
with getEntities is working. Please test filtering, selection, export, etc. and report
any and all weird behavior you see. Note: export seems to only work from
the systems page on master and in this PR.

Also fixes RHICOMPL-1445 in the second commit.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices