### PR TITLE
feat(CreatePolicy): RHICOMPL-1549 Use remediationAvailableFilter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,9 +2239,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-inventory-compliance": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-compliance/-/frontend-components-inventory-compliance-3.1.3.tgz",
-      "integrity": "sha512-/lh6OuqHMK1yTlzX+I5EfpyzcIpcJhXkGuamBHCx9J1pzsmrVpRHC0CGR/ErJtYGybpuPGWuBU3sBjY7BkNN/g==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-compliance/-/frontend-components-inventory-compliance-3.1.4.tgz",
+      "integrity": "sha512-Fy94LL6SIUdCYIRqSJ6Cz+wzPrgFxwBO08QH33Z18jW6zIWXm29FRj8RkK9/nQW5lEbvTnID5HESkY1qN/l23Q==",
       "requires": {
         "@apollo/react-hooks": "^3.1.5",
         "@redhat-cloud-services/frontend-components": ">=3.0.0",
@@ -2291,14 +2291,15 @@
       }
     },
     "@redhat-cloud-services/frontend-components-remediations": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-3.1.2.tgz",
-      "integrity": "sha512-SfkR2TNa2XS8dmt96iczuoldn+rAb32qT26N0jZ3XfIcL9UKSvsevXuVuCWl93XSSQfj3ml2fK4FCmawo/hkVQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-3.1.3.tgz",
+      "integrity": "sha512-aZ9H6vuO9P2eafhF/qjjSgvlsiF5eDJX/0Kv+d1khL/6+p8/EfgtyXwAH2LomLNcWg8Atv4O8pLPb2pjQoYloA==",
       "requires": {
         "@data-driven-forms/pf4-component-mapper": "^2.23.3",
         "@data-driven-forms/react-form-renderer": "^2.23.3",
         "@redhat-cloud-services/frontend-components": ">=3.0.0",
         "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
+        "redux-promise-middleware": "^6.1.2",
         "urijs": "^1.19.4"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@patternfly/react-table": "^4.23.14",
     "@patternfly/react-tokens": "^4.10.5",
     "@redhat-cloud-services/frontend-components": "3.0.10",
-    "@redhat-cloud-services/frontend-components-inventory-compliance": "^3.1.3",
+    "@redhat-cloud-services/frontend-components-inventory-compliance": "^3.1.4",
     "@redhat-cloud-services/frontend-components-notifications": "^3.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^3.0.3",
     "@redhat-cloud-services/host-inventory-client": "^1.0.89",

--- a/src/PresentationalComponents/TabbedRules/__snapshots__/TabbedRules.test.js.snap
+++ b/src/PresentationalComponents/TabbedRules/__snapshots__/TabbedRules.test.js.snap
@@ -104,6 +104,7 @@ exports[`TabbedRules passes handleSelect 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}
@@ -209,6 +210,7 @@ exports[`TabbedRules passes handleSelect 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}
@@ -314,6 +316,7 @@ exports[`TabbedRules passes handleSelect 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}
@@ -426,6 +429,7 @@ exports[`TabbedRules renders tabs with default 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}
@@ -530,6 +534,7 @@ exports[`TabbedRules renders tabs with default 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}
@@ -634,6 +639,7 @@ exports[`TabbedRules renders tabs with default 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}
@@ -746,6 +752,7 @@ exports[`TabbedRules renders tabs with second item as default 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}
@@ -850,6 +857,7 @@ exports[`TabbedRules renders tabs with second item as default 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}
@@ -954,6 +962,7 @@ exports[`TabbedRules renders tabs with second item as default 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={false}
       remediationsEnabled={false}
       selectedFilter={false}
       selectedRefIds={Array []}

--- a/src/SmartComponents/CreatePolicy/EditPolicyRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyRules.js
@@ -104,6 +104,7 @@ export const EditPolicyRules = ({ profileId, benchmarkId, osMajorVersion, osMino
                 remediationsEnabled={ false }
                 tailoringEnabled
                 selectedFilter
+                remediationAvailableFilter
                 columns={ columns }
                 loading={ loading }
                 handleSelect={ (selectedRuleRefIds) => change('selectedRuleRefIds', selectedRuleRefIds) }

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyRules.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyRules.test.js.snap
@@ -83,6 +83,7 @@ exports[`EditPolicyRules expect to render with error on error 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={true}
       remediationsEnabled={false}
       selectedFilter={true}
       selectedRefIds={Array []}
@@ -202,6 +203,7 @@ exports[`EditPolicyRules expect to render without error 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={true}
       remediationsEnabled={false}
       selectedFilter={true}
       selectedRefIds={Array []}
@@ -328,6 +330,7 @@ exports[`EditPolicyRules expect to render without error 2`] = `
           },
         ]
       }
+      remediationAvailableFilter={true}
       remediationsEnabled={false}
       selectedFilter={true}
       selectedRefIds={
@@ -425,6 +428,7 @@ exports[`EditPolicyRules expect to render without error on loading 1`] = `
           },
         ]
       }
+      remediationAvailableFilter={true}
       remediationsEnabled={false}
       selectedFilter={true}
       selectedRefIds={Array []}


### PR DESCRIPTION
Use the remediationAvailableFilter in the rules table within the policy
wizard. We may use this filter elsewhere in the future, anywhere that we
display remediation availability, but for now, this only adds the filter
to the wizard's rules table.

Requires https://github.com/RedHatInsights/frontend-components/pull/1039

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices