### PR TITLE
feat(CreatePolicy): RHICOMPL-1547 implemented empty state for systems

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { propTypes as reduxFormPropTypes, reduxForm, formValueSelector } from 'redux-form';
-import { Form, FormGroup, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { Button, Form, FormGroup, Text, TextContent, TextVariants, WizardContextConsumer } from '@patternfly/react-core';
 import { InventoryTable, SystemsTable } from 'SmartComponents';
 import { GET_SYSTEMS_WITHOUT_FAILED_RULES } from '../SystemsTable/constants';
 import { compose } from 'redux';
@@ -11,6 +11,8 @@ import { systemName, countOsMinorVersions } from 'Store/Reducers/SystemStore';
 
 const EditPolicySystems = ({ change, osMajorVersion, osMinorVersionCounts, selectedSystemIds }) => {
     const newInventory = useFeature('newInventory');
+    const multiversionRules = useFeature('multiversionTabs');
+
     const columns = [{
         key: 'facts.compliance.display_name',
         title: 'Name',
@@ -43,6 +45,33 @@ const EditPolicySystems = ({ change, osMajorVersion, osMinorVersionCounts, selec
         }
     }, [selectedSystemIds, osMinorVersionCounts, change]);
 
+    const emptyStateComponent = (<React.Fragment>
+        <TextContent className="pf-u-mb-md">
+            <Text>
+                You do not have any <b>RHEL { osMajorVersion }</b> systems connected to Insights and enabled for Compliance.<br/>
+                Policies must be created with at least one system.
+            </Text>
+        </TextContent>
+        <TextContent className="pf-u-mb-md">
+            <Text>
+                Choose a different operating system, or connect RHEL { osMajorVersion } systems to Insights.
+            </Text>
+        </TextContent>
+        <WizardContextConsumer>
+            { ({ goToStepById }) => <Button onClick={() => goToStepById(1)}>Choose a different operating system</Button> }
+        </WizardContextConsumer>
+    </React.Fragment>);
+
+    const prependComponent = (<React.Fragment>
+        <TextContent className="pf-u-mb-md">
+            <Text>
+                Select which of your <b>RHEL { osMajorVersion }</b> systems should be included
+                in this policy.<br />
+                Systems can be added or removed at any time.
+            </Text>
+        </TextContent>
+    </React.Fragment>);
+
     const InvCmp = newInventory ? InventoryTable : SystemsTable;
 
     return (
@@ -51,15 +80,12 @@ const EditPolicySystems = ({ change, osMajorVersion, osMinorVersionCounts, selec
                 <Text component={TextVariants.h1}>
                     Systems
                 </Text>
-                <Text>
-                    Select which of your <b>RHEL { osMajorVersion }</b> systems should be included
-                    in this policy.<br />
-                    Systems can be added or removed at any time.
-                </Text>
             </TextContent>
             <Form>
                 <FormGroup>
                     <InvCmp
+                        prependComponent={prependComponent}
+                        emptyStateComponent={multiversionRules ? emptyStateComponent : undefined}
                         columns={columns}
                         remediationsEnabled={false}
                         compact

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
@@ -11,19 +11,6 @@ Array [
     >
       Systems
     </h1>
-    <p
-      className=""
-      data-pf-content={true}
-    >
-      Select which of your 
-      <b>
-        RHEL 
-        6
-      </b>
-       systems should be included in this policy.
-      <br />
-      Systems can be added or removed at any time.
-    </p>
   </div>,
   <form
     className="pf-c-form"

--- a/src/SmartComponents/SystemsTable/InventoryTable.test.js
+++ b/src/SmartComponents/SystemsTable/InventoryTable.test.js
@@ -1,0 +1,75 @@
+import { init } from 'Store';
+import logger from 'redux-logger';
+import { useSelector } from 'react-redux';
+
+import { InventoryTable } from './InventoryTable';
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn(),
+    useStore: jest.fn(),
+    useDispatch: jest.fn()
+}));
+
+const items = {
+    data: {
+        systems: {
+            totalCount: 1,
+            edges: [
+                {
+                    node: {
+                        id: 1
+                    }
+                }
+            ]
+        }
+    }
+};
+
+describe('InventoryTable', () => {
+    const store = init(logger).getStore();
+    const client = { query: jest.fn(() => Promise.resolve(items)) };
+    const updateSystemsFunction = jest.fn(jest.fn(() => Promise.resolve(items)));
+    const updateRowsFunction = jest.fn(jest.fn(() => Promise.resolve(items)));
+    const defaultProps = {
+        store,
+        client,
+        updateSystems: updateSystemsFunction,
+        updateRows: updateRowsFunction,
+        clearInventoryFilter: jest.fn(),
+        titleComponent: 'Title Component',
+        emptyStateComponent: 'Empty State Component'
+    };
+    const MockComponent = jest.fn(({ children, loaded }) => {
+        return children && loaded ? children : 'Loading...';
+    });
+
+    beforeEach(() => {
+        global.insights = {
+            loadInventory: jest.fn(() => {
+                return Promise.resolve({
+                    inventoryConnector: () => ({
+                        InventoryTable: MockComponent
+                    }),
+                    INVENTORY_ACTION_TYPES: {},
+                    mergeWithEntities: () => ({})
+                });
+            })
+        };
+
+    });
+
+    it('expect to not render a loading state', () => {
+        const state = {
+            entities: {
+                selectedEntities: []
+            }
+        };
+        useSelector.mockImplementation((callback) => (callback(state)));
+        const wrapper = shallow(
+            <InventoryTable { ...defaultProps } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/SystemsTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/InventoryTable.test.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InventoryTable expect to not render a loading state 1`] = `
+<StateView
+  stateValues={
+    Object {
+      "empty": false,
+      "error": undefined,
+      "noError": true,
+    }
+  }
+>
+  <StateViewPart
+    stateKey="error"
+  >
+    <ErrorPage />
+  </StateViewPart>
+  <StateViewPart
+    stateKey="empty"
+  >
+    Empty State Component
+  </StateViewPart>
+  <StateViewPart
+    stateKey="noError"
+  >
+    <ForwardRef
+      actions={
+        Array [
+          Object {
+            "onClick": [Function],
+            "title": "View in inventory",
+          },
+        ]
+      }
+      activeFiltersConfig={
+        Object {
+          "filters": Array [],
+          "onDelete": [Function],
+        }
+      }
+      bulkSelect={
+        Object {
+          "checked": false,
+          "count": 0,
+          "label": undefined,
+          "onSelect": [Function],
+        }
+      }
+      dedicatedAction={
+        <Memo(Connect(ComplianceRemediationButton))
+          allSystems={Array []}
+          selectedRules={Array []}
+        />
+      }
+      exportConfig={
+        Object {
+          "isDisabled": true,
+          "onSelect": [Function],
+        }
+      }
+      fallback={
+        <SkeletonTable
+          canSelectAll={false}
+          colSize={2}
+          hasRadio={false}
+          isSelectable={false}
+          paddingColumnSize={0}
+          rowSize={15}
+        />
+      }
+      filterConfig={
+        Object {
+          "items": Array [
+            Object {
+              "filterValues": Object {
+                "onChange": [Function],
+                "value": "",
+              },
+              "id": "name",
+              "label": "Name",
+              "placeholder": "Filter by name",
+              "type": "text",
+            },
+          ],
+        }
+      }
+      isLoaded={false}
+      items={Array []}
+      onLoad={[Function]}
+      onRefresh={[Function]}
+      page={1}
+      perPage={50}
+      tableProps={
+        Object {
+          "canSelectAll": false,
+        }
+      }
+      total={0}
+      variant=""
+    />
+  </StateViewPart>
+</StateView>
+`;


### PR DESCRIPTION
Added optional `emptyStateComponent` and `titleComponent` attributes to the `InventoryTable` component that are invoked from the `SystemInventory` in the create policy wizard. The goal is to show an informative message if there are no systems available with the selected OS major version and provide a button to go back two steps to reselect the OS major.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
