### PR TITLE
feat(Systems):  RHICOMPL-1716 - Enable OS minor version filter for policy OS versions

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -52,7 +52,7 @@ export const ComplianceSystems = () => {
                             systemProps={{
                                 isFullView: true
                             }}
-                            showOsFilter
+                            showOsMinorVersionFilter={ policies.map((policy) => (policy.majorOsVersion)) }
                             showComplianceSystemsInfo
                             enableEditPolicy={ false }
                             remediationsEnabled={ false }

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -7,10 +7,10 @@ import { systemsWithRuleObjectsFailed } from 'Utilities/ruleHelpers';
 import { osMinorVersionFilter } from './constants';
 import useExport from 'Utilities/hooks/useTableTools/useExport';
 
-const groupByMajorVersion = (versions = [], showFilter) => {
+const groupByMajorVersion = (versions = [], showFilter = []) => {
     const showVersion = (version) => {
         if (showFilter.length > 0) {
-            return Array(showFilter).map(String).includes(String(version));
+            return showFilter.map(String).includes(String(version));
         } else {
             return true;
         }

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,6 +52,7 @@ const toSystemsOsMinorFilterConfigurationItem = (osVersions) => (
     (majorVersion) => ({
         label: `RHEL ${ majorVersion }`,
         value: majorVersion,
+        groupSelectable: true,
         items: osVersions[majorVersion].map((minorVersion) => ({
             label: `RHEL ${ majorVersion }.${ minorVersion }`,
             value: minorVersion


### PR DESCRIPTION
This enables the OS minor version filter for the `ComplianceSystems` component  and enables the group selection option (to be) introduced for the group filter[0].

https://user-images.githubusercontent.com/7757/118270604-93b89480-b4c0-11eb-81d9-18985cca2d61.mp4

⚠️ For the group selection to work the `frontend-components` package needs to be linked in `LOCAL_CHROME`, not compliance-frontend.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices


[0] https://github.com/RedHatInsights/frontend-components/pull/1112