### PR TITLE
WIP: Use datadrivenforms for Edit Policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
       "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.12.13"
       }
@@ -276,7 +275,6 @@
       "version": "7.13.12",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
       "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.13.12"
       }
@@ -365,8 +363,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -401,7 +398,6 @@
       "version": "7.13.10",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
       "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
@@ -1264,7 +1260,6 @@
       "version": "7.13.14",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
       "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
@@ -1287,19 +1282,32 @@
         "minimist": "^1.2.0"
       }
     },
-    "@data-driven-forms/pf4-component-mapper": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-2.24.0.tgz",
-      "integrity": "sha512-GRReWOSGcDdLgypmbRLFSt+XJQjUcIUylMbjb8Oc2qUbOL/EqlkspKD8aRx5ViLuq9lT9CdQO+f2SBuJ8eJdrw==",
+    "@data-driven-forms/common": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.6.0.tgz",
+      "integrity": "sha512-A7ylnTIx0b4ZlhxXnNIquSiiHFR+FIKoidQ+Q1V8n/7KRP63Q0DIOnZmesjTR9BPURQMASETYFxmtqG9RJ6+BQ==",
       "requires": {
+        "clsx": "^1.0.4",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "react-select": "^3.0.8"
+      }
+    },
+    "@data-driven-forms/pf4-component-mapper": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-3.6.0.tgz",
+      "integrity": "sha512-juhWmo9xQu6kHUggJZzZTkgmycjgNUWnMjW7l/enRFub+TUqKxLmAtsfTTMH4IdfZ1OTfiQbuYw870Q1AmpQHQ==",
+      "requires": {
+        "@data-driven-forms/common": "*",
         "downshift": "^5.4.3",
+        "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       }
     },
     "@data-driven-forms/react-form-renderer": {
-      "version": "2.24.1",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-2.24.1.tgz",
-      "integrity": "sha512-0UeHFFNPCc2XiYMHwnlW+N4Wrag9eygZD+mkPwKu6MAFweH1eWn4D4N3LUkE4O6FJw16mPMzfI3iizXN8T9uQA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.6.0.tgz",
+      "integrity": "sha512-xhO64BmQ2YI4ygkCaM2bT2sKfv3p7FrvnyWv9nSbhf5Ui2pVBldyeVv3+kEzAl8DqrP8ZRKa0w1T3fAAGLzD4g==",
       "requires": {
         "final-form": "^4.20.0",
         "final-form-arrays": "^3.0.2",
@@ -1315,6 +1323,94 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
       "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
       "dev": true
+    },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.17",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+          "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
+        }
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.0",
@@ -2307,6 +2403,31 @@
         "@redhat-cloud-services/host-inventory-client": "^1.0.94",
         "redux-promise-middleware": "^6.1.2",
         "urijs": "^1.19.4"
+      },
+      "dependencies": {
+        "@data-driven-forms/pf4-component-mapper": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-2.24.0.tgz",
+          "integrity": "sha512-GRReWOSGcDdLgypmbRLFSt+XJQjUcIUylMbjb8Oc2qUbOL/EqlkspKD8aRx5ViLuq9lT9CdQO+f2SBuJ8eJdrw==",
+          "requires": {
+            "downshift": "^5.4.3",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@data-driven-forms/react-form-renderer": {
+          "version": "2.24.1",
+          "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-2.24.1.tgz",
+          "integrity": "sha512-0UeHFFNPCc2XiYMHwnlW+N4Wrag9eygZD+mkPwKu6MAFweH1eWn4D4N3LUkE4O6FJw16mPMzfI3iizXN8T9uQA==",
+          "requires": {
+            "final-form": "^4.20.0",
+            "final-form-arrays": "^3.0.2",
+            "final-form-focus": "^1.1.2",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.7.2",
+            "react-final-form": "^6.5.0",
+            "react-final-form-arrays": "^3.1.1"
+          }
+        }
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
@@ -2635,8 +2756,7 @@
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prettier": {
       "version": "2.2.3",
@@ -3169,7 +3289,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -4103,6 +4222,35 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
+      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -4141,6 +4289,46 @@
         "require-package-name": "^2.0.1"
       }
     },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        }
+      }
+    },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
@@ -4170,6 +4358,11 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.0"
       }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-imports": {
       "version": "2.0.0",
@@ -4668,8 +4861,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camel-case": {
       "version": "4.1.2",
@@ -4744,7 +4936,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -4754,8 +4945,7 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         }
       }
     },
@@ -5082,6 +5272,11 @@
         "is-regexp": "^2.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5127,7 +5322,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -5135,8 +5329,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colorette": {
       "version": "1.2.2",
@@ -5252,7 +5445,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -6015,6 +6207,15 @@
         "utila": "~0.4"
       }
     },
+    "dom-helpers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "dom-serializer": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
@@ -6287,7 +6488,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -7322,6 +7522,11 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -7474,8 +7679,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
       "version": "1.1.4",
@@ -7887,7 +8091,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -7910,8 +8113,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -8410,7 +8612,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -8419,8 +8620,7 @@
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         }
       }
     },
@@ -8613,8 +8813,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-bigint": {
       "version": "1.0.1",
@@ -8665,7 +8864,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
       "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -10655,8 +10853,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -10781,8 +10978,7 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-      "dev": true
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "linkifyjs": {
       "version": "2.1.9",
@@ -11100,6 +11296,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "memory-fs": {
       "version": "0.5.0",
@@ -12437,7 +12638,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -12554,8 +12754,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -13289,6 +13488,14 @@
         "@babel/runtime": "^7.12.1"
       }
     },
+    "react-input-autosize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
+      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-intl": {
       "version": "5.15.8",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.15.8.tgz",
@@ -13370,6 +13577,21 @@
         "sitemap": "^1.6.0"
       }
     },
