### PR TITLE
fix(supported popover): RHICOMPL-1461 update docs link

### DIFF
--- a/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.js
+++ b/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.js
@@ -2,6 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { Popover, Tooltip, Text } from '@patternfly/react-core';
 import { ExclamationTriangleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { supportedConfigsLink } from '@redhat-cloud-services/frontend-components-inventory-compliance';
 
 const UNSUPPORTED_SINGULAR_MESSAGE =
     'This system was using an incompatible version of the SSG at the time this report was generated. ' +
@@ -19,9 +20,6 @@ const UNSUPPORTED_PLURAL_MESSAGE = <React.Fragment>
 const WarningWithPopover = ({ children, variant = 'plural' }) => {
     const headerContent = 'Unsupported SSG versions';
     const bodyContent = variant === 'plural' ? UNSUPPORTED_PLURAL_MESSAGE : UNSUPPORTED_SINGULAR_MESSAGE;
-    const supportedConfigsLink = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/' +
-        'html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/' +
-        'compl-assess-overview-con#compl-assess-supported-configurations-con';
     const footerContent = <a target='_blank' rel='noopener noreferrer' href={ supportedConfigsLink }>Supported SSG versions</a>;
 
     return <Popover id='unsupported-popover' maxWidth='25rem'


### PR DESCRIPTION
It seems the url for this page changed slightly without us being notified. The link is defined in frontend components also, so I've opted to export it there. This PR required https://github.com/RedHatInsights/frontend-components/pull/992.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices