### PR TITLE
fix(PolicyDetails): RHICOMPL-1627 untailored policy by OS version

### DIFF
--- a/src/SmartComponents/PolicyDetails/EditRulesButtonToolbarItem.js
+++ b/src/SmartComponents/PolicyDetails/EditRulesButtonToolbarItem.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { ToolbarItem, Button } from '@patternfly/react-core';
+import { BackgroundLink } from 'PresentationalComponents';
+import { useAnchor } from 'Utilities/Router';
+
+const EditRulesButtonToolbarItem = ({ policy }) => {
+    let anchor = useAnchor();
+
+    return (
+        <ToolbarItem>
+            <BackgroundLink
+                to={ `/scappolicies/${ policy.id }/edit` }
+                state={ { policy } }
+                hash={ anchor }
+                backgroundLocation={ { hash: anchor } }>
+                <Button variant='primary'>Edit rules</Button>
+            </BackgroundLink>
+        </ToolbarItem>
+    );
+};
+
+EditRulesButtonToolbarItem.propTypes = {
+    policy: propTypes.object.isRequired
+};
+
+export default EditRulesButtonToolbarItem;

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.test.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.test.js
@@ -23,7 +23,24 @@ const mocks = [
                     complianceThreshold: 1,
                     compliantHostCount: 1,
                     policy: {
-                        name: 'parentpolicy'
+                        name: 'parentpolicy',
+                        profiles: [
+                            {
+                                id: '1',
+                                refId: '121212',
+                                name: 'profile1',
+                                description: 'profile description',
+                                osMinorVersion: '',
+                                businessObjective: {
+                                    id: '1',
+                                    title: 'BO 1'
+                                },
+                                benchmark: {
+                                    title: 'benchmark',
+                                    version: '0.1.5'
+                                }
+                            }
+                        ]
                     },
                     businessObjective: {
                         id: '1',

--- a/src/SmartComponents/PolicyDetails/PolicyMultiversionRules.js
+++ b/src/SmartComponents/PolicyDetails/PolicyMultiversionRules.js
@@ -1,33 +1,13 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { PageSection, PageSectionVariants, ToolbarItem, Button } from '@patternfly/react-core';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 import {
     selectColumns as selectRulesTableColumns
 } from '@redhat-cloud-services/frontend-components-inventory-compliance/SystemRulesTable';
-import { useAnchor } from 'Utilities/Router';
-import { TabbedRules, BackgroundLink } from 'PresentationalComponents';
+import { TabbedRules } from 'PresentationalComponents';
 import { mapCountOsMinorVersions } from 'Store/Reducers/SystemStore';
 import { sortingByProp } from 'Utilities/helpers';
-
-const EditRulesButtonToolbarItem = ({ policy }) => {
-    let anchor = useAnchor();
-
-    return (
-        <ToolbarItem>
-            <BackgroundLink
-                to={ `/scappolicies/${ policy.id }/edit` }
-                state={ { policy } }
-                hash={ anchor }
-                backgroundLocation={ { hash: anchor } }>
-                <Button variant='primary'>Edit rules</Button>
-            </BackgroundLink>
-        </ToolbarItem>
-    );
-};
-
-EditRulesButtonToolbarItem.propTypes = {
-    policy: propTypes.object.isRequired
-};
+import EditRulesButtonToolbarItem from './EditRulesButtonToolbarItem';
 
 const PolicyMultiversionRules = ({ policy }) => {
     const { hosts, policy: { profiles } } = policy;

--- a/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
@@ -4,6 +4,7 @@ import { Alert, Text, TextVariants, PageSection, PageSectionVariants } from '@pa
 import SystemRulesTable, {
     selectColumns as selectRulesTableColumns
 } from '@redhat-cloud-services/frontend-components-inventory-compliance/SystemRulesTable';
+import EditRulesButtonToolbarItem from './EditRulesButtonToolbarItem';
 
 const PolicyRulesTab = ({ loading, policy }) => (
     <React.Fragment>
@@ -24,6 +25,7 @@ const PolicyRulesTab = ({ loading, policy }) => (
                 profile: { refId: policy.refId, name: policy.name },
                 rules: policy.rules
             }]}
+            toolbarItems={ <EditRulesButtonToolbarItem policy={ policy } /> }
         />
     </React.Fragment>
 );

--- a/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
@@ -8,7 +8,11 @@ import EditRulesButtonToolbarItem from './EditRulesButtonToolbarItem';
 
 const PolicyRulesTab = ({ loading, policy }) => (
     <React.Fragment>
-        <Alert variant="info" isInline title="Rule editing coming soon" />
+        <Alert isInline variant='info' title='Rule editing is now available.'>
+            Edit rules by clicking the &quot;Edit rules&quot; button in the toolbar. Rule can now be edited for
+            each minor version of the RHEL OS associated with this policy and will be displayed in the policy
+            after the &quot;Edit rules&quot; modal has been opened and saved.
+        </Alert>
         <PageSection variant={PageSectionVariants.light}>
             <Text component={TextVariants.p}>
                 <strong>What rules are shown on this list?&nbsp;</strong>

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -21,6 +21,23 @@ exports[`PolicyDetails expect to render without error 1`] = `
           "name": "profile1",
           "policy": Object {
             "name": "parentpolicy",
+            "profiles": Array [
+              Object {
+                "benchmark": Object {
+                  "title": "benchmark",
+                  "version": "0.1.5",
+                },
+                "businessObjective": Object {
+                  "id": "1",
+                  "title": "BO 1",
+                },
+                "description": "profile description",
+                "id": "1",
+                "name": "profile1",
+                "osMinorVersion": "",
+                "refId": "121212",
+              },
+            ],
           },
           "refId": "121212",
           "totalHostCount": 1,
@@ -111,6 +128,23 @@ exports[`PolicyDetails expect to render without error 1`] = `
                   "name": "profile1",
                   "policy": Object {
                     "name": "parentpolicy",
+                    "profiles": Array [
+                      Object {
+                        "benchmark": Object {
+                          "title": "benchmark",
+                          "version": "0.1.5",
+                        },
+                        "businessObjective": Object {
+                          "id": "1",
+                          "title": "BO 1",
+                        },
+                        "description": "profile description",
+                        "id": "1",
+                        "name": "profile1",
+                        "osMinorVersion": "",
+                        "refId": "121212",
+                      },
+                    ],
                   },
                   "refId": "121212",
                   "totalHostCount": 1,
@@ -175,6 +209,23 @@ exports[`PolicyDetails expect to render without error 1`] = `
                 "name": "profile1",
                 "policy": Object {
                   "name": "parentpolicy",
+                  "profiles": Array [
+                    Object {
+                      "benchmark": Object {
+                        "title": "benchmark",
+                        "version": "0.1.5",
+                      },
+                      "businessObjective": Object {
+                        "id": "1",
+                        "title": "BO 1",
+                      },
+                      "description": "profile description",
+                      "id": "1",
+                      "name": "profile1",
+                      "osMinorVersion": "",
+                      "refId": "121212",
+                    },
+                  ],
                 },
                 "refId": "121212",
                 "totalHostCount": 1,
@@ -185,7 +236,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
         <ContentTab
           eventKey="rules"
         >
-          <PolicyMultiversionRules
+          <PolicyRulesTab
             policy={
               Object {
                 "benchmark": Object {
@@ -203,6 +254,23 @@ exports[`PolicyDetails expect to render without error 1`] = `
                 "name": "profile1",
                 "policy": Object {
                   "name": "parentpolicy",
+                  "profiles": Array [
+                    Object {
+                      "benchmark": Object {
+                        "title": "benchmark",
+                        "version": "0.1.5",
+                      },
+                      "businessObjective": Object {
+                        "id": "1",
+                        "title": "BO 1",
+                      },
+                      "description": "profile description",
+                      "id": "1",
+                      "name": "profile1",
+                      "osMinorVersion": "",
+                      "refId": "121212",
+                    },
+                  ],
                 },
                 "refId": "121212",
                 "totalHostCount": 1,
@@ -231,6 +299,23 @@ exports[`PolicyDetails expect to render without error 1`] = `
                 "name": "profile1",
                 "policy": Object {
                   "name": "parentpolicy",
+                  "profiles": Array [
+                    Object {
+                      "benchmark": Object {
+                        "title": "benchmark",
+                        "version": "0.1.5",
+                      },
+                      "businessObjective": Object {
+                        "id": "1",
+                        "title": "BO 1",
+                      },
+                      "description": "profile description",
+                      "id": "1",
+                      "name": "profile1",
+                      "osMinorVersion": "",
+                      "refId": "121212",
+                    },
+                  ],
                 },
                 "refId": "121212",
                 "totalHostCount": 1,


### PR DESCRIPTION
Show canonical rule set if the policy was not yet tailored by each of
the OS minor version out of the assigned systems.

Unifies GraphQL query with some slight redundancy, and drops the
useFeature hook.

Show an Alert for OS-untailored policies.

![Screenshot_2021-04-08 My HIPAA - SCAP policies - Compliance Red Hat Insights](https://user-images.githubusercontent.com/7695766/114058283-9c032b80-9893-11eb-9cb9-8ef523407d6f.png)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
