### PR TITLE
fix(EditPolicy): RHICOMPL-1755 Keep rule selections when systems change

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -50,7 +50,6 @@ export const EditPolicyForm = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
             ...updatedPolicy,
             hosts: selectedEntities ? selectedEntities : []
         });
-        updateSelectedRuleRefIds();
 
         setOsMinorVersionCounts(
             profilesToOsMinorMap(policyProfiles, selectedEntities)


### PR DESCRIPTION
Before, when updating the selected systems (not even adding or removing new
OS tabs), the rule selections were reset to the original policy's rule
selections. This change keeps the rule selection reset only when the
modal is first loaded (`useEffect(..., [policy])`).

I'm not sure when this `updateSelectedRuleRefIds` function was added to the useEffect for policy updates, so it's possible this re-introduces a different bug I'm not aware of.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices