### PR TITLE
fix(PolicyCreate): RHICOMPL-484 editing Name and Description

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyDetails.js
@@ -7,12 +7,14 @@ import { Form, FormGroup, Text, TextContent, TextVariants } from '@patternfly/re
 import { ReduxFormTextInput, ReduxFormTextArea } from 'PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers';
 import { ProfileThresholdField } from 'PresentationalComponents';
 
-const EditPolicyDetails = ({ change, policy }) => {
+const EditPolicyDetails = ({ change, policy, refId }) => {
 
     useEffect(() => {
-        change('name', `${policy.name}`);
-        change('refId', `${policy.refId}`);
-        change('description', `${policy.description}`);
+        if (policy && policy.refId !== refId) {
+            change('name', `${policy.name}`);
+            change('refId', `${policy.refId}`);
+            change('description', `${policy.description}`);
+        }
     }, [policy]);
 
     return (
@@ -71,6 +73,7 @@ const selector = formValueSelector('policyForm');
 
 EditPolicyDetails.propTypes = {
     policy: propTypes.object,
+    refId: propTypes.string,
     change: reduxFormPropTypes.change
 };
 
@@ -78,6 +81,7 @@ const mapStateToProps = (state) => {
     const policy = JSON.parse(selector(state, 'profile'));
     return {
         policy,
+        refId: selector(state, 'refId'),
         initialValues: {
             name: `${policy.name}`,
             refId: `${policy.refId}`,


### PR DESCRIPTION
Name and Description were not editable unless the other fields were
edited first.  The useEffect was called on each Name/Desc. field value
change resetting it to original profile value(s).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
