### PR TITLE
fix(PolicyCreate): RHICOMPL-1722 return null when no errors

### DIFF
--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy.js
@@ -13,7 +13,7 @@ import { withApollo } from '@apollo/client/react/hoc';
 import usePolicy from 'SmartComponents/EditPolicy/usePolicy';
 
 const EmtpyStateWithErrors = ({ errors }) => (
-    (errors && Array.isArray(errors) && errors.length > 0) &&
+    (errors && Array.isArray(errors) && errors.length > 0) ? (
         <EmptyStateBody className='wizard-failed-errors'>
             <List>
                 {
@@ -23,6 +23,7 @@ const EmtpyStateWithErrors = ({ errors }) => (
                 }
             </List>
         </EmptyStateBody>
+    ) : null
 );
 
 EmtpyStateWithErrors.propTypes = {


### PR DESCRIPTION
The `EmtpyStateWithErrors` component crashes if there are no errors after saving the form. By adding a fallback to return `null` the problem should go away.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
