### PR TITLE
fix(EditPolic): RHICOMPL-1640 systems to be selected 

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -60,7 +60,7 @@ export const ComplianceSystems = () => {
     }];
     const policies = data?.profiles?.edges.map(({ node }) => node);
 
-    useLayoutEffect(() => { dispatch({ type: 'SELECT_ENTITIES', payload: { ids: [] } }); }, []);
+    useLayoutEffect(() => { dispatch({ type: 'CLEAR_INVENTORY_ENTITIES' }); }, []);
 
     return (
         <React.Fragment>

--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
@@ -85,10 +85,7 @@ export const CreateSCAPPolicy = ({ change, selectedBenchmarkId }) => {
     const setBenchmark = ({ id, osMajorVersion }) => {
         if (selectedBenchmark?.osMajorVersion !== osMajorVersion) {
             change('systems', []);
-            dispatch({
-                type: 'SELECT_ENTITIES',
-                payload: { ids: [] }
-            });
+            dispatch({ type: 'CLEAR_INVENTORY_ENTITIES' });
         }
 
         change('benchmark', id);

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect } from 'react';
 import propTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
@@ -101,10 +101,7 @@ export const EditPolicy = ({ route }) => {
     const saveEnabled = updatedPolicy && !updatedPolicy.complianceThresholdValid;
 
     const linkToBackgroundWithHash = () => {
-        dispatch({
-            type: 'SELECT_ENTITIES',
-            payload: { ids: [] }
-        });
+        dispatch({ type: 'CLEAR_INVENTORY_ENTITIES' });
         linkToBackground({ hash: anchor });
     };
 
@@ -192,6 +189,8 @@ export const EditPolicy = ({ route }) => {
             );
         }
     }, [policy]);
+
+    useLayoutEffect(() => { dispatch({ type: 'CLEAR_INVENTORY_ENTITIES' }); }, []);
 
     useTitleEntity(route, policy?.name);
 

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -180,10 +180,6 @@ export const EditPolicy = ({ route }) => {
             });
             updateSelectedRuleRefIds();
 
-            dispatch({
-                type: 'SELECT_ENTITIES',
-                payload: { ids: policy?.hosts || [] }
-            });
             setOsMinorVersionCounts(
                 profilesToOsMinorMap(policyProfiles, policy.hosts)
             );
@@ -220,7 +216,7 @@ export const EditPolicy = ({ route }) => {
 
                 <Tab eventKey='systems' title={ <TabTitleText>Systems</TabTitleText> }>
                     <EditPolicySystemsTab
-                        osMajorVersion={ policy.osMajorVersion }
+                        policy={ policy }
                         policyOsMinorVersions={ uniq(policyProfiles.map(profile => profile.osMinorVersion)) }
                     />
                 </Tab>

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Alert, AlertActionLink, Text, TextContent } from '@patternfly/react-core';
 import { useSelector } from 'react-redux';
 import { InventoryTable } from 'SmartComponents';
@@ -40,8 +41,21 @@ PrependComponent.propTypes = {
     osMajorVersion: propTypes.number
 };
 
-const EditPolicySystemsTab = ({ osMajorVersion, policyOsMinorVersions }) => {
+const EditPolicySystemsTab = ({ policy, policyOsMinorVersions }) => {
+    const { osMajorVersion } = policy;
     const { push, location } = useHistory();
+    const dispatch = useDispatch();
+    const [tableLoaded, setTableLoaded] = useState(false);
+
+    useEffect(() => {
+        if (!policy || !tableLoaded) { return; }
+
+        dispatch({
+            type: 'SELECT_ENTITIES',
+            payload: { ids: policy?.hosts?.map(({ id }) => id) || [] }
+        });
+    }, [policy, tableLoaded]);
+
     const selectedSystemOsMinorVersions = useSelector(state => (
         state?.entities?.selectedEntities?.map((entity) => (`${entity.osMinorVersion}`))
     ));
@@ -81,6 +95,7 @@ const EditPolicySystemsTab = ({ osMajorVersion, policyOsMinorVersions }) => {
                 defaultFilter={ osMajorVersion && `os_major_version = ${osMajorVersion}` }
                 enableExport={ false }
                 remediationsEnabled={ false }
+                onLoad={ () => setTableLoaded(true) }
             />
             {newOsMinorVersions() && <Alert
                 variant="info"
@@ -96,7 +111,10 @@ const EditPolicySystemsTab = ({ osMajorVersion, policyOsMinorVersions }) => {
 };
 
 EditPolicySystemsTab.propTypes = {
-    osMajorVersion: propTypes.string,
+    policy: propTypes.shape({
+        osMajorVersion: propTypes.string,
+        hosts: propTypes.arrayOf(propTypes.object)
+    }),
     policyOsMinorVersions: propTypes.arrayOf(propTypes.number)
 };
 

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
@@ -10,12 +10,15 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
-    useSelector: jest.fn(() => [])
+    useSelector: jest.fn(() => []),
+    useDispatch: jest.fn(() => [])
 }));
 
 describe('EditPolicySystemsTab', () => {
     const defaultProps = {
-        osMajorVersion: 7,
+        policy: {
+            osMajorVersion: 7
+        },
         policyOsMinorVersions: [1, 2, 3]
     };
     const MockComponent = jest.fn(({ children, loaded }) => {

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -125,6 +125,28 @@ exports[`EditPolicy expect to render with active tab open 1`] = `
         }
       >
         <EditPolicySystemsTab
+          policy={
+            Object {
+              "benchmark": Object {
+                "title": "benchmark",
+                "version": "0.1.5",
+              },
+              "businessObjective": Object {
+                "id": "1",
+                "title": "BO 1",
+              },
+              "complianceThreshold": 1,
+              "compliantHostCount": 1,
+              "description": "profile description",
+              "id": "1",
+              "name": "profile1",
+              "policy": Object {
+                "name": "parentpolicy",
+              },
+              "refId": "121212",
+              "totalHostCount": 1,
+            }
+          }
           policyOsMinorVersions={Array []}
         />
       </Tab>
@@ -258,6 +280,28 @@ exports[`EditPolicy expect to render without error 1`] = `
         }
       >
         <EditPolicySystemsTab
+          policy={
+            Object {
+              "benchmark": Object {
+                "title": "benchmark",
+                "version": "0.1.5",
+              },
+              "businessObjective": Object {
+                "id": "1",
+                "title": "BO 1",
+              },
+              "complianceThreshold": 1,
+              "compliantHostCount": 1,
+              "description": "profile description",
+              "id": "1",
+              "name": "profile1",
+              "policy": Object {
+                "name": "parentpolicy",
+              },
+              "refId": "121212",
+              "totalHostCount": 1,
+            }
+          }
           policyOsMinorVersions={Array []}
         />
       </Tab>

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -33,6 +33,7 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
       />
     }
     enableExport={false}
+    onLoad={[Function]}
     prependComponent={
       <PrependComponent
         osMajorVersion={7}

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -108,7 +108,7 @@ export const PolicyDetails = ({ route }) => {
         refetch();
     }, [location, refetch]);
 
-    useLayoutEffect(() => { dispatch({ type: 'SELECT_ENTITIES', payload: { ids: [] } }); }, []);
+    useLayoutEffect(() => { dispatch({ type: 'CLEAR_INVENTORY_ENTITIES' }); }, []);
 
     useTitleEntity(route, policy?.name);
 

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -148,7 +148,7 @@ export const ReportDetails = ({ route }) => {
         )
     }];
 
-    useLayoutEffect(() => { dispatch({ type: 'SELECT_ENTITIES', payload: { ids: [] } }); }, []);
+    useLayoutEffect(() => { dispatch({ type: 'CLEAR_INVENTORY_ENTITIES' }); }, []);
 
     useTitleEntity(route, policyName);
 

--- a/src/SmartComponents/SystemsTable/InventoryTable.js
+++ b/src/SmartComponents/SystemsTable/InventoryTable.js
@@ -44,7 +44,8 @@ export const InventoryTable = ({
     defaultFilter,
     emptyStateComponent,
     prependComponent,
-    showOsMinorVersionFilter
+    showOsMinorVersionFilter,
+    onLoad
 }) => {
     const store = useStore();
     const dispatch = useDispatch();
@@ -155,6 +156,7 @@ export const InventoryTable = ({
                                 INVENTORY_ACTION_TYPES, columns, showAllSystems, policyId
                             ))
                     });
+                    onLoad && onLoad();
                 }}
                 fallback={<SkeletonTable colSize={2} rowSize={15} />}
                 tableProps={{
@@ -228,7 +230,8 @@ InventoryTable.propTypes = {
     showOsMinorVersionFilter: PropTypes.oneOfType([
         PropTypes.bool,
         PropTypes.arrayOf(PropTypes.number)
-    ])
+    ]),
+    onLoad: PropTypes.func
 };
 
 InventoryTable.defaultProps = {

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -212,5 +212,6 @@ export const systemsReducer = (INVENTORY_ACTION, columns) => applyReducerHash({
     },
     ['SELECT_ENTITIES']: (state, { payload: { ids } }) => ({
         selectedEntities: ids
-    })
+    }),
+    ['CLEAR_INVENTORY_ENTITIES']: () => ({})
 });

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -113,8 +113,8 @@ export const countOsMinorVersions = (systems) => (
     Object.values(mapCountOsMinorVersions(systems)).sort(sortingByProp('osMinorVersion', 'desc'))
 );
 
-export const systemsToRows = (systems) => (
-    systems.map(({ node }) => ({
+const systemsToRows = (systems, selectedEntities) => (
+    (systems || []).map(({ node }) => ({
         ...node,
         policyNames: policyNames({ policies: node?.policies, testResultProfiles: [] }),
         rulesPassed: profilesRulesPassed(node.testResultProfiles).length,
@@ -125,7 +125,8 @@ export const systemsToRows = (systems) => (
         score: score(node),
         supported: supported(node),
         ssgVersion: profilesSsgVersions(node),
-        detailsLink: detailsLink(node)
+        detailsLink: detailsLink(node),
+        selected: selectedEntities && isSelected(node.id, selectedEntities)
     }))
 );
 
@@ -175,27 +176,21 @@ export const systemsReducer = (INVENTORY_ACTION, columns) => applyReducerHash({
         systems,
         systemsCount,
         total: systemsCount,
-        rows: systemsToRows(systems).map((row) => ({
-            ...row, selected: isSelected(row.id, state.selectedEntities)
-        })),
+        rows: systemsToRows(systems, state.selectedEntities),
         columns,
         loaded: true
     }),
     [INVENTORY_ACTION.LOAD_ENTITIES_PENDING]: (state) => ({
         ...state,
         total: state.systemsCount,
-        rows: state.systems !== undefined ? systemsToRows(state.systems).map((row) => ({
-            ...row, selected: isSelected(row.id, state.selectedEntities)
-        })) : [],
+        rows: systemsToRows(state.systems, state.selectedEntities),
         columns,
         loaded: state.systemsCount !== undefined
     }),
     [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => ({
         ...state,
         total: state.systemsCount,
-        rows: state.systems !== undefined ? systemsToRows(state.systems).map((row) => ({
-            ...row, selected: isSelected(row.id, state.selectedEntities)
-        })) : [],
+        rows: systemsToRows(state.systems, state.selectedEntities),
         columns,
         loaded: state.systemsCount !== undefined
     }),

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -131,8 +131,9 @@ const systemsToRows = (systems, selectedEntities) => (
 );
 
 const selectRowsByIds = (state, ids) => {
+    const alreadySelectedIds = (state.selectedEntities || []).map((e) => (e.id));
     const rowsToSelect = state.rows.filter((row) => (
-        ids.includes(row.id) && !(state.selectedEntities || []).map((e) => (e.id)).includes(row.id)
+        ids.includes(row.id) && !alreadySelectedIds.includes(row.id)
     ));
 
     return {


### PR DESCRIPTION
Fixes the issue of systems not being selected in the edit modal (for a policy that has a system assigned).
The issue was reproducible by loading a fresh page with no InventoryTable yet renered and opening the modal (e.g. from a Policy
Details page, tab Details).

Adds CLEAR_INVENTORY_ENTITIES event to clear the state of the inventory table instead of the SELECT_ENTITIES which should be use to select entities only. The full state clearing is required for columns to render properly (probably some bug within Inventory).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
