### PR TITLE
feat(CreatePolicy): RHICOMPL-1521 gather selected OS minor versions

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -85,6 +85,10 @@ export const CreatePolicy = ({
 CreatePolicy.propTypes = {
     benchmark: propTypes.string,
     osMajorVersion: propTypes.string,
+    osMinorVersionCounts: propTypes.arrayOf(propTypes.shape({
+        osMinorVersion: propTypes.number,
+        count: propTypes.number
+    })),
     complianceThreshold: propTypes.string,
     businessObjective: propTypes.object,
     dispatch: propTypes.func,
@@ -105,6 +109,7 @@ export default connect(
     state => ({
         benchmark: selector(state, 'benchmark'),
         osMajorVersion: selector(state, 'osMajorVersion'),
+        osMinorVersionCounts: selector(state, 'osMinorVersionCounts'),
         businessObjective: selector(state, 'businessObjective'),
         complianceThreshold: selector(state, 'complianceThreshold') || 100.0,
         name: selector(state, 'name'),

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -7,9 +7,9 @@ import { compose } from 'redux';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import useFeature from 'Utilities/hooks/useFeature';
-import { systemName } from 'Store/Reducers/SystemStore';
+import { systemName, countOsMinorVersions } from 'Store/Reducers/SystemStore';
 
-const EditPolicySystems = ({ change, osMajorVersion, selectedSystemIds }) => {
+const EditPolicySystems = ({ change, osMajorVersion, osMinorVersionCounts, selectedSystemIds }) => {
     const newInventory = useFeature('newInventory');
     const columns = [{
         key: 'facts.compliance.display_name',
@@ -36,7 +36,11 @@ const EditPolicySystems = ({ change, osMajorVersion, selectedSystemIds }) => {
         if (selectedSystemIds) {
             change('systems', selectedSystemIds);
         }
-    }, [selectedSystemIds, change]);
+
+        if (osMinorVersionCounts) {
+            change('osMinorVersionCounts', osMinorVersionCounts);
+        }
+    }, [selectedSystemIds, osMinorVersionCounts, change]);
 
     const InvCmp = newInventory ? InventoryTable : SystemsTable;
 
@@ -70,17 +74,23 @@ const EditPolicySystems = ({ change, osMajorVersion, selectedSystemIds }) => {
 
 EditPolicySystems.propTypes = {
     osMajorVersion: propTypes.string,
+    osMinorVersionCounts: propTypes.arrayOf(propTypes.shape({
+        osMinorVersion: propTypes.number,
+        count: propTypes.number
+    })),
     selectedSystemIds: propTypes.array,
     change: reduxFormPropTypes.change
 };
 
 EditPolicySystems.defaultProps = {
-    selectedSystemIds: []
+    selectedSystemIds: [],
+    osMinorVersionCounts: []
 };
 
 const selector = formValueSelector('policyForm');
 const mapStateToProps = (state) => ({
     osMajorVersion: selector(state, 'osMajorVersion'),
+    osMinorVersionCounts: countOsMinorVersions(state.entities?.selectedEntities),
     selectedSystemIds: (state.entities?.selectedEntities || []).map((e) => (e.id))
 });
 

--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -1,1 +1,15 @@
 export const uniq = (collection) => [...new Set(collection)];
+
+export const sortingByProp = (propName, order = 'asc') => (
+    (objA, objB) => {
+        const propA = (objA && objA[propName]) || '';
+        const propB = (objB && objB[propName]) || '';
+        if (propA === propB) {
+            return 0;
+        } else if (order === 'asc') {
+            return propA < propB ? -1 : 1;
+        } else {
+            return propA < propB ? 1 : -1;
+        }
+    }
+);

--- a/src/Utilities/helpers.test.js
+++ b/src/Utilities/helpers.test.js
@@ -1,0 +1,79 @@
+import { uniq, sortingByProp } from './helpers';
+
+describe('uniq', () => {
+    it('should deduplicate items', () => {
+        let result = uniq(['a', 'b', 'b', 'c']);
+        expect(result.sort()).toEqual(['a', 'b', 'c']);
+    });
+});
+
+describe('sortingByProp', () => {
+    it('should sort string properties', () => {
+        const input = [
+            { prop: 'c' },
+            { prop: 'd' },
+            { prop: 'a' }
+        ];
+        expect(input.sort(sortingByProp('prop'))).toEqual([
+            { prop: 'a' },
+            { prop: 'c' },
+            { prop: 'd' }
+        ]);
+    });
+
+    it('should sort string properties descending', () => {
+        const input = [
+            { prop: 'c' },
+            { prop: 'd' },
+            { prop: 'a' }
+        ];
+        expect(input.sort(sortingByProp('prop', 'desc'))).toEqual([
+            { prop: 'd' },
+            { prop: 'c' },
+            { prop: 'a' }
+        ]);
+    });
+
+    it('should sort nubmer poperties', () => {
+        const input = [
+            { prop: 10 },
+            { prop: 1 },
+            { prop: 0 }
+        ];
+        expect(input.sort(sortingByProp('prop'))).toEqual([
+            { prop: 0 },
+            { prop: 1 },
+            { prop: 10 }
+        ]);
+    });
+
+    it('should sort with a missing poperty', () => {
+        const input = [
+            { prop: 'c' },
+            { otherProp: 'z' },
+            { prop: 'd' },
+            { prop: 'a' }
+        ];
+        expect(input.sort(sortingByProp('prop'))).toEqual([
+            { otherProp: 'z' },
+            { prop: 'a' },
+            { prop: 'c' },
+            { prop: 'd' }
+        ]);
+    });
+
+    it('should sort with a null item', () => {
+        const input = [
+            { prop: 'c' },
+            null,
+            { prop: 'd' },
+            { prop: 'a' }
+        ];
+        expect(input.sort(sortingByProp('prop'))).toEqual([
+            null,
+            { prop: 'a' },
+            { prop: 'c' },
+            { prop: 'd' }
+        ]);
+    });
+});

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -19,6 +19,7 @@ import {
     profilesRulesFailed
 } from 'Utilities/ruleHelpers';
 import Truncate from 'react-truncate';
+import { sortingByProp } from 'Utilities/helpers';
 
 const NEVER = 'Never';
 
@@ -115,6 +116,19 @@ const isSelected = (id, selectedEntities) => (
 const profilesSsgVersions = ({ testResultProfiles: profiles = [] }) => (
     profiles.map((p) => (p.ssgVersion)).filter((version) => (!!version)).join(', ')
 );
+
+export const countOsMinorVersions = (systems) => {
+    if (!systems) { return []; }
+
+    const counted = systems.reduce((acc, { osMinorVersion }) => {
+        if (osMinorVersion !== undefined && osMinorVersion !== null) {
+            (acc[osMinorVersion] = acc[osMinorVersion] || { osMinorVersion, count: 0 }).count++;
+        }
+
+        return acc;
+    }, {});
+    return Object.values(counted).sort(sortingByProp('osMinorVersion'));
+};
 
 export const systemsToInventoryEntities = (systems, entities, showAllSystems, selectedEntities) => (
     entities.map(entity => {

--- a/src/store/Reducers/SystemStore.test.js
+++ b/src/store/Reducers/SystemStore.test.js
@@ -3,6 +3,7 @@ import {
     hasOsInfo,
     lastScanned,
     policyNames,
+    countOsMinorVersions,
     systemsToInventoryEntities
 } from './SystemStore';
 import { systems, entities } from '@/__fixtures__/systems.js';
@@ -144,5 +145,24 @@ describe('hasOsInfo', () => {
             osMinorVersion: null
         });
         expect(result).toEqual(false);
+    });
+});
+
+describe('countOsMinorVersions', () => {
+    it('gathers unique OS minor versions sorted', () => {
+        const systems = [
+            { osMinorVersion: 10 },
+            { osMinorVersion: 1 },
+            { osMinorVersion: 9 },
+            { osMinorVersion: 9 },
+            { osMinorVersion: 0 },
+            {}
+        ];
+        expect(countOsMinorVersions(systems)).toEqual([
+            { osMinorVersion: 0, count: 1 },
+            { osMinorVersion: 1, count: 1 },
+            { osMinorVersion: 9, count: 2 },
+            { osMinorVersion: 10, count: 1 }
+        ]);
     });
 });


### PR DESCRIPTION
Gathers OS minor versions of selected systems within the PolicyCreate wizard using `countOsMinorVersions` reducer. The result is sorted naturally.

Adds a PoC within the Rules step in the wizard to see the result (requires `?multiversionTabs=enable`). This PoC would likely be fully replaced/reverted with implementation of the tabs for each OS version. One step at a time...

PoC ("Tailoring for ...")
![Screenshot_2021-03-16 SCAP policies - Compliance Red Hat Insights](https://user-images.githubusercontent.com/7695766/111299220-fa037100-864f-11eb-9578-642076d53ee5.png)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
