### PR TITLE
fix(ReviewCreatedPolicy): Show N system(s) during review

### DIFF
--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
@@ -43,7 +43,7 @@ const ReviewCreatedPolicy = ({
             <Text>
                 Review your SCAP policy before finishing.
             </Text>
-            <Text component={TextVariants.h3}>{ name }</Text>
+            <Text component={TextVariants.h3} style={ { marginTop: 0 } }>{ name }</Text>
             <TextList component={TextListVariants.dl}>
                 <TextListItem component={TextListItemVariants.dt}>Policy type</TextListItem>
                 <TextListItem component={TextListItemVariants.dd}>{ parentProfileName }</TextListItem>

--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
@@ -64,7 +64,7 @@ const ReviewCreatedPolicy = ({
                                     RHEL {osMajorVersion}.{osMinorVersion}
                                 </TextListItem>
                                 <TextListItem component={TextListItemVariants.dd}>
-                                    { count }
+                                    { count } { count > 1 ? 'systems' : 'system' }
                                 </TextListItem>
                             </React.Fragment>
                         )) }

--- a/src/SmartComponents/CreatePolicy/__snapshots__/ReviewCreatedPolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/ReviewCreatedPolicy.test.js.snap
@@ -170,6 +170,8 @@ exports[`ReviewCreatedPolicy expect to render without error 1`] = `
                           data-pf-content={true}
                         >
                           10
+                           
+                          systems
                         </dd>
                       </TextListItem>
                       <TextListItem
@@ -203,6 +205,8 @@ exports[`ReviewCreatedPolicy expect to render without error 1`] = `
                           data-pf-content={true}
                         >
                           3
+                           
+                          systems
                         </dd>
                       </TextListItem>
                     </dl>

--- a/src/SmartComponents/CreatePolicy/__snapshots__/ReviewCreatedPolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/ReviewCreatedPolicy.test.js.snap
@@ -59,10 +59,20 @@ exports[`ReviewCreatedPolicy expect to render without error 1`] = `
           </Text>
           <Text
             component="h3"
+            style={
+              Object {
+                "marginTop": 0,
+              }
+            }
           >
             <h3
               className=""
               data-pf-content={true}
+              style={
+                Object {
+                  "marginTop": 0,
+                }
+              }
             >
               C2S for Red Hat Enterprise Linux 6
             </h3>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/761923/115058901-c49ead00-9eb3-11eb-92de-4b7b711b88f2.png)

~I checked the fonts and line heights, and the review step already matches those exact values in the mocks, so I don't think there's anything to change there.~ I found an extra margin-top, which is the default for the h3 it was attached to, but the mock doesn't show this, so I've forced it to 0.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices