### PR TITLE
feat: usePolicyUpdate -> usePolicy for create or edit

### DIFF
--- a/src/PresentationalComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/PresentationalComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -110,6 +110,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "4c27fe09-9a7f-437c-b38b-e42272d9ccf0",
                     "majorOsVersion": 7,
                     "name": "Standard System Security Profile for Red Hat Enterprise Linux 7",
@@ -151,6 +157,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "9b034440-e3dd-4c19-8f2c-ca75e813d57d",
                     "majorOsVersion": 7,
                     "name": "DISA STIG for Red Hat Enterprise Linux 7",
@@ -192,6 +204,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "19921ca4-8526-4651-8876-3c8587e8e125",
                     "majorOsVersion": 7,
                     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72",
@@ -408,6 +426,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     "businessObjective": null,
                     "complianceThreshold": 100,
                     "compliantHostCount": 4,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline23",
@@ -530,6 +554,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 67,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
                     "majorOsVersion": 7,
                     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
@@ -618,6 +648,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "dae0487d-3201-4ee0-af5f-b94cde2af818",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline2",
@@ -659,6 +695,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 69.5,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
                     "majorOsVersion": 7,
                     "name": "C2S for Red Hat Enterprise Linux 7",
@@ -700,6 +742,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
                     "majorOsVersion": 7,
                     "name": "Criminal Justice Information Services (CJIS) Security Policy",
@@ -741,6 +789,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
                     "majorOsVersion": 7,
                     "name": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
@@ -782,6 +836,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
                     "majorOsVersion": 7,
                     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -823,6 +883,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
                     "majorOsVersion": 7,
                     "name": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
@@ -864,6 +930,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
                     "majorOsVersion": 7,
                     "name": "Health Insurance Portability and Accountability Act (HIPAA)",
@@ -905,6 +977,12 @@ exports[`PoliciesTable Pagination and search should be able to move to next and 
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline",
@@ -1129,6 +1207,12 @@ exports[`PoliciesTable Pagination and search should show only matching results a
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
                     "majorOsVersion": 7,
                     "name": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
@@ -1345,6 +1429,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     "businessObjective": null,
                     "complianceThreshold": 100,
                     "compliantHostCount": 4,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline23",
@@ -1470,6 +1560,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 67,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
                     "majorOsVersion": 7,
                     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
@@ -1561,6 +1657,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "dae0487d-3201-4ee0-af5f-b94cde2af818",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline2",
@@ -1605,6 +1707,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 69.5,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
                     "majorOsVersion": 7,
                     "name": "C2S for Red Hat Enterprise Linux 7",
@@ -1649,6 +1757,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
                     "majorOsVersion": 7,
                     "name": "Criminal Justice Information Services (CJIS) Security Policy",
@@ -1693,6 +1807,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
                     "majorOsVersion": 7,
                     "name": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
@@ -1737,6 +1857,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
                     "majorOsVersion": 7,
                     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -1781,6 +1907,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
                     "majorOsVersion": 7,
                     "name": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
@@ -1825,6 +1957,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
                     "majorOsVersion": 7,
                     "name": "Health Insurance Portability and Accountability Act (HIPAA)",
@@ -1869,6 +2007,12 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline",
@@ -2272,6 +2416,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     "businessObjective": null,
                     "complianceThreshold": 100,
                     "compliantHostCount": 4,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline23",
@@ -2394,6 +2544,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 67,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
                     "majorOsVersion": 7,
                     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
@@ -2482,6 +2638,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "dae0487d-3201-4ee0-af5f-b94cde2af818",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline2",
@@ -2523,6 +2685,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 69.5,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
                     "majorOsVersion": 7,
                     "name": "C2S for Red Hat Enterprise Linux 7",
@@ -2564,6 +2732,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
                     "majorOsVersion": 7,
                     "name": "Criminal Justice Information Services (CJIS) Security Policy",
@@ -2605,6 +2779,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
                     "majorOsVersion": 7,
                     "name": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
@@ -2646,6 +2826,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
                     "majorOsVersion": 7,
                     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -2687,6 +2873,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
                     "majorOsVersion": 7,
                     "name": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
@@ -2728,6 +2920,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
                     "majorOsVersion": 7,
                     "name": "Health Insurance Portability and Accountability Act (HIPAA)",
@@ -2769,6 +2967,12 @@ exports[`PoliciesTable expect to render without error 1`] = `
                     },
                     "businessObjective": null,
                     "complianceThreshold": 100,
+                    "hosts": Array [
+                      Object {
+                        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                        "osMinorVersion": 7,
+                      },
+                    ],
                     "id": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
                     "majorOsVersion": 7,
                     "name": "United States Government Configuration Baseline",

--- a/src/PresentationalComponents/ReportCardGrid/__snapshots__/ResportsCardGrid.test.js.snap
+++ b/src/PresentationalComponents/ReportCardGrid/__snapshots__/ResportsCardGrid.test.js.snap
@@ -23,6 +23,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           "businessObjective": null,
           "complianceThreshold": 100,
           "compliantHostCount": 4,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
           "majorOsVersion": 7,
           "name": "United States Government Configuration Baseline23",
@@ -137,6 +143,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 67,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
           "majorOsVersion": 7,
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
@@ -217,6 +229,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "dae0487d-3201-4ee0-af5f-b94cde2af818",
           "majorOsVersion": 7,
           "name": "United States Government Configuration Baseline2",
@@ -250,6 +268,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 69.5,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
           "majorOsVersion": 7,
           "name": "C2S for Red Hat Enterprise Linux 7",
@@ -283,6 +307,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
           "majorOsVersion": 7,
           "name": "Criminal Justice Information Services (CJIS) Security Policy",
@@ -316,6 +346,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
           "majorOsVersion": 7,
           "name": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
@@ -349,6 +385,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
           "majorOsVersion": 7,
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -382,6 +424,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
           "majorOsVersion": 7,
           "name": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
@@ -415,6 +463,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
           "majorOsVersion": 7,
           "name": "Health Insurance Portability and Accountability Act (HIPAA)",
@@ -448,6 +502,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
           "majorOsVersion": 7,
           "name": "United States Government Configuration Baseline",
@@ -481,6 +541,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "4c27fe09-9a7f-437c-b38b-e42272d9ccf0",
           "majorOsVersion": 7,
           "name": "Standard System Security Profile for Red Hat Enterprise Linux 7",
@@ -514,6 +580,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "9b034440-e3dd-4c19-8f2c-ca75e813d57d",
           "majorOsVersion": 7,
           "name": "DISA STIG for Red Hat Enterprise Linux 7",
@@ -547,6 +619,12 @@ exports[`ReportCardGrid expect to render without error 1`] = `
           },
           "businessObjective": null,
           "complianceThreshold": 100,
