### PR TITLE
fix: RHICOMPL-1701 Adjust wizard and modal sizes

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -86,7 +86,6 @@ export const CreatePolicy = ({
         <React.Fragment>
             <Wizard
                 isOpen
-                width={ 1220 }
                 onNext={ onNext }
                 onGoToStep={ resetAnchor }
                 onBack={ resetAnchor }

--- a/src/SmartComponents/CreatePolicy/__snapshots__/CreatePolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/CreatePolicy.test.js.snap
@@ -71,7 +71,7 @@ exports[`CreatePolicy expect to render the wizard 1`] = `
     ]
   }
   title="Create SCAP policy"
-  width={1220}
+  width={null}
 />
 `;
 

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -127,8 +127,9 @@ export const EditPolicy = ({ route }) => {
 
     return <Modal
         isOpen
-        style={ { height: '768px' } }
-        width={ 1220 }
+        position={ 'top' }
+        style={ { minHeight: '768px' } }
+        variant={ 'large' }
         title={ `Edit ${ policy ? policy.name : '' }` }
         onClose={ () => linkToBackgroundWithHash() }
         actions={ actions }>

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -29,17 +29,17 @@ exports[`EditPolicy expect to render without error 1`] = `
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
+  position="top"
   showClose={true}
   style={
     Object {
-      "height": "768px",
+      "minHeight": "768px",
     }
   }
   title="Edit profile1"
   titleIconVariant={null}
   titleLabel=""
-  variant="default"
-  width={1220}
+  variant="large"
 >
   <StateViewWithError
     stateValues={


### PR DESCRIPTION
Remove all specific pixel values and rely on isLarge in the modal.
Additionally, set the modal position to 'top' to tie it to the top
of the screen so the tabs don't change absolute position on the
screen as the user switches tabs.

![image](https://user-images.githubusercontent.com/761923/116932111-ddd38780-ac2f-11eb-9310-4b031adcdb72.png)
![image](https://user-images.githubusercontent.com/761923/116932137-e461ff00-ac2f-11eb-82ba-cc0155ca51e3.png)
![image](https://user-images.githubusercontent.com/761923/116932157-e88e1c80-ac2f-11eb-8bc2-11c76a0e09e7.png)

I'll address the remaining changes on RHICOMPL-1701 in a different PR.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices