### PR TITLE
feat(TabbedRules): RHICOMPL-1719 use GraphQL instead of REST

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -57,6 +57,7 @@ query Benchmarks($filter: String!){
             profiles {
                 id
                 refId
+                ssgVersion
             }
         }
     }


### PR DESCRIPTION
This affects the create policy wizard and the edit policy modal.

This changes the benchmarks query used to build tabs based on which SSG
versions are supported on which OS versions from a REST query to using
GraphQL. I've seen this REST request take 1-2 seconds to complete, but
in GraphQL with only the attributes we need, it takes something like
35ms.

~I'm seeing the following error on the create policy wizard: `Uncaught Error: EmtpyStateWithErrors(...):` I investigated a bit but so far haven't figured out what the issue is.~ Fixed with unrelated PR. The edit policy modal should work as expected.

Requires https://github.com/RedHatInsights/compliance-backend/pull/809

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices