### PR TITLE
fix(CreatePolicy): RHICOMPL-484 new name and description on reselect 

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { compose } from 'redux';
-import { Field, reduxForm, formValueSelector } from 'redux-form';
+import { Field, reduxForm, formValueSelector, propTypes as reduxFormPropTypes } from 'redux-form';
 import { connect } from 'react-redux';
 import propTypes from 'prop-types';
 import { Form, FormGroup, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { ReduxFormTextInput, ReduxFormTextArea } from 'PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers';
 import { ProfileThresholdField } from 'PresentationalComponents';
 
-const EditPolicyDetails = ({ policy }) => {
+const EditPolicyDetails = ({ change, policy }) => {
+
+    useEffect(() => {
+        change('name', `${policy.name}`);
+        change('refId', `${policy.refId}`);
+        change('description', `${policy.description}`);
+    }, [policy]);
+
     return (
         <React.Fragment>
             <TextContent>
@@ -64,7 +71,7 @@ const selector = formValueSelector('policyForm');
 
 EditPolicyDetails.propTypes = {
     policy: propTypes.object,
-    dispatch: propTypes.func
+    change: reduxFormPropTypes.change
 };
 
 const mapStateToProps = (state) => {

--- a/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
@@ -7,7 +7,7 @@ import { Form, FormGroup, Text, TextContent, TextVariants } from '@patternfly/re
 import { ReduxFormTextInput, ReduxFormTextArea } from 'PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers';
 import { ProfileThresholdField } from 'PresentationalComponents';
 
-const EditPolicyDetails = ({ profile: policy }) => {
+const EditPolicyDetails = ({ policy }) => {
     return (
         <React.Fragment>
             <TextContent>
@@ -63,24 +63,27 @@ const EditPolicyDetails = ({ profile: policy }) => {
 const selector = formValueSelector('policyForm');
 
 EditPolicyDetails.propTypes = {
-    profile: propTypes.object,
+    policy: propTypes.object,
     dispatch: propTypes.func
 };
 
+const mapStateToProps = (state) => {
+    const policy = JSON.parse(selector(state, 'profile'));
+    return {
+        policy,
+        initialValues: {
+            name: `${policy.name}`,
+            refId: `${policy.refId}`,
+            description: `${policy.description}`,
+            benchmark: selector(state, 'benchmark'),
+            osMajorVersion: selector(state, 'osMajorVersion'),
+            profile: selector(state, 'profile')
+        }
+    };
+};
+
 export default compose(
-    connect(
-        state => ({
-            profile: JSON.parse(selector(state, 'profile')),
-            initialValues: {
-                name: `${JSON.parse(selector(state, 'profile')).name}`,
-                refId: `${JSON.parse(selector(state, 'profile')).refId}`,
-                description: `${JSON.parse(selector(state, 'profile')).description}`,
-                benchmark: selector(state, 'benchmark'),
-                osMajorVersion: selector(state, 'osMajorVersion'),
-                profile: selector(state, 'profile')
-            }
-        })
-    ),
+    connect(mapStateToProps),
     reduxForm({
         form: 'policyForm',
         destroyOnUnmount: false,

--- a/src/SmartComponents/CreatePolicy/EditPolicyDetails.test.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyDetails.test.js
@@ -21,7 +21,7 @@ describe('EditPolicyDetails', () => {
     it('expect to render without error', () => {
         const component = shallow(
             <Provider store={ store }>
-                <EditPolicyDetails profile={JSON.parse(policyFormValues.profile)}/>
+                <EditPolicyDetails policy={JSON.parse(policyFormValues.profile)}/>
             </Provider>
         );
         expect(toJson(component)).toMatchSnapshot();

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyDetails.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicyDetails.test.js.snap
@@ -33,7 +33,7 @@ exports[`EditPolicyDetails expect to render without error 1`] = `
   }
 >
   <EditPolicyDetails
-    profile={
+    policy={
       Object {
         "complianceThreshold": 100,
         "description": "This profile demonstrates compliance against the U.S. Government Commercial Cloud Services (C2S)",


### PR DESCRIPTION
When a user selects a different Policy type and/or RHEL major version,
the name and description of a policy is reset based on the values from
the selected policy type.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
