### PR TITLE
feat(Rules): RHICOMPL-1551 add SSG popover to tab content f483843 

### DIFF
--- a/src/PresentationalComponents/SupportedSSGVersionsLink/SupportedSSGVersionsLink.js
+++ b/src/PresentationalComponents/SupportedSSGVersionsLink/SupportedSSGVersionsLink.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { supportedConfigsLink } from '@redhat-cloud-services/frontend-components-inventory-compliance';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 const SupportedSSGVersionsLink = () => (
     <a target='_blank' rel='noopener noreferrer' href={ supportedConfigsLink }>
-        Supported SSG versions
+        Supported SSG versions <ExternalLinkAltIcon />
     </a>
 );
 

--- a/src/PresentationalComponents/SupportedSSGVersionsLink/SupportedSSGVersionsLink.js
+++ b/src/PresentationalComponents/SupportedSSGVersionsLink/SupportedSSGVersionsLink.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { supportedConfigsLink } from '@redhat-cloud-services/frontend-components-inventory-compliance';
+
+const SupportedSSGVersionsLink = () => (
+    <a target='_blank' rel='noopener noreferrer' href={ supportedConfigsLink }>
+        Supported SSG versions
+    </a>
+);
+
+export default SupportedSSGVersionsLink;

--- a/src/PresentationalComponents/SupportedSSGVersionsLink/SupportedSSGVersionsLink.test.js
+++ b/src/PresentationalComponents/SupportedSSGVersionsLink/SupportedSSGVersionsLink.test.js
@@ -1,0 +1,11 @@
+import SupportedSSGVersionsLink from './SupportedSSGVersionsLink';
+
+describe('SupportedSSGVersionsLink', () => {
+    it('expect to render without error', () => {
+        const wrapper = shallow(
+            <SupportedSSGVersionsLink count={ 0 } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/SupportedSSGVersionsLink/__snapshots__/SupportedSSGVersionsLink.test.js.snap
+++ b/src/PresentationalComponents/SupportedSSGVersionsLink/__snapshots__/SupportedSSGVersionsLink.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SupportedSSGVersionsLink expect to render without error 1`] = `
+<a
+  href="https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/con-compl-assess-overview_compl-assess-overview#con-compl-assess-supported-configurations_compl-assess-overview"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  Supported SSG versions
+</a>
+`;

--- a/src/PresentationalComponents/SupportedSSGVersionsLink/__snapshots__/SupportedSSGVersionsLink.test.js.snap
+++ b/src/PresentationalComponents/SupportedSSGVersionsLink/__snapshots__/SupportedSSGVersionsLink.test.js.snap
@@ -6,6 +6,11 @@ exports[`SupportedSSGVersionsLink expect to render without error 1`] = `
   rel="noopener noreferrer"
   target="_blank"
 >
-  Supported SSG versions
+  Supported SSG versions 
+  <ExternalLinkAltIcon
+    color="currentColor"
+    noVerticalAlign={false}
+    size="sm"
+  />
 </a>
 `;

--- a/src/PresentationalComponents/TabbedRules/OsVersionText.js
+++ b/src/PresentationalComponents/TabbedRules/OsVersionText.js
@@ -1,5 +1,5 @@
 const OsVersionText = ({ profile, newOsMinorVersion }) => (
-    `RHEL ${ profile.osMajorVersion }.${ (profile.osMinorVersion || newOsMinorVersion) }`
+    `RHEL${'\u00A0'}${ profile.osMajorVersion }.${ (profile.osMinorVersion || newOsMinorVersion) }`
 );
 
 export default OsVersionText;

--- a/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
+++ b/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
@@ -3,10 +3,11 @@ import propTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 import {
-    Text, TextVariants, TextContent, Grid, Spinner, Badge
+    Text, TextVariants, TextContent, Grid, Spinner, Badge, Popover
 } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import SystemRulesTable from '@redhat-cloud-services/frontend-components-inventory-compliance/SystemRulesTable';
-import { StateViewWithError, StateViewPart } from 'PresentationalComponents';
+import { StateViewWithError, StateViewPart, SupportedSSGVersionsLink } from 'PresentationalComponents';
 import { pluralize } from 'Utilities/TextHelper';
 import OsVersionText from './OsVersionText';
 
@@ -19,6 +20,43 @@ const ProfileSystemCount = ({ count = 0 }) => (
 ProfileSystemCount.propTypes = {
     profile: propTypes.object,
     count: propTypes.number
+};
+
+const SSGVersionText = ({ profile, newOsMinorVersion }) => (
+    <Text component={ TextVariants.p }>
+        SSG version { profile.ssgVersion }
+        {' '}
+        <Popover
+            position='right'
+            bodyContent={ <SSGPopoverBody { ...{ profile, newOsMinorVersion } } /> }
+            footerContent={ <SupportedSSGVersionsLink /> }>
+            <OutlinedQuestionCircleIcon style={ { cursor: 'pointer' } } />
+        </Popover>
+    </Text>
+);
+
+SSGVersionText.propTypes = {
+    profile: propTypes.object.isRequired,
+    newOsMinorVersion: propTypes.string
+};
+
+const SSGPopoverBody = ({ profile, newOsMinorVersion }) => (
+    <TextContent style={ { fontSize: 'var(--pf-c-popover--FontSize)' } }>
+        <Text>
+            This is the latest supported version of the SCAP Security Guide (SSG) for
+            {' '}
+            <OsVersionText { ...{ profile, newOsMinorVersion } } />
+        </Text>
+        <Text>
+            <OsVersionText { ...{ profile, newOsMinorVersion } } /> systems assigned to this
+            policy will report using this rule list.
+        </Text>
+    </TextContent>
+);
+
+SSGPopoverBody.propTypes = {
+    profile: propTypes.object.isRequired,
+    newOsMinorVersion: propTypes.string
 };
 
 const BENCHMARK_QUERY = gql`
@@ -55,13 +93,11 @@ const ProfileTabContent = ({
         <Grid>
             <TextContent className="pf-u-mt-md">
                 <Text component={ TextVariants.h3 } >
-                    <OsVersionText profile={ profile } newOsMinorVersion={ newOsMinorVersion} />
+                    <OsVersionText { ...{ profile, newOsMinorVersion } } />
                     {' '}
                     <ProfileSystemCount count={ systemCount } />
                 </Text>
-                <Text component={ TextVariants.p }>
-                    SSG version { profile.ssgVersion }
-                </Text>
+                <SSGVersionText { ...{ profile, newOsMinorVersion } } />
             </TextContent>
         </Grid>
         <StateViewWithError stateValues={ { error, loading, rules } }>

--- a/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.js
+++ b/src/PresentationalComponents/UnsupportedSSGVersion/UnsupportedSSGVersion.js
@@ -2,7 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { Popover, Tooltip, Text } from '@patternfly/react-core';
 import { ExclamationTriangleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { supportedConfigsLink } from '@redhat-cloud-services/frontend-components-inventory-compliance';
+import { SupportedSSGVersionsLink } from 'PresentationalComponents';
 
 const UNSUPPORTED_SINGULAR_MESSAGE =
     'This system was using an incompatible version of the SSG at the time this report was generated. ' +
@@ -17,16 +17,16 @@ const UNSUPPORTED_PLURAL_MESSAGE = <React.Fragment>
     </Text>
 </React.Fragment>;
 
-const WarningWithPopover = ({ children, variant = 'plural' }) => {
-    const headerContent = 'Unsupported SSG versions';
-    const bodyContent = variant === 'plural' ? UNSUPPORTED_PLURAL_MESSAGE : UNSUPPORTED_SINGULAR_MESSAGE;
-    const footerContent = <a target='_blank' rel='noopener noreferrer' href={ supportedConfigsLink }>Supported SSG versions</a>;
-
-    return <Popover id='unsupported-popover' maxWidth='25rem'
-        { ...{ headerContent, bodyContent, footerContent } } >
+const WarningWithPopover = ({ children, variant = 'plural' }) => (
+    <Popover
+        id='unsupported-popover'
+        maxWidth='25rem'
+        headerContent='Unsupported SSG versions'
+        bodyContent={ variant === 'plural' ? UNSUPPORTED_PLURAL_MESSAGE : UNSUPPORTED_SINGULAR_MESSAGE }
+        footerContent={ <SupportedSSGVersionsLink /> }>
         { children }
-    </Popover>;
-};
+    </Popover>
+);
 
 WarningWithPopover.propTypes = {
     children: propTypes.node,

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -25,6 +25,7 @@ export { default as PolicyPopover } from './PolicyPopover/PolicyPopover';
 export { default as NoResultsTable, emptyRows } from './NoResultsTable/NoResultsTable';
 export { default as PoliciesTable } from './PoliciesTable/PoliciesTable';
 export { default as ProfileThresholdField } from './ProfileThresholdField/ProfileThresholdField';
+export { default as SupportedSSGVersionsLink } from './SupportedSSGVersionsLink/SupportedSSGVersionsLink';
 export { default as UnsupportedSSGVersion } from './UnsupportedSSGVersion/UnsupportedSSGVersion';
 export { default as SubPageTitle } from './SubPageTitle/SubPageTitle';
 export { default as OperatingSystemBadge } from './OperatingSystemBadge/OperatingSystemBadge';


### PR DESCRIPTION
Refactors the Supported SSGs link to a separate component.
Adds the popover next to the SSG version within the rules tab content.
Adds the external icon icon.
Updates the popover wording to match the behavior.

![Screenshot_2021-04-07 SCAP policies - Compliance Red Hat Insights](https://user-images.githubusercontent.com/7695766/113897572-495e3c80-97cb-11eb-88b4-db80af843d9c.png)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
