### PR TITLE
fix(EditPolicy): RHICOMPL-1701 Reduce minHeight to 350px

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -128,7 +128,7 @@ export const EditPolicy = ({ route }) => {
     return <Modal
         isOpen
         position={ 'top' }
-        style={ { minHeight: '768px' } }
+        style={ { minHeight: '350px' } }
         variant={ 'large' }
         title={ `Edit ${ policy ? policy.name : '' }` }
         onClose={ () => linkToBackgroundWithHash() }

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -33,7 +33,7 @@ exports[`EditPolicy expect to render without error 1`] = `
   showClose={true}
   style={
     Object {
-      "minHeight": "768px",
+      "minHeight": "350px",
     }
   }
   title="Edit profile1"


### PR DESCRIPTION
This fixes the button placement on screens smaller than 768px. The issue
will still be present on screens smaller than about 550px, but that should be
much less common.

Even at 564px screen height:

![image](https://user-images.githubusercontent.com/761923/117658785-28419080-b169-11eb-89c7-9ba64bb9f531.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices