### PR TITLE
fix(EditPolicy): RHICOMPL-1651 rules loading states 

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -112,8 +112,8 @@ const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, osMinorV
         },
         skip: filter.length === 0
     });
-    const dataState = ((tabsData?.length > 0) ? profilesData : undefined);
     const loadingState = ((loading || benchmarksLoading) ? true : undefined);
+    const dataState = ((!loadingState && tabsData?.length > 0) ? profilesData : undefined);
 
     useLayoutEffect(() => {
         if (profilesData) {

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -59,13 +59,15 @@ const getBenchmarkProfile = (benchmark, profileRefId) => (
 
 const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, osMinorVersionCounts }) => {
     const osMajorVersion = policy?.osMajorVersion;
+    const osMinorVersions = Object.keys(osMinorVersionCounts).sort();
     const benchmarkSearch = `os_major_version = ${ osMajorVersion } ` +
-        `and latest_supported_os_minor_version ^ (${ Object.keys(osMinorVersionCounts).sort().join(',') })`;
+        `and latest_supported_os_minor_version ^ (${ osMinorVersions.join(',') })`;
 
     const { data: benchmarks, loading: benchmarksLoading } = useCollection('benchmarks', {
         type: 'benchmark',
         include: ['profiles'],
-        params: { search: benchmarkSearch }
+        params: { search: benchmarkSearch },
+        skip: osMinorVersions.length === 0
     }, [benchmarkSearch]);
 
     let profileIds = [];

--- a/src/Utilities/hooks/api/useCollection.js
+++ b/src/Utilities/hooks/api/useCollection.js
@@ -60,10 +60,16 @@ const useCollection = (collection, options = {}, effects = []) => {
     };
 
     useEffect(() => {
+        setCollectionState({
+            data: undefined,
+            loading: true,
+            error: undefined
+        });
+
         fetchCollection(apiClient, collection, params, options).then((data) => {
             setCollectionState({
                 data,
-                loading: undefined,
+                loading: false,
                 error: undefined
             });
         });

--- a/src/Utilities/hooks/api/useCollection.js
+++ b/src/Utilities/hooks/api/useCollection.js
@@ -48,7 +48,7 @@ const fetchCollection = async (apiClient, collection, params = {}, options = {})
 const useCollection = (collection, options = {}, effects = []) => {
     const [collectionState, setCollectionState] = useState({
         data: undefined,
-        loading: true,
+        loading: !options?.skip,
         error: undefined
     });
     const apiClient = useApi({
@@ -60,6 +60,16 @@ const useCollection = (collection, options = {}, effects = []) => {
     };
 
     useEffect(() => {
+        if (options?.skip) {
+            setCollectionState({
+                data: undefined,
+                loading: false,
+                error: undefined
+            });
+
+            return;
+        }
+
         setCollectionState({
             data: undefined,
             loading: true,
@@ -73,7 +83,7 @@ const useCollection = (collection, options = {}, effects = []) => {
                 error: undefined
             });
         });
-    }, effects);
+    }, [...effects, options?.skip]);
 
     return collectionState;
 };


### PR DESCRIPTION
* fixes showing spinner in the edit modal early, especially if the policy does not have tabs configured yet
  * with added `skip` option to `useCollection`
* fixes `useCollection` to reset to default on effects variable change, which fixes showing spinner right after user selects a system from a new OS minor group
* fixes showing spinner only if the new data are being still being loaded (old were shown right under the spinner)

Note, I haven't experienced any issues with the Create Policy Wizard regarding a missing loading state.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
