### PR TITLE
fix(CreatePolicy): default prop threshold should be a string

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -113,7 +113,7 @@ export default connect(
         osMajorVersion: selector(state, 'osMajorVersion'),
         osMinorVersionCounts: selector(state, 'osMinorVersionCounts'),
         businessObjective: selector(state, 'businessObjective'),
-        complianceThreshold: selector(state, 'complianceThreshold') || 100.0,
+        complianceThreshold: selector(state, 'complianceThreshold') || '100.0',
         name: selector(state, 'name'),
         profile: selector(state, 'profile'),
         refId: selector(state, 'refId'),


### PR DESCRIPTION
This happens when the wizard first loads:

```
Warning: Failed prop type: Invalid prop `complianceThreshold` of type `number` supplied to `CreatePolicy`, expected `string`.
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices