### PR TITLE
fix(EditPolicy): RHICOMPL-1742 save button disabled on empty systems (split)

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -77,6 +77,8 @@ export const EditPolicy = ({ route }) => {
     const dispatch = useDispatch();
     const anchor = useAnchor();
     const [updatedPolicy, setUpdatedPolicy] = useState(null);
+    const [selectedRuleRefIds, setSelectedRuleRefIds] = useState([]);
+    const [selectedHosts, setSelectedHosts] = useState();
     const updatePolicy = usePolicy();
     const linkToBackground = useLinkToBackground('/scappolicies');
     const [isSaving, setIsSaving] = useState();
@@ -94,7 +96,12 @@ export const EditPolicy = ({ route }) => {
         if (isSaving) { return; }
 
         setIsSaving(true);
-        updatePolicy(policy, updatedPolicy).then(() => {
+        const updatedPolicyHostsAndRules = {
+            ...updatedPolicy,
+            selectedRuleRefIds,
+            hosts: selectedHosts
+        };
+        updatePolicy(policy, updatedPolicyHostsAndRules).then(() => {
             setIsSaving(false);
             linkToBackgroundWithHash();
         }).catch(() => {
@@ -137,7 +144,11 @@ export const EditPolicy = ({ route }) => {
                 <Spinner />
             </StateViewPart>
             <StateViewPart stateKey="policy">
-                <EditPolicyForm { ...{ policy, updatedPolicy, setUpdatedPolicy } } />
+                <EditPolicyForm
+                    { ...{
+                        policy, updatedPolicy, setUpdatedPolicy,
+                        selectedRuleRefIds, setSelectedRuleRefIds, setSelectedHosts
+                    } } />
             </StateViewPart>
         </StateViewWithError>
     </Modal>;

--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -19,10 +19,14 @@ const profilesToOsMinorMap = (profiles, hosts) => (
     }, mapCountOsMinorVersions(hosts || []))
 );
 
-export const EditPolicyForm = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
+export const EditPolicyForm = ({
+    policy,
+    setUpdatedPolicy,
+    selectedRuleRefIds, setSelectedRuleRefIds,
+    setSelectedHosts
+}) => {
     const policyProfiles = policy?.policy?.profiles || [];
     const dispatch = useDispatch();
-    const [selectedRuleRefIds, setSelectedRuleRefIds] = useState([]);
     const [osMinorVersionCounts, setOsMinorVersionCounts] = useState({});
     const selectedEntities = useSelector((state) => (state?.entities?.selectedEntities));
 
@@ -46,10 +50,7 @@ export const EditPolicyForm = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
     };
 
     useEffect(() => {
-        setUpdatedPolicy({
-            ...updatedPolicy,
-            hosts: selectedEntities ? selectedEntities : []
-        });
+        setSelectedHosts(selectedEntities ? selectedEntities : []);
         updateSelectedRuleRefIds();
 
         setOsMinorVersionCounts(
@@ -76,8 +77,6 @@ export const EditPolicyForm = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
             );
         }
     }, [policy]);
-
-    useEffect(() => setUpdatedPolicy({ ...updatedPolicy, selectedRuleRefIds }), [selectedRuleRefIds]);
 
     return (
         <Form>
@@ -110,8 +109,10 @@ export const EditPolicyForm = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
 
 EditPolicyForm.propTypes = {
     policy: propTypes.object,
-    updatedPolicy: propTypes.object,
-    setUpdatedPolicy: propTypes.func
+    setUpdatedPolicy: propTypes.func,
+    selectedRuleRefIds: propTypes.arrayOf(propTypes.object),
+    setSelectedRuleRefIds: propTypes.func,
+    setSelectedHosts: propTypes.func
 };
 
 export default EditPolicyForm;

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -100,6 +100,9 @@ exports[`EditPolicy expect to render without error 1`] = `
             "totalHostCount": 1,
           }
         }
+        selectedRuleRefIds={Array []}
+        setSelectedHosts={[Function]}
+        setSelectedRuleRefIds={[Function]}
         setUpdatedPolicy={[Function]}
         updatedPolicy={null}
       />

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyForm.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyForm.test.js.snap
@@ -38,7 +38,6 @@ exports[`EditPolicyForm expect to render without error 1`] = `
             "name": "parentpolicy",
           }
         }
-        selectedRuleRefIds={Array []}
       />
     </Tab>
     <Tab


### PR DESCRIPTION
The updatedPolicy has been set more than once in EditPolicyForm whithin
three different useEffect callbacks.  Because the effects did not have it
as a dependency (for triggering reasons) they do not get the updated
content from the previous useEffect.  Since these useEffects can fire
all at the same time, one would not get the update from the other.  This
fixes this by splitting it to three separate state variables.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
