### PR TITLE
fix(PolicyCreate): RHICOMPL-1636 no wizard jumps if no systems selected

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -50,7 +50,7 @@ export const CreatePolicy = ({
             id: 4,
             name: 'Rules',
             component: <EditPolicyRules/>,
-            canJumpTo: stepIdReached >= 4,
+            canJumpTo: systemIds?.length > 0 && stepIdReached >= 4,
             enableNext: validateRulesPage(selectedRuleRefIds)
         },
         {
@@ -58,14 +58,14 @@ export const CreatePolicy = ({
             name: 'Review',
             component: <ReviewCreatedPolicy/>,
             nextButtonText: 'Finish',
-            canJumpTo: stepIdReached >= 5
+            canJumpTo: systemIds?.length > 0 && stepIdReached >= 5
         },
         {
             id: 6,
             name: 'Finished',
             component: <FinishedCreatePolicy onWizardFinish={ onClose } />,
             isFinishedStep: true,
-            canJumpTo: stepIdReached >= 6
+            canJumpTo: systemIds?.length > 0 && stepIdReached >= 6
         }
     ];
 


### PR DESCRIPTION
Added an additional condition to the `canJumpTo` attribute in each wizard step after the systems. This way if the user goes back and deselects all systems, there will be no way to go forward in the wizard and create a policy without systems.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