+    "react-select": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.2.0.tgz",
+      "integrity": "sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-input-autosize": "^3.0.0",
+        "react-transition-group": "^4.3.0"
+      }
+    },
     "react-shallow-renderer": {
       "version": "16.14.1",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
@@ -13407,6 +13629,17 @@
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
         }
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "react-truncate": {
@@ -14011,7 +14244,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -14098,8 +14330,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -15922,7 +16153,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -16238,8 +16468,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -17795,8 +18024,7 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@apollo/client": "^3.3.15",
     "@babel/runtime": "^7.13.10",
-    "@data-driven-forms/pf4-component-mapper": "^2.24.0",
-    "@data-driven-forms/react-form-renderer": "^2.24.1",
+    "@data-driven-forms/pf4-component-mapper": "^3.6.0",
+    "@data-driven-forms/react-form-renderer": "^3.6.0",
     "@patternfly/react-charts": "^6.14.11",
     "@patternfly/react-core": "^4.106.2",
     "@patternfly/react-icons": "^4.9.9",

--- a/src/PresentationalComponents/FormRenderer/FormRenderer.js
+++ b/src/PresentationalComponents/FormRenderer/FormRenderer.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import FormRenderer from '@data-driven-forms/react-form-renderer/form-renderer';
+
+import FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';
+import pf4ComponentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
+
+export const mapperExtension = {
+    // 'field-type': Component,
+};
+
+const CustomFormRenderer = ({ componentMapper, ...props }) => (
+    <FormRenderer
+        FormTemplate={ FormTemplate }
+        componentMapper = {{
+            ...pf4ComponentMapper,
+            ...mapperExtension,
+            ...componentMapper
+        }}
+        { ...props } />
+);
+
+CustomFormRenderer.propTypes = {
+    componentMapper: PropTypes.object
+};
+
+export default CustomFormRenderer;

--- a/src/PresentationalComponents/ReduxFormWrappers/__snapshots__/ReduxFormWrappers.test.js.snap
+++ b/src/PresentationalComponents/ReduxFormWrappers/__snapshots__/ReduxFormWrappers.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReduxFormCreatableSelectInput expect to render without error 1`] = `
-<Select$1
+<Select
   additionalProp="Prop1"
   input={
     Object {

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -26,3 +26,4 @@ export { default as UnsupportedSSGVersion } from './UnsupportedSSGVersion/Unsupp
 export { default as SubPageTitle } from './SubPageTitle/SubPageTitle';
 export { default as OperatingSystemBadge } from './OperatingSystemBadge/OperatingSystemBadge';
 export { default as TabbedRules } from './TabbedRules/TabbedRules';
+export { default as FormRenderer } from './FormRenderer/FormRenderer';

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -8,7 +8,7 @@ import { Button, Modal, Spinner } from '@patternfly/react-core';
 import { useLinkToBackground, useAnchor } from 'Utilities/Router';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
 import { StateViewWithError, StateViewPart } from 'PresentationalComponents';
-import EditPolicyForm from './EditPolicyForm';
+import EditPolicyForm from './EditPolicyDataForm';
 import usePolicy from './usePolicy';
 
 export const MULTIVERSION_QUERY = gql`

--- a/src/SmartComponents/EditPolicy/EditPolicyDataForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyDataForm.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { FormRenderer } from 'PresentationalComponents';
+import { mapCountOsMinorVersions } from 'Store/Reducers/SystemStore';
+import { default as formSchema, componentMapper } from './schema';
+
+const profilesToOsMinorMap = (profiles, hosts) => (
+    (profiles || []).reduce((acc, profile) => {
+        if (profile.osMinorVersion !== '') {
+            acc[profile.osMinorVersion] ||= { osMinorVersion: profile.osMinorVersion, count: 0 };
+        }
+
+        return acc;
+    }, mapCountOsMinorVersions(hosts || []))
+);
+
+export const EditPolicyForm = ({ policy }) => {
+    const policyProfiles = policy?.policy?.profiles || [];
+    const osMinorVersionCounts = profilesToOsMinorMap(policyProfiles, policy.hosts);
+
+    // Using JSON in a string datatype may not be ideal
+    // look into either being able to define a custom data type or solve with other more fitting type
+    const initialRuleSelection = JSON.stringify(policyProfiles.map((policyProfile) => ({
+        id: policyProfile.id,
+        ruleRefIds: policyProfile.rules.map((rule) => (rule.refId)),
+        count: osMinorVersionCounts[policyProfile.osMinorVersion]
+    })));
+    const initialSystemsSeletion = JSON.stringify(policy?.hosts);
+
+    const schema = formSchema(policy, {
+        initialRuleSelection,
+        initialSystemsSeletion,
+        ruleFieldProps: {
+            osMinorVersionCounts,
+            policy
+        }
+    });
+
+    const onSubmit = (...args) => {
+        console.log(...args);
+    };
+
+    const onCancel = (...args) => {
+        console.log(...args);
+    };
+
+    return <FormRenderer { ...{
+        componentMapper,
+        schema,
+        onSubmit,
+        onCancel
+    } } />;
+};
+
+EditPolicyForm.propTypes = {
+    policy: propTypes.object,
+    updatedPolicy: propTypes.object,
+    setUpdatedPolicy: propTypes.func
+};
+
+export default EditPolicyForm;

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesField.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesField.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import {
+    EmptyState, EmptyStateBody, Text, TextContent, Title
+} from '@patternfly/react-core';
+import propTypes from 'prop-types';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import EmptyTable from '@redhat-cloud-services/frontend-components/EmptyTable';
+import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
+import { StateViewWithError, StateViewPart, TabbedRules } from 'PresentationalComponents';
+import {
+    useBenchmarksQuery, useTabsData, useProfilesQuery
+} from './hooks';
+
+const EditPolicyRulesTabEmptyState = () => <EmptyState>
+    <Title headingLevel="h5" size="lg">
+        No rules can be configured
+    </Title>
+    <EmptyStateBody>
+        This policy has no associated systems, and therefore no rules can be configured.
+    </EmptyStateBody>
+    <EmptyStateBody>
+        Add at least one system to configure rules for this policy.
+    </EmptyStateBody>
+</EmptyState>;
+
+export const EditPolicyRulesField = (props) => {
+    const { input } = useFieldApi(props);
+    const {
+        FieldProps: { policy, osMinorVersionCounts }
+    } = props;
+    const toTabsData = useTabsData(policy, osMinorVersionCounts);
+    const selectedRuleRefIds = JSON.parse(input.value);
+
+    const {
+        data: benchmarksData,
+        error: benchmarksError,
+        loading: benchmarksLoading
+    } = useBenchmarksQuery(policy, osMinorVersionCounts);
+    const benchmarks = benchmarksData?.benchmarks?.nodes;
+
+    const tabsData = toTabsData(benchmarks, selectedRuleRefIds);
+
+    const {
+        data: profilesData, error: profilesError, loading: profilesLoading
+    } = useProfilesQuery(tabsData);
+
+    const loadingState = ((profilesLoading || benchmarksLoading) ? true : undefined);
+    const dataState = ((!loadingState && tabsData?.length > 0) ? profilesData : undefined);
+    const error = benchmarksError || profilesError;
+
+    const handleSelect = ({ id: profileId }, rules) => {
+        const updatedProfileRules = selectedRuleRefIds.map((ruleSet) => {
+            if (ruleSet.id === profileId) {
+                return { ...ruleSet, ruleRefIds: rules };
+            } else {
+                return ruleSet;
+            }
+        });
+
+        input.onChange(JSON.stringify(updatedProfileRules));
+    };
+
+    return <StateViewWithError stateValues={ {
+        error,
+        data: !error && dataState,
+        loading: loadingState,
+        empty: !loadingState && !dataState && !error
+    } }>
+        <StateViewPart stateKey="loading">
+            <EmptyTable><Spinner/></EmptyTable>
+        </StateViewPart>
+        <StateViewPart stateKey="data">
+            <TextContent>
+                <Text>
+                    Different release versions of RHEL are associated with different versions of
+                    the SCAP Security Guide (SSG), therefore each release must be customized independently.
+                </Text>
+            </TextContent>
+            <TabbedRules
+                tabsData={ tabsData }
+                remediationsEnabled={ false }
+                selectedFilter
+                level={ 1 }
+                handleSelect={ handleSelect } />
+        </StateViewPart>
+        <StateViewPart stateKey="empty">
+            <EditPolicyRulesTabEmptyState />
+        </StateViewPart>
+    </StateViewWithError>;
+};
+
+EditPolicyRulesField.propTypes = {
+    policy: propTypes.object,
+    osMinorVersionCounts: propTypes.shape({
+        osMinorVersion: propTypes.shape({
+            osMinorVersion: propTypes.number,
+            count: propTypes.number
+        })
+    }),
+    FieldProps: propTypes.object
+};
+
+export default EditPolicyRulesField;

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsField.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsField.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
+import { Alert, AlertActionLink, Text, TextContent } from '@patternfly/react-core';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import { InventoryTable } from 'SmartComponents';
+import { GET_SYSTEMS_WITHOUT_FAILED_RULES } from '../SystemsTable/constants';
+
+const EmptyState = ({ osMajorVersion }) => (
+    <React.Fragment>
+        <TextContent className="pf-u-mb-md">
+            <Text>
+                You do not have any <b>RHEL { osMajorVersion }</b> systems connected to Insights and enabled for Compliance.
+            </Text>
+        </TextContent>
+        <TextContent className="pf-u-mb-md">
+            <Text>
+                Connect RHEL { osMajorVersion } systems to Insights.
+            </Text>
+        </TextContent>
+    </React.Fragment>
+);
+
+EmptyState.propTypes = {
+    osMajorVersion: propTypes.number
+};
+
+const PrependComponent = ({ osMajorVersion }) => (
+    <React.Fragment>
+        <TextContent className="pf-u-mb-md">
+            <Text>
+                Select which of your <b>RHEL { osMajorVersion }</b> systems should be included
+                in this policy.
+            </Text>
+        </TextContent>
+    </React.Fragment>
+);
+
+PrependComponent.propTypes = {
+    osMajorVersion: propTypes.number
+};
+
+const EditPolicySystemsField = (props) => {
+    const { input } = useFieldApi(props);
+    const { osMajorVersion } = props;
+    const { push, location } = useHistory();
+    const preselectedSystems = JSON.parse(input.value || '[]');
+    console.log(preselectedSystems);
+
+    const columns = [{
+        key: 'display_name',
+        title: 'Name',
+        props: {
+            width: 40, isStatic: true
+        },
+        renderFunc: (displayName, _id, { name }) => (displayName || name)
+    }, {
+        key: 'osMinorVersion',
+        title: 'Operating system',
+        props: {
+            width: 40, isStatic: true
+        },
+        renderFunc: (osMinorVersion, _id, { osMajorVersion }) => `RHEL ${osMajorVersion}.${osMinorVersion}`
+    }];
+
+    return (
+        <React.Fragment>
+            <InventoryTable
+                showOsMinorVersionFilter={ [osMajorVersion] }
+                prependComponent={ <PrependComponent osMajorVersion={ osMajorVersion } />  }
+                emptyStateComponent={ <EmptyState osMajorVersion={ osMajorVersion } />  }
+                columns={ columns }
+                compact
+                showActions={ false }
+                query={ GET_SYSTEMS_WITHOUT_FAILED_RULES }
+                defaultFilter={ osMajorVersion && `os_major_version = ${osMajorVersion}` }
+                enableExport={ false }
+                remediationsEnabled={ false }
+            />
+
+            { false && <Alert
+                variant="info"
+                isInline
+                title="You selected a system that has a release version previously not included in this policy."
+                actionLinks={
+                    <AlertActionLink onClick={ () => push({ ...location, hash: '#rules' }) }>Open rule editing</AlertActionLink>
+                }>
+                <p>If you have edited any rules for this policy, you will need to do so for this release version as well.</p>
+            </Alert>}
+        </React.Fragment>
+    );
+};
+
+EditPolicySystemsField.propTypes = {
+    osMajorVersion: propTypes.string,
+    policyOsMinorVersions: propTypes.arrayOf(propTypes.number)
+};
+
+export default EditPolicySystemsField;

--- a/src/SmartComponents/EditPolicy/constants.js
+++ b/src/SmartComponents/EditPolicy/constants.js
@@ -1,0 +1,55 @@
+import gql from 'graphql-tag';
+
+export const BENCHMARKS_QUERY = gql`
+query Benchmarks($filter: String!){
+    benchmarks(search: $filter){
+        nodes {
+            id
+            latestSupportedOsMinorVersions
+            profiles {
+                id
+                refId
+                ssgVersion
+            }
+        }
+    }
+}
+`;
+
+export const PROFILES_QUERY = gql`
+query Profiles($filter: String!){
+    profiles(search: $filter){
+        edges {
+            node {
+                id
+                name
+                refId
+                osMinorVersion
+                osMajorVersion
+                policy {
+                    id
+
+                }
+                policyType
+                benchmark {
+                    id
+                    refId
+                    latestSupportedOsMinorVersions
+                    osMajorVersion
+                }
+                ssgVersion
+                rules {
+                    id
+                    title
+                    severity
+                    rationale
+                    refId
+                    description
+                    remediationAvailable
+                    identifier
+                }
+            }
+        }
+    }
+}
+`;

--- a/src/SmartComponents/EditPolicy/hooks.js
+++ b/src/SmartComponents/EditPolicy/hooks.js
@@ -1,0 +1,75 @@
+import { useQuery } from '@apollo/client';
+import { sortingByProp } from 'Utilities/helpers';
+import { BENCHMARKS_QUERY, PROFILES_QUERY } from './constants';
+
+export const useTabsData = (policy, osMinorVersionCounts) => {
+    const getBenchmarkBySupportedOsMinor = (benchmarks, osMinorVersion) => (
+        benchmarks.find((benchmark) =>
+            benchmark.latestSupportedOsMinorVersions?.includes(osMinorVersion)
+        )
+    );
+
+    const getBenchmarkProfile = (benchmark, profileRefId) => (
+        benchmark.profiles.find((benchmarkProfile) => (benchmarkProfile.refId === profileRefId))
+    );
+
+    return (benchmarks = [], selectedRuleRefIds = []) => (
+        Object.values(osMinorVersionCounts).sort(
+            sortingByProp('osMinorVersion', 'desc')
+        ).map(({ osMinorVersion, count: systemCount }) => {
+            osMinorVersion = `${osMinorVersion}`;
+            let profile = policy.policy.profiles.find((profile) => (profile.osMinorVersion === osMinorVersion));
+            let osMajorVersion = policy.osMajorVersion;
+
+            if (!profile && benchmarks) {
+                const benchmark = getBenchmarkBySupportedOsMinor(benchmarks, osMinorVersion);
+                if (benchmark) {
+                    const benchmarkProfile = getBenchmarkProfile(benchmark, policy.refId);
+                    if (benchmarkProfile) {
+                        profile = policy.policy.profiles.find((profile) => (profile.parentProfileId === benchmarkProfile.id));
+
+                        profile = {
+                            ...benchmarkProfile,
+                            benchmark,
+                            osMajorVersion,
+                            ...profile
+                        };
+                    }
+                }
+            }
+
+            return {
+                profile,
+                systemCount,
+                newOsMinorVersion: osMinorVersion,
+                selectedRuleRefIds: selectedRuleRefIds?.find(({ id }) => id === profile?.id)?.ruleRefIds
+            };
+        }).filter(({ profile, newOsMinorVersion }) => !!profile && newOsMinorVersion)
+    );
+};
+
+export const useBenchmarksQuery = (policy, osMinorVersionCounts) => {
+    const osMajorVersion = policy?.osMajorVersion;
+    const osMinorVersions = Object.keys(osMinorVersionCounts).sort();
+    const benchmarkSearch = `os_major_version = ${ osMajorVersion } ` +
+        `and latest_supported_os_minor_version ^ "${ osMinorVersions.join(',') }"`;
+
+    return useQuery(BENCHMARKS_QUERY, {
+        variables: {
+            filter: benchmarkSearch
+        },
+        skip: osMinorVersions.length === 0
+    });
+};
+
+export const useProfilesQuery = (tabsData) => {
+    const profileIds = tabsData.map((tab) => (tab.profile.id));
+    const filter = `${ profileIds.map((i) => (`id = ${ i }`)).join(' OR ') }`;
+
+    return useQuery(PROFILES_QUERY, {
+        variables: {
+            filter
+        },
+        skip: filter.length === 0
+    });
+};

--- a/src/SmartComponents/EditPolicy/schema.js
+++ b/src/SmartComponents/EditPolicy/schema.js
@@ -1,0 +1,79 @@
+import EditPolicyRulesField from './EditPolicyRulesField';
+import EditPolicySystemsField from './EditPolicySystemsField';
+
+export const componentMapper = {
+    rules: EditPolicyRulesField,
+    systems: EditPolicySystemsField
+};
+
+const detailsTab = (policy) =>({
+    validateFields: [],
+    name: '1',
+    title: 'Details',
+    description: '',
+    fields: [{
+        name: 'description',
+        label: 'Policy description',
+        component: 'textarea',
+        value: policy.description,
+        validate: []
+    }, {
+        name: 'businessObjective',
+        label: 'Business objective',
+        component: 'text-field',
+        validate: []
+    }, {
+        name: 'businessObjective',
+        label: 'Compliance threshold (%)',
+        component: 'text-field',
+        validate: []
+    }]
+});
+
+const rulesTab = (initialRuleSelection, props) => ({
+    validateFields: [],
+    name: '2',
+    title: 'Rules',
+    description: '',
+    fields: [{
+        name: 'rules',
+        component: 'rules',
+        initialValue: initialRuleSelection,
+        FieldProps: props,
+        dataType: 'string',
+        validate: []
+    }]
+});
+
+const systemsTab = (initialSystemsSeletion, { osMajorVersion }) => ({
+    validateFields: [],
+    name: '2',
+    title: 'Systems',
+    description: '',
+    fields: [{
+        name: 'systems',
+        component: 'systems',
+        initialValue: initialSystemsSeletion,
+        FieldProps: {
+            osMajorVersion
+        },
+        dataType: 'string',
+        validate: []
+    }]
+});
+
+export default (
+    policy, {
+        initialRuleSelection, initialSystemsSeletion, ruleFieldProps
+    }
+) => ({
+    fields: [{
+        component: 'tabs',
+        name: 'tabs',
+        fields: [
+            detailsTab(policy),
+            rulesTab(initialRuleSelection, ruleFieldProps),
+            systemsTab(initialSystemsSeletion, policy)
+        ]
+    }]
+});


### PR DESCRIPTION
This is a proof of concept to actually use data-driven forms and not just one of it’s wrapper components.
We currently have two forms that are very similar in functionally, but different in styling, the wizard and the edit policy form. Both have or have had issues with form state management. In order to fix these and prevent further issues, we should explore the option of moving both to a mature (not obsolete) framework to take the form state management parts off of our hands and provide us with functionality we can take advantage of for future features.

Data-Driven forms will allow us to use custom rules and system “fields”, these can be used in both forms with different schemas. 

* [x] Implement tab as field
* [ ] Implement systems tab as field
* [ ] Enable saving/canceling via Modal Button
    * Implement custom form template or use existing one for modals
* [ ] Implement field interactions
    * (Update rules field when systems change)
    * Use the useFormsAPI & FormSpy
* [ ] Implement custom routed tabs "fields"



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
