### PR TITLE
fix(EditPolicyDetails): RHICOMPL-1692 apply the form grid on fields

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyDetailsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyDetailsTab.js
@@ -17,7 +17,7 @@ export const useThresholdValidate = () => {
 const EditPolicyDetailsTab = ({ policy, setUpdatedPolicy }) => {
     const [validThreshold, validateThreshold] = useThresholdValidate();
 
-    return <React.Fragment>
+    return <div className="pf-c-form">
         <FormGroup label="Policy description" isRequired fieldId="description">
             <TextArea
                 style={ { width: 800, height: 110 } }
@@ -75,7 +75,7 @@ const EditPolicyDetailsTab = ({ policy, setUpdatedPolicy }) => {
                     }));
                 }} />
         </FormGroup>
-    </React.Fragment>;
+    </div>;
 };
 
 EditPolicyDetailsTab.propTypes = {

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyDetailsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyDetailsTab.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EditPolicyDetailsTab expect to render without error 1`] = `
-<Fragment>
+<div
+  className="pf-c-form"
+>
   <FormGroup
     fieldId="description"
     isRequired={true}
@@ -61,5 +63,5 @@ exports[`EditPolicyDetailsTab expect to render without error 1`] = `
       type="number"
     />
   </FormGroup>
-</Fragment>
+</div>
 `;


### PR DESCRIPTION
The `Form` component from PF applies a grid on its direct child `FormGroup` components, but it doesn't when the children are for example under a tab. So I am abusing the `pf-c-form` class on a wrapping `<div>` in order to have the same look&feel.

**Before:**
![Screenshot from 2021-04-19 10-08-39](https://user-images.githubusercontent.com/649130/115202973-3dda1200-a0f7-11eb-9f38-22a2e1730362.png)

**After:**
![Screenshot from 2021-04-19 10-06-28](https://user-images.githubusercontent.com/649130/115202906-2b5fd880-a0f7-11eb-905b-14932a97ee05.png)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
