### PR TITLE
fix(EditPolicySystemsTab): RHICOMPL-1697 new rules alert

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -3,7 +3,6 @@ import propTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { Form, Tab, TabTitleText } from '@patternfly/react-core';
 import { RoutedTabs } from 'PresentationalComponents';
-import { uniq } from 'Utilities/helpers';
 import EditPolicyDetailsTab from './EditPolicyDetailsTab';
 import EditPolicyRulesTab from './EditPolicyRulesTab';
 import EditPolicySystemsTab from './EditPolicySystemsTab';
@@ -28,6 +27,7 @@ export const EditPolicyForm = ({
     const policyProfiles = policy?.policy?.profiles || [];
     const dispatch = useDispatch();
     const [osMinorVersionCounts, setOsMinorVersionCounts] = useState({});
+    const [newRuleTabs, setNewRuleTabs] = useState(false);
     const selectedEntities = useSelector((state) => (state?.entities?.selectedEntities));
 
     const handleRuleSelect = (profile, newSelectedRuleRefIds) => {
@@ -89,6 +89,7 @@ export const EditPolicyForm = ({
                 <Tab eventKey='rules' title={ <TabTitleText>Rules</TabTitleText> }>
                     <EditPolicyRulesTab
                         policy={ policy }
+                        setNewRuleTabs={ setNewRuleTabs }
                         handleSelect={ handleRuleSelect }
                         selectedRuleRefIds={ selectedRuleRefIds }
                         osMinorVersionCounts={ osMinorVersionCounts }
@@ -98,7 +99,7 @@ export const EditPolicyForm = ({
                 <Tab eventKey='systems' title={ <TabTitleText>Systems</TabTitleText> }>
                     <EditPolicySystemsTab
                         osMajorVersion={ policy.osMajorVersion }
-                        policyOsMinorVersions={ uniq(policyProfiles.map(profile => profile.osMinorVersion)) }
+                        newRuleTabs={ newRuleTabs }
                     />
                 </Tab>
             </RoutedTabs>

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -120,7 +120,7 @@ export const toTabsData = (policy, osMinorVersionCounts, benchmarks, selectedRul
     }).filter(({ profile, newOsMinorVersion }) => !!profile && newOsMinorVersion)
 );
 
-export const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, osMinorVersionCounts }) => {
+export const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, osMinorVersionCounts, setNewRuleTabs }) => {
     const osMajorVersion = policy?.osMajorVersion;
     const osMinorVersions = Object.keys(osMinorVersionCounts).sort();
     const benchmarkSearch = `os_major_version = ${ osMajorVersion } ` +
@@ -152,6 +152,14 @@ export const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, o
     });
     const loadingState = ((profilesLoading || benchmarksLoading) ? true : undefined);
     const dataState = ((!loadingState && tabsData?.length > 0) ? profilesData : undefined);
+
+    if (!loadingState) {
+        setNewRuleTabs(!!tabsData.find(tab => (
+            policy.policy.profiles.find(profile => (
+                profile.osMinorVersion !== tab.newOsMinorVersion
+            ))
+        )));
+    }
 
     useLayoutEffect(() => {
         if (profilesData) {
@@ -198,6 +206,7 @@ export const EditPolicyRulesTab = ({ handleSelect, policy, selectedRuleRefIds, o
 
 EditPolicyRulesTab.propTypes = {
     handleSelect: propTypes.func,
+    setNewRuleTabs: propTypes.func,
     policy: propTypes.object,
     osMinorVersionCounts: propTypes.shape({
         osMinorVersion: propTypes.shape({

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.test.js
@@ -22,7 +22,8 @@ describe('EditPolicyRulesTab', () => {
         const wrapper = shallow(
             <EditPolicyRulesTab
                 handleSelect={ () => {} }
-                policy={ { policy: policies.edges[0].node  } }
+                setNewRuleTabs={ () => {} }
+                policy={ { policy: { profiles: [] } } }
                 selectedRuleRefIds={ [] }
                 osMinorVersionCounts={ {} }
             />
@@ -34,6 +35,7 @@ describe('EditPolicyRulesTab', () => {
         const wrapper = shallow(
             <EditPolicyRulesTab
                 handleSelect={ () => {} }
+                setNewRuleTabs={ () => {} }
                 policy={ policies.edges[0].node }
                 selectedRuleRefIds={ [] }
                 osMinorVersionCounts={ {

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Alert, AlertActionLink, Text, TextContent } from '@patternfly/react-core';
-import { useSelector } from 'react-redux';
 import { InventoryTable } from 'SmartComponents';
 import { GET_SYSTEMS_WITHOUT_FAILED_RULES } from '../SystemsTable/constants';
 import propTypes from 'prop-types';
@@ -40,17 +39,8 @@ PrependComponent.propTypes = {
     osMajorVersion: propTypes.string
 };
 
-const EditPolicySystemsTab = ({ osMajorVersion, policyOsMinorVersions }) => {
+const EditPolicySystemsTab = ({ osMajorVersion, newRuleTabs }) => {
     const { push, location } = useHistory();
-    const selectedSystemOsMinorVersions = useSelector(state => (
-        state?.entities?.selectedEntities?.map((entity) => (`${entity.osMinorVersion}`))
-    ));
-
-    const newOsMinorVersions = () => (
-        selectedSystemOsMinorVersions?.find((systemOsMinorVersion) => (
-            !policyOsMinorVersions.includes(systemOsMinorVersion)
-        ))
-    );
 
     const columns = [{
         key: 'display_name',
@@ -82,7 +72,7 @@ const EditPolicySystemsTab = ({ osMajorVersion, policyOsMinorVersions }) => {
                 enableExport={ false }
                 remediationsEnabled={ false }
             />
-            {newOsMinorVersions() && <Alert
+            {newRuleTabs && <Alert
                 variant="info"
                 isInline
                 title="You selected a system that has a release version previously not included in this policy."
@@ -97,7 +87,7 @@ const EditPolicySystemsTab = ({ osMajorVersion, policyOsMinorVersions }) => {
 
 EditPolicySystemsTab.propTypes = {
     osMajorVersion: propTypes.string,
-    policyOsMinorVersions: propTypes.arrayOf(propTypes.number)
+    newRuleTabs: propTypes.bool
 };
 
 export default EditPolicySystemsTab;

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
@@ -16,12 +16,19 @@ jest.mock('react-router-dom', () => ({
 describe('EditPolicySystemsTab', () => {
     const defaultProps = {
         osMajorVersion: '7',
-        policyOsMinorVersions: [1, 2, 3]
+        newRuleTabs: false
     };
 
     it('expect to render without error', async () => {
         const wrapper = shallow(
             <EditPolicySystemsTab { ...defaultProps } />
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render with new tabs alert', async () => {
+        const wrapper = shallow(
+            <EditPolicySystemsTab { ...defaultProps } newRuleTabs={ true } />
         );
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyForm.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyForm.test.js.snap
@@ -38,6 +38,7 @@ exports[`EditPolicyForm expect to render without error 1`] = `
             "name": "parentpolicy",
           }
         }
+        setNewRuleTabs={[Function]}
       />
     </Tab>
     <Tab
@@ -49,7 +50,7 @@ exports[`EditPolicyForm expect to render without error 1`] = `
       }
     >
       <EditPolicySystemsTab
-        policyOsMinorVersions={Array []}
+        newRuleTabs={false}
       />
     </Tab>
   </RoutedTabs>

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -1,5 +1,515 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
+<Fragment>
+  <withApollo(InventoryTable)
+    columns={
+      Array [
+        Object {
+          "key": "display_name",
+          "props": Object {
+            "isStatic": true,
+            "width": 40,
+          },
+          "renderFunc": [Function],
+          "title": "Name",
+        },
+        Object {
+          "key": "osMinorVersion",
+          "props": Object {
+            "isStatic": true,
+            "width": 40,
+          },
+          "renderFunc": [Function],
+          "title": "Operating system",
+        },
+      ]
+    }
+    compact={true}
+    defaultFilter="os_major_version = 7"
+    emptyStateComponent={
+      <EmptyState
+        osMajorVersion="7"
+      />
+    }
+    enableExport={false}
+    prependComponent={
+      <PrependComponent
+        osMajorVersion="7"
+      />
+    }
+    query={
+      Object {
+        "definitions": Array [
+          Object {
+            "directives": Array [],
+            "kind": "OperationDefinition",
+            "name": Object {
+              "kind": "Name",
+              "value": "getSystems",
+            },
+            "operation": "query",
+            "selectionSet": Object {
+              "kind": "SelectionSet",
+              "selections": Array [
+                Object {
+                  "alias": undefined,
+                  "arguments": Array [
+                    Object {
+                      "kind": "Argument",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "search",
+                      },
+                      "value": Object {
+                        "kind": "Variable",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "filter",
+                        },
+                      },
+                    },
+                    Object {
+                      "kind": "Argument",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "limit",
+                      },
+                      "value": Object {
+                        "kind": "Variable",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "perPage",
+                        },
+                      },
+                    },
+                    Object {
+                      "kind": "Argument",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "offset",
+                      },
+                      "value": Object {
+                        "kind": "Variable",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "page",
+                        },
+                      },
+                    },
+                  ],
+                  "directives": Array [],
+                  "kind": "Field",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "systems",
+                  },
+                  "selectionSet": Object {
+                    "kind": "SelectionSet",
+                    "selections": Array [
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "totalCount",
+                        },
+                        "selectionSet": undefined,
+                      },
+                      Object {
+                        "alias": undefined,
+                        "arguments": Array [],
+                        "directives": Array [],
+                        "kind": "Field",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "edges",
+                        },
+                        "selectionSet": Object {
+                          "kind": "SelectionSet",
+                          "selections": Array [
+                            Object {
+                              "alias": undefined,
+                              "arguments": Array [],
+                              "directives": Array [],
+                              "kind": "Field",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "node",
+                              },
+                              "selectionSet": Object {
+                                "kind": "SelectionSet",
+                                "selections": Array [
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "id",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "name",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "osMajorVersion",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "osMinorVersion",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [
+                                      Object {
+                                        "kind": "Argument",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "policyId",
+                                        },
+                                        "value": Object {
+                                          "kind": "Variable",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "policyId",
+                                          },
+                                        },
+                                      },
+                                    ],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "testResultProfiles",
+                                    },
+                                    "selectionSet": Object {
+                                      "kind": "SelectionSet",
+                                      "selections": Array [
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "id",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "name",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "lastScanned",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "external",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "compliant",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "score",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "supported",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "ssgVersion",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "policy",
+                                          },
+                                          "selectionSet": Object {
+                                            "kind": "SelectionSet",
+                                            "selections": Array [
+                                              Object {
+                                                "alias": undefined,
+                                                "arguments": Array [],
+                                                "directives": Array [],
+                                                "kind": "Field",
+                                                "name": Object {
+                                                  "kind": "Name",
+                                                  "value": "id",
+                                                },
+                                                "selectionSet": undefined,
+                                              },
+                                            ],
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [
+                                      Object {
+                                        "kind": "Argument",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "policyId",
+                                        },
+                                        "value": Object {
+                                          "kind": "Variable",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "policyId",
+                                          },
+                                        },
+                                      },
+                                    ],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "policies",
+                                    },
+                                    "selectionSet": Object {
+                                      "kind": "SelectionSet",
+                                      "selections": Array [
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "id",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "name",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "variableDefinitions": Array [
+              Object {
+                "defaultValue": undefined,
+                "directives": Array [],
+                "kind": "VariableDefinition",
+                "type": Object {
+                  "kind": "NonNullType",
+                  "type": Object {
+                    "kind": "NamedType",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "String",
+                    },
+                  },
+                },
+                "variable": Object {
+                  "kind": "Variable",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "filter",
+                  },
+                },
+              },
+              Object {
+                "defaultValue": undefined,
+                "directives": Array [],
+                "kind": "VariableDefinition",
+                "type": Object {
+                  "kind": "NamedType",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "ID",
+                  },
+                },
+                "variable": Object {
+                  "kind": "Variable",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "policyId",
+                  },
+                },
+              },
+              Object {
+                "defaultValue": undefined,
+                "directives": Array [],
+                "kind": "VariableDefinition",
+                "type": Object {
+                  "kind": "NamedType",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "Int",
+                  },
+                },
+                "variable": Object {
+                  "kind": "Variable",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "perPage",
+                  },
+                },
+              },
+              Object {
+                "defaultValue": undefined,
+                "directives": Array [],
+                "kind": "VariableDefinition",
+                "type": Object {
+                  "kind": "NamedType",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "Int",
+                  },
+                },
+                "variable": Object {
+                  "kind": "Variable",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "page",
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        "kind": "Document",
+        "loc": Object {
+          "end": 825,
+          "start": 0,
+        },
+      }
+    }
+    remediationsEnabled={false}
+    showActions={false}
+    showOsMinorVersionFilter={
+      Array [
+        "7",
+      ]
+    }
+  />
+  <Alert
+    actionLinks={
+      <AlertActionLink
+        onClick={[Function]}
+      >
+        Open rule editing
+      </AlertActionLink>
+    }
+    isInline={true}
+    title="You selected a system that has a release version previously not included in this policy."
+    variant="info"
+  >
+    <p>
+      If you have edited any rules for this policy, you will need to do so for this release version as well.
+    </p>
+  </Alert>
+</Fragment>
+`;
+
 exports[`EditPolicySystemsTab expect to render without error 1`] = `
 <Fragment>
   <withApollo(InventoryTable)


### PR DESCRIPTION
The new rules alert should only show when new tabs appear. This PR fixes
an issue where the alert appeared for new systems, despite not having
a valid policy type due to the OS version. This solution highlights the
performance issue with the rules tab requesting all benchmark rules.
This request is required to determine if the newly added system OS
versions have this policy type, so the alert is quite sluggish, on the
order of 1-2 seconds, to update when new systems are selected. I'm
hopeful we'll optimize the rules tab queries, which will also fix this
sluggish alert.

I've reported this API sluggishness as RHICOMPL-1706.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices