### PR TITLE
feat(EditPolicyRulesTab): RHICOMPL-1684 empty state

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -1,5 +1,7 @@
 import React, { useLayoutEffect } from 'react';
-import { Text, TextContent } from '@patternfly/react-core';
+import {
+    EmptyState, EmptyStateBody, Text, TextContent, Title
+} from '@patternfly/react-core';
 import gql from 'graphql-tag';
 import propTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
@@ -56,6 +58,18 @@ const getBenchmarkBySupportedOsMinor = (benchmarks, osMinorVersion) => (
 const getBenchmarkProfile = (benchmark, profileRefId) => (
     benchmark.profiles.find((benchmarkProfile) => (benchmarkProfile.refId === profileRefId))
 );
+
+const EditPolicyRulesTabEmptyState = () => <EmptyState>
+    <Title headingLevel="h5" size="lg">
+        No rules can be configured
+    </Title>
+    <EmptyStateBody>
+        This policy has no associated systems, and therefore no rules can be configured.
+    </EmptyStateBody>
+    <EmptyStateBody>
+        Add at least one system to configure rules for this policy.
+    </EmptyStateBody>
+</EmptyState>;
 
 const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, osMinorVersionCounts }) => {
     const osMajorVersion = policy?.osMajorVersion;
@@ -128,7 +142,9 @@ const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, osMinorV
         }
     }, [profilesData]);
 
-    return <StateViewWithError stateValues={ { error, data: dataState, loading: loadingState } }>
+    return <StateViewWithError stateValues={ {
+        error, data: dataState, loading: loadingState, empty: !loadingState && !dataState
+    } }>
         <StateViewPart stateKey="loading">
             <EmptyTable><Spinner/></EmptyTable>
         </StateViewPart>
@@ -145,6 +161,9 @@ const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, osMinorV
                 selectedFilter
                 level={ 1 }
                 handleSelect={ handleSelect } />
+        </StateViewPart>
+        <StateViewPart stateKey="empty">
+            <EditPolicyRulesTabEmptyState />
         </StateViewPart>
     </StateViewWithError>;
 };

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.test.js
@@ -1,0 +1,30 @@
+import { useQuery } from '@apollo/react-hooks';
+import EditPolicyRulesTab from './EditPolicyRulesTab.js';
+
+jest.mock('@apollo/react-hooks');
+
+describe('EditPolicyRulesTab', () => {
+    useQuery.mockImplementation(() => ({
+        data: {
+            benchmarks: {
+                edges: [{
+                    id: '1',
+                    osMajorVersion: '7',
+                    rules: []
+                }]
+            }
+        }, error: undefined, loading: undefined
+    }));
+
+    it('expect to render without error', async () => {
+        const wrapper = shallow(
+            <EditPolicyRulesTab
+                handleSelect={ () => {} }
+                policy={ { policy: { profiles: [] } } }
+                selectedRuleRefIds={ [] }
+                osMinorVersionCounts={ {} }
+            />
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyRulesTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyRulesTab.test.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditPolicyRulesTab expect to render without error 1`] = `
+<StateViewWithError
+  stateValues={
+    Object {
+      "data": undefined,
+      "empty": true,
+      "error": undefined,
+      "loading": undefined,
+    }
+  }
+>
+  <StateViewPart
+    stateKey="loading"
+  >
+    <EmptyTable>
+      <Spinner />
+    </EmptyTable>
+  </StateViewPart>
+  <StateViewPart
+    stateKey="data"
+  >
+    <TextContent>
+      <Text>
+        Different release versions of RHEL are associated with different versions of the SCAP Security Guide (SSG), therefore each release must be customized independently.
+      </Text>
+    </TextContent>
+    <TabbedRules
+      columns={
+        Array [
+          Object {
+            "title": "Name",
+            "transforms": Array [
+              [Function],
+            ],
+          },
+          Object {
+            "title": "Severity",
+            "transforms": Array [
+              [Function],
+              [Function],
+            ],
+          },
+          Object {
+            "original": "Ansible",
+            "props": Object {
+              "tooltip": "Ansible",
+            },
+            "title": <React.Fragment>
+              <AnsibeTowerIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+               Ansible
+            </React.Fragment>,
+            "transforms": Array [
+              [Function],
+              [Function],
+            ],
+          },
+        ]
+      }
+      handleSelect={[Function]}
+      level={1}
+      remediationsEnabled={false}
+      selectedFilter={true}
+      tabsData={Array []}
+    />
+  </StateViewPart>
+  <StateViewPart
+    stateKey="empty"
+  >
+    <EditPolicyRulesTabEmptyState />
+  </StateViewPart>
+</StateViewWithError>
+`;


### PR DESCRIPTION
This empty state occurs when there are no tabs on the policy due to
having no systems.

Also adds a very rudimentary test for this tab component, which was missing.

![image](https://user-images.githubusercontent.com/761923/114776668-ba0fd680-9d40-11eb-9adc-08a54fb3eab3.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices