### PR TITLE
fix(EditPolicy): RHICOMPL-1683 crash on missing canonical profile

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -79,14 +79,16 @@ const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, osMinorV
             const benchmark = getBenchmarkBySupportedOsMinor(benchmarks.collection, osMinorVersion);
             if (benchmark) {
                 const benchmarkProfile = getBenchmarkProfile(benchmark, policy.refId);
-                profile = policy.policy.profiles.find((profile) => (profile.parentProfileId === benchmarkProfile.id));
+                if (benchmarkProfile) {
+                    profile = policy.policy.profiles.find((profile) => (profile.parentProfileId === benchmarkProfile.id));
 
-                profile = {
-                    ...benchmarkProfile,
-                    benchmark: benchmarkProfile.relationships?.benchmark?.data,
-                    rules: benchmarkProfile.relationships?.rules?.data,
-                    ...profile
-                };
+                    profile = {
+                        ...benchmarkProfile,
+                        benchmark: benchmarkProfile.relationships?.benchmark?.data,
+                        rules: benchmarkProfile.relationships?.rules?.data,
+                        ...profile
+                    };
+                }
             }
         }
 


### PR DESCRIPTION
Reproducer:
1. Create a policy with with a type (refId) that isn't available in some available OS minor versions. (example: NIST)
2. Select 7.9 systems as well as lower versions that do not have that type (NIST)
3. Finish and create.
4. Open edit modal and select Rules tab.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
