### PR TITLE
feat(CreatePolicy): RHICOMPL-1546 display OS version for systems

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -19,16 +19,17 @@ const EditPolicySystems = ({ change, osMajorVersion, osMinorVersionCounts, selec
         },
         ...newInventory && {
             key: 'display_name',
-            renderFunc: systemName
+            renderFunc: (displayName, id, { name }) => systemName(displayName, id, { name })
         }
     }, {
-        key: 'facts.compliance.policies',
-        title: 'Policies',
+        key: 'facts.compliance.osMinorVersion',
+        title: 'Operating system',
         props: {
             width: 40, isStatic: true
         },
         ...newInventory && {
-            key: 'policies'
+            key: 'osMinorVersion',
+            renderFunc: (osMinorVersion, _id, { osMajorVersion }) => `RHEL ${osMajorVersion}.${osMinorVersion}`
         }
     }];
 

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -25,6 +25,33 @@ export const EditPolicy = ({ route }) => {
     const selectedEntities = useSelector((state) => (state?.entities?.selectedEntities));
     const saveEnabled = updatedPolicy && !updatedPolicy.complianceThresholdValid;
 
+    const columns = [
+        {
+            key: 'facts.compliance.display_name',
+            title: 'Name',
+            props: {
+                width: 40, isStatic: true
+            },
+            ...newInventory && {
+                key: 'display_name',
+                renderFunc: (displayName, id, extra) => {
+                    return extra?.lastScanned ? systemName(displayName, id, { name: extra?.name }) : displayName;
+                }
+            }
+        },
+        {
+            key: 'facts.compliance.osMinorVersion',
+            title: 'Operating system',
+            props: {
+                width: 40, isStatic: true
+            },
+            ...newInventory && {
+                key: 'osMinorVersion',
+                renderFunc: (osMinorVersion, _id, { osMajorVersion }) => `RHEL ${osMajorVersion}.${osMinorVersion}`
+            }
+        }
+    ];
+
     const linkToBackgroundWithHash = () => {
         newInventory && dispatch({
             type: 'SELECT_ENTITIES',
@@ -102,19 +129,7 @@ export const EditPolicy = ({ route }) => {
                         policyId={ policy.id }
                         defaultFilter={ `os_major_version = ${policy.majorOsVersion}` }
                         query={GET_SYSTEMS_WITHOUT_FAILED_RULES}
-                        columns={[{
-                            key: 'facts.compliance.display_name',
-                            title: 'Name',
-                            props: {
-                                width: 40, isStatic: true
-                            },
-                            ...newInventory && {
-                                key: 'display_name',
-                                renderFunc: (displayName, id, extra) => {
-                                    return extra?.lastScanned ? systemName(displayName, id, extra) : displayName;
-                                }
-                            }
-                        }]}
+                        columns={columns}
                         preselectedSystems={ policy?.hosts.map((h) => ({ id: h.id })) || [] } />
                 </Tab>
             </RoutedTabs>

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -100,6 +100,15 @@ exports[`EditPolicy expect to render with active tab open 1`] = `
                 "renderFunc": [Function],
                 "title": "Name",
               },
+              Object {
+                "key": "osMinorVersion",
+                "props": Object {
+                  "isStatic": true,
+                  "width": 40,
+                },
+                "renderFunc": [Function],
+                "title": "Operating system",
+              },
             ]
           }
           compact={true}
@@ -660,6 +669,15 @@ exports[`EditPolicy expect to render without error 1`] = `
                 },
                 "renderFunc": [Function],
                 "title": "Name",
+              },
+              Object {
+                "key": "osMinorVersion",
+                "props": Object {
+                  "isStatic": true,
+                  "width": 40,
+                },
+                "renderFunc": [Function],
+                "title": "Operating system",
               },
             ]
           }


### PR DESCRIPTION
The Policies column has been replaced with the OS version which has been extracted from beneath the display name.

Just for the sake of consistency, should this column also be displayed for the non-wizard when editing a policy?

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
