### PR TITLE
fix(EditPolicy): RHICOMPL-1742 save button disabled on empty systems

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -46,10 +46,10 @@ export const EditPolicyForm = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
     };
 
     useEffect(() => {
-        setUpdatedPolicy({
-            ...updatedPolicy,
+        setUpdatedPolicy((prevState) => ({
+            ...prevState,
             hosts: selectedEntities ? selectedEntities : []
-        });
+        }));
         updateSelectedRuleRefIds();
 
         setOsMinorVersionCounts(
@@ -61,10 +61,11 @@ export const EditPolicyForm = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
         if (policy) {
             const complianceThresholdValid =
                 (policy.complianceThreshold < 101 && policy.complianceThreshold > 0);
-            setUpdatedPolicy({
+            setUpdatedPolicy((prevState) => ({
+                ...prevState,
                 ...policy,
                 complianceThresholdValid
-            });
+            }));
             updateSelectedRuleRefIds();
 
             dispatch({
@@ -77,7 +78,13 @@ export const EditPolicyForm = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
         }
     }, [policy]);
 
-    useEffect(() => setUpdatedPolicy({ ...updatedPolicy, selectedRuleRefIds }), [selectedRuleRefIds]);
+    useEffect(() => (
+        setUpdatedPolicy((prevState) => ({
+            ...prevState,
+            ...updatedPolicy,
+            selectedRuleRefIds
+        }))
+    ), [selectedRuleRefIds]);
 
     return (
         <Form>


### PR DESCRIPTION
The updatedPolicy has been set more than once in EditPolicyForm whithin
three different useEffect callbacks.  Because the effects did not have it
as a dependency (for triggering reasons) they do not get the updated
content from the previous useEffect.  Since these useEffects can fire
all at the same time, one would not get the update from the other.  This
fixes this by using the previous state to merge with the new one.

There are alternatives for fixing this, like splitting the
updatedPolicy to three separate state variables hold by the EditPolicy.

**Alternative at #1178**

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