+          "hosts": Array [
+            Object {
+              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+              "osMinorVersion": 7,
+            },
+          ],
           "id": "19921ca4-8526-4651-8876-3c8587e8e125",
           "majorOsVersion": 7,
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72",

--- a/src/PresentationalComponents/ReportDetailsDescription/__snapshots__/ReportDetailsDescription.test.js.snap
+++ b/src/PresentationalComponents/ReportDetailsDescription/__snapshots__/ReportDetailsDescription.test.js.snap
@@ -15,6 +15,12 @@ exports[`ReportDetailsDescription expect to render without error 1`] = `
         "businessObjective": null,
         "complianceThreshold": 100,
         "compliantHostCount": 4,
+        "hosts": Array [
+          Object {
+            "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+            "osMinorVersion": 7,
+          },
+        ],
         "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
         "majorOsVersion": 7,
         "name": "United States Government Configuration Baseline23",

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Filters.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Filters.test.js.snap
@@ -11,6 +11,12 @@ Array [
     "businessObjective": null,
     "complianceThreshold": 100,
     "compliantHostCount": 4,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
     "majorOsVersion": 7,
     "name": "United States Government Configuration Baseline23",
@@ -112,6 +118,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 67,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "719999b6-d230-4ba5-8dba-7ab3dc6561e0",
     "majorOsVersion": 7,
     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
@@ -179,6 +191,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "dae0487d-3201-4ee0-af5f-b94cde2af818",
     "majorOsVersion": 7,
     "name": "United States Government Configuration Baseline2",
@@ -199,6 +217,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 69.5,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "20a9d997-62a6-40cc-a5f3-19d466eb975e",
     "majorOsVersion": 7,
     "name": "C2S for Red Hat Enterprise Linux 7",
@@ -219,6 +243,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "6d345bd2-d597-4df8-9bcf-71c41155b42c",
     "majorOsVersion": 7,
     "name": "Criminal Justice Information Services (CJIS) Security Policy",
@@ -239,6 +269,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
     "majorOsVersion": 7,
     "name": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
@@ -259,6 +295,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "3c4823a1-2c16-46ae-b2fe-0cebf5a03931",
     "majorOsVersion": 7,
     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -279,6 +321,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "f7b7977a-403b-4cd1-ab90-20b6f9a5a359",
     "majorOsVersion": 7,
     "name": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
@@ -299,6 +347,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "36abc364-6dc3-4e35-94f4-d10fa77e866e",
     "majorOsVersion": 7,
     "name": "Health Insurance Portability and Accountability Act (HIPAA)",
@@ -319,6 +373,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220",
     "majorOsVersion": 7,
     "name": "United States Government Configuration Baseline",
@@ -339,6 +399,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "4c27fe09-9a7f-437c-b38b-e42272d9ccf0",
     "majorOsVersion": 7,
     "name": "Standard System Security Profile for Red Hat Enterprise Linux 7",
@@ -359,6 +425,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "9b034440-e3dd-4c19-8f2c-ca75e813d57d",
     "majorOsVersion": 7,
     "name": "DISA STIG for Red Hat Enterprise Linux 7",
@@ -379,6 +451,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "19921ca4-8526-4651-8876-3c8587e8e125",
     "majorOsVersion": 7,
     "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72",
@@ -406,6 +484,12 @@ Array [
     },
     "businessObjective": null,
     "complianceThreshold": 100,
+    "hosts": Array [
+      Object {
+        "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+        "osMinorVersion": 7,
+      },
+    ],
     "id": "c8e15347-9c2b-495d-8e54-503c2f9582b6",
     "majorOsVersion": 7,
     "name": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
@@ -203,6 +203,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 businessObjective={null}
                 complianceThreshold={100}
                 compliantHostCount={4}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="b71376fd-015e-4209-99af-4543e82e5dc5"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline23"
@@ -311,6 +319,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 businessObjective={null}
                 complianceThreshold={100}
                 compliantHostCount={4}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="b71376fd-015e-4209-99af-4543e82e5dc5"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline23"
@@ -419,6 +435,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 businessObjective={null}
                 complianceThreshold={100}
                 compliantHostCount={4}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="b71376fd-015e-4209-99af-4543e82e5dc5"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline23"
@@ -530,6 +554,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="dae0487d-3201-4ee0-af5f-b94cde2af818"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline2"
@@ -556,6 +588,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="dae0487d-3201-4ee0-af5f-b94cde2af818"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline2"
@@ -582,6 +622,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="dae0487d-3201-4ee0-af5f-b94cde2af818"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline2"
@@ -612,6 +660,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline"
@@ -638,6 +694,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline"
@@ -664,6 +728,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="d35c8aad-8fc8-49e8-bff0-4d9d3dc8f220"
                 majorOsVersion={7}
                 name="United States Government Configuration Baseline"
@@ -694,6 +766,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="c8e15347-9c2b-495d-8e54-503c2f9582b6"
                 majorOsVersion={7}
                 name="Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)"
@@ -720,6 +800,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="c8e15347-9c2b-495d-8e54-503c2f9582b6"
                 majorOsVersion={7}
                 name="Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)"
@@ -746,6 +834,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="c8e15347-9c2b-495d-8e54-503c2f9582b6"
                 majorOsVersion={7}
                 name="Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)"
@@ -776,6 +872,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="4c27fe09-9a7f-437c-b38b-e42272d9ccf0"
                 majorOsVersion={7}
                 name="Standard System Security Profile for Red Hat Enterprise Linux 7"
@@ -802,6 +906,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="4c27fe09-9a7f-437c-b38b-e42272d9ccf0"
                 majorOsVersion={7}
                 name="Standard System Security Profile for Red Hat Enterprise Linux 7"
@@ -828,6 +940,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="4c27fe09-9a7f-437c-b38b-e42272d9ccf0"
                 majorOsVersion={7}
                 name="Standard System Security Profile for Red Hat Enterprise Linux 7"
@@ -858,6 +978,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="f7b7977a-403b-4cd1-ab90-20b6f9a5a359"
                 majorOsVersion={7}
                 name="Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)"
@@ -884,6 +1012,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="f7b7977a-403b-4cd1-ab90-20b6f9a5a359"
                 majorOsVersion={7}
                 name="Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)"
@@ -910,6 +1046,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="f7b7977a-403b-4cd1-ab90-20b6f9a5a359"
                 majorOsVersion={7}
                 name="Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)"
@@ -940,6 +1084,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={67}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="719999b6-d230-4ba5-8dba-7ab3dc6561e0"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73"
@@ -1013,6 +1165,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={67}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="719999b6-d230-4ba5-8dba-7ab3dc6561e0"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73"
@@ -1086,6 +1246,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={67}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="719999b6-d230-4ba5-8dba-7ab3dc6561e0"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73"
@@ -1163,6 +1331,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="19921ca4-8526-4651-8876-3c8587e8e125"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72"
@@ -1189,6 +1365,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="19921ca4-8526-4651-8876-3c8587e8e125"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72"
@@ -1215,6 +1399,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="19921ca4-8526-4651-8876-3c8587e8e125"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72"
@@ -1245,6 +1437,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="3c4823a1-2c16-46ae-b2fe-0cebf5a03931"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7"
@@ -1271,6 +1471,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="3c4823a1-2c16-46ae-b2fe-0cebf5a03931"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7"
@@ -1297,6 +1505,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="3c4823a1-2c16-46ae-b2fe-0cebf5a03931"
                 majorOsVersion={7}
                 name="PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7"
@@ -1327,6 +1543,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="36abc364-6dc3-4e35-94f4-d10fa77e866e"
                 majorOsVersion={7}
                 name="Health Insurance Portability and Accountability Act (HIPAA)"
@@ -1353,6 +1577,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="36abc364-6dc3-4e35-94f4-d10fa77e866e"
                 majorOsVersion={7}
                 name="Health Insurance Portability and Accountability Act (HIPAA)"
@@ -1379,6 +1611,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="36abc364-6dc3-4e35-94f4-d10fa77e866e"
                 majorOsVersion={7}
                 name="Health Insurance Portability and Accountability Act (HIPAA)"
@@ -1409,6 +1649,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="9b034440-e3dd-4c19-8f2c-ca75e813d57d"
                 majorOsVersion={7}
                 name="DISA STIG for Red Hat Enterprise Linux 7"
@@ -1435,6 +1683,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="9b034440-e3dd-4c19-8f2c-ca75e813d57d"
                 majorOsVersion={7}
                 name="DISA STIG for Red Hat Enterprise Linux 7"
@@ -1461,6 +1717,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="9b034440-e3dd-4c19-8f2c-ca75e813d57d"
                 majorOsVersion={7}
                 name="DISA STIG for Red Hat Enterprise Linux 7"
@@ -1491,6 +1755,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="6d345bd2-d597-4df8-9bcf-71c41155b42c"
                 majorOsVersion={7}
                 name="Criminal Justice Information Services (CJIS) Security Policy"
@@ -1517,6 +1789,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="6d345bd2-d597-4df8-9bcf-71c41155b42c"
                 majorOsVersion={7}
                 name="Criminal Justice Information Services (CJIS) Security Policy"
@@ -1543,6 +1823,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={100}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="6d345bd2-d597-4df8-9bcf-71c41155b42c"
                 majorOsVersion={7}
                 name="Criminal Justice Information Services (CJIS) Security Policy"
@@ -1573,6 +1861,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={69.5}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="20a9d997-62a6-40cc-a5f3-19d466eb975e"
                 majorOsVersion={7}
                 name="C2S for Red Hat Enterprise Linux 7"
@@ -1599,6 +1895,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={69.5}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="20a9d997-62a6-40cc-a5f3-19d466eb975e"
                 majorOsVersion={7}
                 name="C2S for Red Hat Enterprise Linux 7"
@@ -1625,6 +1929,14 @@ exports[`ReportsTable expect to render without error 1`] = `
                 }
                 businessObjective={null}
                 complianceThreshold={69.5}
+                hosts={
+                  Array [
+                    Object {
+                      "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                      "osMinorVersion": 7,
+                    },
+                  ]
+                }
                 id="20a9d997-62a6-40cc-a5f3-19d466eb975e"
                 majorOsVersion={7}
                 name="C2S for Red Hat Enterprise Linux 7"

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
@@ -21,7 +21,8 @@ const FinishedCreatePolicy = ({
     businessObjective,
     refId,
     benchmarkId,
-    systemIds
+    systemIds,
+    selectedRuleRefIds
 }) => {
     const [percent, setPercent] = useState(0);
     const [message, setMessage] = useState('This usually takes a minute or two.');
@@ -29,8 +30,8 @@ const FinishedCreatePolicy = ({
     const [failed, setFailed] = useState(false);
     const updatePolicy = usePolicyUpdate();
 
-    useEffect(async () => {
-        await updatePolicy(null, {
+    useEffect(() => {
+        updatePolicy(null, {
             cloneFromProfileId,
             description,
             name,
@@ -38,10 +39,15 @@ const FinishedCreatePolicy = ({
             businessObjective: { title: businessObjective },
             refId,
             benchmarkId,
-            hosts: systemIds.map((id) => ({ id }))
+            hosts: systemIds.map((id) => ({ id })),
+            selectedRuleRefIds
+        }).then(() => {
+            setPercent(100);
+        }).catch((error) => {
+            setMessage(error.networkError.message);
+            setErrors(error.networkError.result.errors);
+            setFailed(true);
         });
-
-        setPercent(100);
     }, []);
 
     let listErrors;

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
@@ -10,7 +10,7 @@ import { reduxForm, formValueSelector } from 'redux-form';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withApollo } from '@apollo/react-hoc';
-import usePolicyUpdate from 'SmartComponents/EditPolicy/usePolicyUpdate';
+import usePolicy from 'SmartComponents/EditPolicy/usePolicy';
 
 const FinishedCreatePolicy = ({
     onWizardFinish,
@@ -28,7 +28,7 @@ const FinishedCreatePolicy = ({
     const [message, setMessage] = useState('This usually takes a minute or two.');
     const [errors, setErrors] = useState(null);
     const [failed, setFailed] = useState(false);
-    const updatePolicy = usePolicyUpdate();
+    const updatePolicy = usePolicy();
 
     useEffect(() => {
         updatePolicy(null, {

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
@@ -44,8 +44,8 @@ const FinishedCreatePolicy = ({
         }).then(() => {
             setPercent(100);
         }).catch((error) => {
-            setMessage(error.networkError.message);
-            setErrors(error.networkError.result.errors);
+            setMessage(error.networkError?.message);
+            setErrors(error.networkError?.result?.errors);
             setFailed(true);
         });
     }, []);

--- a/src/SmartComponents/CreatePolicy/__snapshots__/FinishedCreatePolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/FinishedCreatePolicy.test.js.snap
@@ -108,18 +108,14 @@ exports[`FinishedCreatePolicy expect to render finished error state 1`] = `
       <div
         className="pf-c-empty-state__body wizard-failed-message"
       >
-        Response not successful: Received status code 406
-      </div>
-      <div
-        className="pf-c-empty-state__body wizard-failed-errors"
-      >
-        <ul
-          className="pf-c-list"
-        >
-          <li>
-            Error reason
-          </li>
-        </ul>
+        No more mocked responses for the query: mutation CreateProfile($input: createProfileInput!) {
+  createProfile(input: $input) {
+    profile {
+      id
+    }
+  }
+}
+, variables: {"input":{"name":"C2S for Red Hat Enterprise Linux 6","description":"This profile demonstrates compliance against the U.S. Government Commercial Cloud Services (C2S)","complianceThreshold":100,"cloneFromProfileId":"197eb783-7bca-45c5-978d-c1e89b0118da","refId":"xccdf_org.ssgproject.content_profile_C2S","benchmarkId":"a5e7f1ea-e63c-40be-a17a-c2a247c11e10"}}
       </div>
       <div
         className="pf-c-empty-state__secondary"
@@ -170,7 +166,7 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
         className="pf-c-empty-state__body"
       >
         <div
-          className="pf-c-progress pf-m-success wizard-progress-bar"
+          className="pf-c-progress wizard-progress-bar"
           id="finished-create-policy"
         >
           <div
@@ -179,7 +175,7 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
             id="finished-create-policy-description"
             onMouseEnter={null}
           >
-            Success
+            Progress
           </div>
           <div
             aria-hidden="true"
@@ -188,36 +184,14 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
             <span
               className="pf-c-progress__measure"
             >
-              100%
-            </span>
-            <span
-              className="pf-c-progress__status-icon"
-            >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 512 512"
-                width="1em"
-              >
-                <path
-                  d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                />
-              </svg>
+              0%
             </span>
           </div>
           <div
             aria-labelledby="finished-create-policy-description"
             aria-valuemax={100}
             aria-valuemin={0}
-            aria-valuenow={100}
+            aria-valuenow={0}
             className="pf-c-progress__bar"
             role="progressbar"
           >
@@ -225,7 +199,7 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
               className="pf-c-progress__indicator"
               style={
                 Object {
-                  "width": "100%",
+                  "width": "0%",
                 }
               }
             >
@@ -239,25 +213,12 @@ exports[`FinishedCreatePolicy expect to render without error 1`] = `
       <div
         className="pf-c-empty-state__body"
       >
-        
+        This usually takes a minute or two.
       </div>
       <div
         className="pf-c-empty-state__secondary"
       >
-        <button
-          aria-disabled={false}
-          aria-label={null}
-          className="pf-c-button pf-m-primary"
-          data-ouia-component-id="OUIA-Generated-Button-primary-1"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
-          onClick={[Function]}
-          role={null}
-          type="button"
-        >
-          Return to application
-        </button>
+        
       </div>
     </div>
   </div>

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -163,6 +163,8 @@ export const EditPolicy = ({ route }) => {
         });
     }, [selectedEntities]);
 
+    useEffect(() => setUpdatedPolicy({ ...updatedPolicy, selectedRuleRefIds }), [selectedRuleRefIds]);
+
     useEffect(() => {
 
         if (policy) {

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -11,7 +11,7 @@ import { useLinkToBackground, useAnchor } from 'Utilities/Router';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
 import EditPolicyDetailsTab from './EditPolicyDetailsTab';
 import EditPolicyRulesTab from './EditPolicyRulesTab';
-import usePolicyUpdate from './usePolicyUpdate';
+import usePolicy from './usePolicy';
 import useFeature from 'Utilities/hooks/useFeature';
 import { systemName } from 'Store/Reducers/SystemStore';
 import { GET_SYSTEMS_WITHOUT_FAILED_RULES } from '../SystemsTable/constants';
@@ -83,7 +83,7 @@ export const EditPolicy = ({ route }) => {
     const anchor = useAnchor();
     const [updatedPolicy, setUpdatedPolicy] = useState(null);
     const [selectedRuleRefIds, setSelectedRuleRefIds] = useState([]);
-    const updatePolicy = usePolicyUpdate();
+    const updatePolicy = usePolicy();
     const linkToBackground = useLinkToBackground('/scappolicies');
     const selectedEntities = useSelector((state) => (state?.entities?.selectedEntities));
     const saveEnabled = updatedPolicy && !updatedPolicy.complianceThresholdValid;

--- a/src/SmartComponents/EditPolicy/EditPolicy.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.test.js
@@ -5,7 +5,7 @@ jest.mock('react-redux', () => ({
     useSelector: jest.fn(() => ({})),
     useDispatch: jest.fn(() => ({}))
 }));
-jest.mock('./usePolicyUpdate', () => (() => {}));
+jest.mock('./usePolicy', () => (() => {}));
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useParams: jest.fn().mockReturnValue({ policy_id: '1' }), // eslint-disable-line

--- a/src/SmartComponents/EditPolicy/usePolicy.js
+++ b/src/SmartComponents/EditPolicy/usePolicy.js
@@ -21,7 +21,7 @@ const useCreateBusinessObjective = () => {
     };
 };
 
-const usePolicyUpdate = () => {
+const usePolicy = () => {
     const createBusinessObjective = useCreateBusinessObjective();
     const [updateProfile] = useMutation(UPDATE_PROFILE);
     const [createProfile] = useMutation(CREATE_PROFILE);
@@ -76,4 +76,4 @@ const usePolicyUpdate = () => {
     };
 };
 
-export default usePolicyUpdate;
+export default usePolicy;

--- a/src/SmartComponents/EditPolicy/usePolicyUpdate.js
+++ b/src/SmartComponents/EditPolicy/usePolicyUpdate.js
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/react-hooks';
 import {
-    ASSOCIATE_SYSTEMS_TO_PROFILES, CREATE_BUSINESS_OBJECTIVE, UPDATE_PROFILE, CREATE_PROFILE
+    ASSOCIATE_SYSTEMS_TO_PROFILES, CREATE_BUSINESS_OBJECTIVE, UPDATE_PROFILE, CREATE_PROFILE, ASSOCIATE_RULES_TO_PROFILE
 } from 'Utilities/graphql/mutations';
 
 const useCreateBusinessObjective = () => {
@@ -26,6 +26,7 @@ const usePolicyUpdate = () => {
     const [updateProfile] = useMutation(UPDATE_PROFILE);
     const [createProfile] = useMutation(CREATE_PROFILE);
     const [associateSystems] = useMutation(ASSOCIATE_SYSTEMS_TO_PROFILES);
+    const [associateRules] = useMutation(ASSOCIATE_RULES_TO_PROFILE);
 
     return async (policy, updatedPolicy) => {
         const businessObjectiveId = await createBusinessObjective(policy, updatedPolicy?.businessObjective);
@@ -61,7 +62,16 @@ const usePolicyUpdate = () => {
             } }
         });
 
-        return profiles;
+        updatedPolicy.selectedRuleRefIds.forEach(async ({ id, ruleRefIds }) => {
+            let ruleInput = {
+                id: profiles.find((profile) => (
+                    profile.id === id || profile.parentProfileId === id
+                )).id,
+                ruleRefIds
+            };
+
+            await associateRules({ variables: { input: ruleInput } });
+        });
     };
 };
 

--- a/src/SmartComponents/EditPolicy/usePolicyUpdate.js
+++ b/src/SmartComponents/EditPolicy/usePolicyUpdate.js
@@ -48,6 +48,7 @@ const usePolicyUpdate = () => {
             let {
                 data: { createProfile: { profile: { id } } }
             } = await createProfile({ variables: { input: policyInput } });
+
             policy = { id };
         } else {
             policyInput.id = policy.id;

--- a/src/SmartComponents/EditPolicy/usePolicyUpdate.js
+++ b/src/SmartComponents/EditPolicy/usePolicyUpdate.js
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/react-hooks';
 import {
-    ASSOCIATE_SYSTEMS_TO_PROFILES, CREATE_BUSINESS_OBJECTIVE, UPDATE_PROFILE
+    ASSOCIATE_SYSTEMS_TO_PROFILES, CREATE_BUSINESS_OBJECTIVE, UPDATE_PROFILE, CREATE_PROFILE
 } from 'Utilities/graphql/mutations';
 
 const useCreateBusinessObjective = () => {
@@ -24,25 +24,44 @@ const useCreateBusinessObjective = () => {
 const usePolicyUpdate = () => {
     const createBusinessObjective = useCreateBusinessObjective();
     const [updateProfile] = useMutation(UPDATE_PROFILE);
+    const [createProfile] = useMutation(CREATE_PROFILE);
     const [associateSystems] = useMutation(ASSOCIATE_SYSTEMS_TO_PROFILES);
 
     return async (policy, updatedPolicy) => {
-        const updatePolicyInput = {
-            id: policy.id,
+        const businessObjectiveId = await createBusinessObjective(policy, updatedPolicy?.businessObjective);
+        let policyInput = {
             name: updatedPolicy.name,
             description: updatedPolicy.description,
-            complianceThreshold: parseFloat(updatedPolicy.complianceThreshold),
-            businessObjectiveId: await createBusinessObjective(policy, updatedPolicy?.businessObjective)
+            complianceThreshold: parseFloat(updatedPolicy.complianceThreshold)
         };
 
-        associateSystems({
+        if (businessObjectiveId) {
+            policyInput.businessObjectiveId = businessObjectiveId;
+        }
+
+        if (policy === null) {
+            policyInput.cloneFromProfileId = updatedPolicy.cloneFromProfileId;
+            policyInput.refId = updatedPolicy.refId;
+            policyInput.benchmarkId = updatedPolicy.benchmarkId;
+
+            let {
+                data: { createProfile: { profile: { id } } }
+            } = await createProfile({ variables: { input: policyInput } });
+            policy = { id };
+        } else {
+            policyInput.id = policy.id;
+
+            await updateProfile({ variables: { input: policyInput } });
+        }
+
+        let { data: { associateSystems: { profile: { policy: { profiles } } } } } = await associateSystems({
             variables: { input: {
                 id: policy.id,
                 systemIds: updatedPolicy.hosts.map((h) => (h.id))
             } }
         });
 
-        return await updateProfile({ variables: { input: updatePolicyInput } });
+        return profiles;
     };
 };
 

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -69,6 +69,7 @@ query Profile($policyId: String!){
         }
         hosts {
             id
+            osMinorVersion
         }
         benchmark {
             id

--- a/src/SmartComponents/PolicyDetails/PolicyMultiversionRules.js
+++ b/src/SmartComponents/PolicyDetails/PolicyMultiversionRules.js
@@ -17,8 +17,15 @@ SSGTabTitle.propTypes = {
     profile: propTypes.object.isRequired
 };
 
-const PolicyMultiversionRules = ({ policy: { policy: { profiles } } }) => {
-    let tabsData = profiles.map((profile) => ({ profile }));
+const PolicyMultiversionRules = ({ policy: { hosts, policy: { profiles } } }) => {
+    let tabsData = profiles.filter(
+        (profile) => profile.osMinorVersion !== ''
+    ).map((profile) => ({
+        profile,
+        systemCount: hosts.filter(
+            (host) => `${host.osMinorVersion}` === profile.osMinorVersion
+        ).length
+    }));
 
     return <React.Fragment>
         <Alert variant="info" isInline title="Rule editing coming soon" />

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyMultiversionRules.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyMultiversionRules.test.js.snap
@@ -76,6 +76,7 @@ exports[`PolicyMultiversionRules expect to render without error 1`] = `
               ],
               "ssgVersion": "0.1.49",
             },
+            "systemCount": 0,
           },
           Object {
             "profile": Object {
@@ -104,6 +105,7 @@ exports[`PolicyMultiversionRules expect to render without error 1`] = `
               ],
               "ssgVersion": "0.1.45",
             },
+            "systemCount": 0,
           },
           Object {
             "profile": Object {
@@ -132,6 +134,7 @@ exports[`PolicyMultiversionRules expect to render without error 1`] = `
               ],
               "ssgVersion": "0.1.46",
             },
+            "systemCount": 0,
           },
         ]
       }

--- a/src/Utilities/graphql/mutations.js
+++ b/src/Utilities/graphql/mutations.js
@@ -16,6 +16,7 @@ mutation associateSystems($input: associateSystemsInput!) {
         profile {
             id
             policy {
+                id
                 profiles {
                     id
                     parentProfileId

--- a/src/Utilities/graphql/mutations.js
+++ b/src/Utilities/graphql/mutations.js
@@ -41,6 +41,16 @@ mutation associateProfiles($input: associateProfilesInput!) {
 }
 `;
 
+export const ASSOCIATE_RULES_TO_PROFILE = gql`
+mutation associateRules($input: associateRulesInput!) {
+    associateRules(input: $input) {
+        profile {
+            id
+        }
+    }
+}
+`;
+
 export const UPDATE_PROFILE = gql`
 mutation UpdateProfile($input: UpdateProfileInput!) {
     updateProfile(input: $input) {

--- a/src/__fixtures__/policies.js
+++ b/src/__fixtures__/policies.js
@@ -12,6 +12,9 @@ export const policies = {
                 testResultHostCount: 8,
                 compliantHostCount: 4,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -167,6 +170,9 @@ export const policies = {
                     ],
                     __typename: 'Profile'
                 },
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -186,6 +192,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -209,6 +218,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -232,6 +244,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -255,6 +270,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -278,6 +296,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -301,6 +322,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -324,6 +348,9 @@ export const policies = {
                 testResultHostCount: 8,
                 businessObjective: null,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -347,6 +374,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -370,6 +400,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -393,6 +426,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'
@@ -416,6 +452,9 @@ export const policies = {
                 totalHostCount: 10,
                 testResultHostCount: 8,
                 majorOsVersion: 7,
+                hosts: [
+                    { id: 'f7d15113-1ac8-4aee-b367-e1777e60979d', osMinorVersion: 7 }
+                ],
                 benchmark: {
                     title: 'Guide to the Secure Configuration of RHEL 7',
                     version: '0.1.49'


### PR DESCRIPTION
Policy creation, editing, and viewing should work as expected, including: Policy fields (name, threshold, etc.) business objective, system assignment, and rule assignment.

Resolved issues:

- [x] associateRules is not called yet
- [x] setting business objective is broken
- [x] policy details rules table shows profiles even when `osMinorVersion === ''`

And some that still exist that we should fix, perhaps in a new PR so break up the work:

- error handling for all API calls; we might handle errors in another PR. It's not so trivial since usePolicyUpdate was not written to consider error handling for all API calls (only policy creation mutation)
- not handled: when the profile doesn't exist in the requested benchmark (i.e. 0.1.45 and CIS). This scenario results in a 'missing' tab for those versions where the profile isn't available. We'll need to handle this somehow, probably with COMP-E-178 (filter hosts by policy type).

I've tried to split this work into commits for easy review, but it's going into the feature branch anyway, so we can improve this quite a bit after merge. I mainly want to make sure everything is working as expected.

~Requires https://github.com/RedHatInsights/compliance-backend/pull/804 and https://github.com/RedHatInsights/compliance-backend/pull/803~ (merged)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices