### PR TITLE
fix(InventoryTable): RHICOMPL-1476 - Only return OS filter when enabled

### DIFF
--- a/src/SmartComponents/SystemsTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/InventoryTable.test.js.snap
@@ -82,16 +82,6 @@ exports[`InventoryTable expect to not render a loading state 1`] = `
               "placeholder": "Filter by name",
               "type": "text",
             },
-            Object {
-              "filterValues": Object {
-                "groups": Array [],
-                "onChange": [Function],
-                "selected": undefined,
-              },
-              "id": "operatingsystem",
-              "label": "Operating System",
-              "type": "group",
-            },
           ],
         }
       }

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -27,5 +27,5 @@ export const useOsMinorVersionFilter = (showFilter) => {
         skip: !showFilter
     });
 
-    return osMinorVersionFilter(groupByMajorVersion(supportedSsgs?.collection, showFilter));
+    return showFilter ? osMinorVersionFilter(groupByMajorVersion(supportedSsgs?.collection, showFilter)) : [];
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -72,7 +72,7 @@ export const systemsOsMinorFilterConfiguration = (osMajorVersions) => {
 
     return [{
         type: conditionalFilterType.group,
-        label: 'Operating System',
+        label: 'Operating system',
         filterString,
         items
     }];


### PR DESCRIPTION
Before this the filter would appear (miss-configured) on Systems page.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
