### PR TITLE
fix(PolicyDetails): RHICOMPL-1900 - Use dedicatedAction for Edit rules button

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -24,7 +24,8 @@ const RulesTable = ({
     selectedFilter = false,
     handleSelect,
     selectedRefIds = [],
-    hidePassed = false
+    hidePassed = false,
+    ...rulesTableProps
 }) => {
     const rules = toRulesArrayWithProfile(profileRules);
     const showPassFailFilter = (columns.filter((c) => (c.title === 'Passed')).length > 0);
@@ -67,7 +68,8 @@ const RulesTable = ({
                     }] }
                     selectedRules={ (selectedRules || []).filter((rule) => (rule.remediationAvailable)) } />
             )
-        }} />;
+        }}
+        { ...rulesTableProps } />;
 };
 
 RulesTable.propTypes = {

--- a/src/SmartComponents/PolicyDetails/PolicyMultiversionRules.js
+++ b/src/SmartComponents/PolicyDetails/PolicyMultiversionRules.js
@@ -25,7 +25,9 @@ const PolicyMultiversionRules = ({ policy }) => {
                 tabsData={ tabsData }
                 columns={ [Columns.Name, Columns.Severity, Columns.Ansible] }
                 level={ 1 }
-                toolbarItems={ <EditRulesButtonToolbarItem policy={ policy } /> } />
+                options={{
+                    dedicatedAction: () => (<EditRulesButtonToolbarItem policy={ policy } />) // eslint-disable-line
+                }} />
         </PageSection>
     </React.Fragment>;
 };

--- a/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicyRulesTab.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Alert, Text, TextVariants, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import SystemRulesTable, {
-    selectColumns as selectRulesTableColumns
-} from '@redhat-cloud-services/frontend-components-inventory-compliance/SystemRulesTable';
+import { RulesTable } from 'PresentationalComponents';
+import * as Columns from '@/PresentationalComponents/RulesTable/Columns';
+
 import EditRulesButtonToolbarItem from './EditRulesButtonToolbarItem';
 
 const PolicyRulesTab = ({ loading, policy }) => (
@@ -21,15 +21,17 @@ const PolicyRulesTab = ({ loading, policy }) => (
                 those rules will be different and can be viewed on the systems details page.
             </Text>
         </PageSection>
-        <SystemRulesTable
+        <RulesTable
             remediationsEnabled={false}
-            columns={ selectRulesTableColumns(['Name', 'Severity', 'Ansible']) }
+            columns={ [Columns.Name, Columns.Severity, Columns.Ansible] }
             loading={ loading }
             profileRules={[{
                 profile: { refId: policy.refId, name: policy.name },
                 rules: policy.rules
             }]}
-            toolbarItems={ <EditRulesButtonToolbarItem policy={ policy } /> }
+            options={{
+                dedicatedAction: () => (<EditRulesButtonToolbarItem policy={ policy } />) // eslint-disable-line
+            }}
         />
     </React.Fragment>
 );

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyMultiversionRules.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyMultiversionRules.test.js.snap
@@ -49,6 +49,11 @@ exports[`PolicyMultiversionRules expect to render without error 1`] = `
         ]
       }
       level={1}
+      options={
+        Object {
+          "dedicatedAction": [Function],
+        }
+      }
       tabsData={
         Array [
           Object {
@@ -112,130 +117,6 @@ exports[`PolicyMultiversionRules expect to render without error 1`] = `
             "systemCount": 1,
           },
         ]
-      }
-      toolbarItems={
-        <EditRulesButtonToolbarItem
-          policy={
-            Object {
-              "__typename": "Profile",
-              "benchmark": Object {
-                "title": "Guide to the Secure Configuration of RHEL 7",
-                "version": "0.1.49",
-              },
-              "businessObjective": null,
-              "complianceThreshold": 100,
-              "compliantHostCount": 4,
-              "hosts": Array [
-                Object {
-                  "osMinorVersion": "9",
-                },
-                Object {
-                  "osMinorVersion": "9",
-                },
-                Object {
-                  "osMinorVersion": "8",
-                },
-                Object {
-                  "osMinorVersion": "999",
-                },
-              ],
-              "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
-              "majorOsVersion": "7",
-              "name": "United States Government Configuration Baseline23",
-              "policy": Object {
-                "__typename": "Profile",
-                "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
-                "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
-                "profiles": Array [
-                  Object {
-                    "id": "b71376fd-015e-4209-99af",
-                    "name": "United States Government Configuration Baseline123",
-                    "osMinorVersion": "9",
-                    "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                    "rules": Array [
-                      Object {
-                        "__typename": "Rule",
-                        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                        "remediationAvailable": false,
-                        "severity": "medium",
-                        "title": "Record Attempts to Alter the localtime File",
-                      },
-                      Object {
-                        "__typename": "Rule",
-                        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                        "remediationAvailable": false,
-                        "severity": "medium",
-                        "title": "Record Attempts to Alter Time Through clock_settime",
-                      },
-                    ],
-                    "ssgVersion": "0.1.49",
-                  },
-                  Object {
-                    "id": "b71376fd-015e-4209-99ac",
-                    "name": "United States Government Configuration Baseline123",
-                    "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                    "rules": Array [
-                      Object {
-                        "__typename": "Rule",
-                        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                        "remediationAvailable": false,
-                        "severity": "medium",
-                        "title": "Record Attempts to Alter the localtime File",
-                      },
-                      Object {
-                        "__typename": "Rule",
-                        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                        "remediationAvailable": false,
-                        "severity": "medium",
-                        "title": "Record Attempts to Alter Time Through clock_settime",
-                      },
-                    ],
-                    "ssgVersion": "0.1.45",
-                  },
-                  Object {
-                    "id": "b71376fd-015e-4209-99ad",
-                    "name": "United States Government Configuration Baseline123",
-                    "osMinorVersion": "8",
-                    "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                    "rules": Array [
-                      Object {
-                        "__typename": "Rule",
-                        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                        "remediationAvailable": false,
-                        "severity": "medium",
-                        "title": "Record Attempts to Alter the localtime File",
-                      },
-                      Object {
-                        "__typename": "Rule",
-                        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                        "remediationAvailable": false,
-                        "severity": "medium",
-                        "title": "Record Attempts to Alter Time Through clock_settime",
-                      },
-                    ],
-                    "ssgVersion": "0.1.46",
-                  },
-                ],
-              },
-              "policyType": "United States Government Standard",
-              "refId": "xccdf_org.ssgproject.content_profile_ospp23",
-              "testResultHostCount": 8,
-              "totalHostCount": 10,
-            }
-          }
-        />
       }
     />
   </PageSection>


### PR DESCRIPTION
When moving to the new `RulesTable` the "Edit rules" button on the Policy details page got lost.
This fixes the issue and uses the `dedicatedAction` of the `PrimaryToolbar`.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
