### PR TITLE
fix(PolicySystems): RHICOMPL-1519 changed ssg version field key

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -30,7 +30,7 @@ const PolicySystemsTab = ({ policy, systemTableProps }) => {
                     renderFunc: (name, id) => <Link to={{ pathname: `/systems/${id}` }}> {name} </Link>
                 }
             }, ...showSsgVersions ? [{
-                key: 'facts.compliance',
+                key: 'ssgVersion',
                 title: 'SSG version',
                 renderFunc: (profile, ...rest) => {
                     let realProfile = profile;

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
@@ -14,7 +14,7 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
         "title": "Name",
       },
       Object {
-        "key": "facts.compliance",
+        "key": "ssgVersion",
         "renderFunc": [Function],
         "title": "SSG version",
       },


### PR DESCRIPTION
The export feature in the systems tab under a specific policy crashes on a wrong field key for the SSG version field. I'm not sure if I'm doing the fix correctly and/or how should I test this, except of verifying it in the UI.

This is a typical case of the meme which I was not able to find as a picture:
*- Why ˙!=˙*
*- Because ˙==˙ crashed*

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
