### PR TITLE
fix(InventoryTable): RHICOMPL-1682 - Only show empty state when not filtered

### DIFF
--- a/src/SmartComponents/SystemsTable/InventoryTable.js
+++ b/src/SmartComponents/SystemsTable/InventoryTable.js
@@ -95,7 +95,7 @@ export const InventoryTable = ({
             setIsLoaded(true);
             setPagination(() => ({ page, perPage }));
 
-            if (emptyStateComponent && !loading && data.systems.totalCount === 0) {
+            if (emptyStateComponent && !loading && data.systems.totalCount === 0 && combindedFilter.length === 0) {
                 setIsEmpty(true);
             }
 


### PR DESCRIPTION
The empty component passed in should only be used when it is not filtered by a user filter.


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
