### PR TITLE
feat(SystemsTable): RHICOMPL-1657 - Pass filters and orderBy to API

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -67,10 +67,17 @@ export const EditPolicySystems = ({ change, osMajorVersion, selectedSystems }) =
                         showOsMinorVersionFilter={ [osMajorVersion] }
                         prependComponent={ <PrependComponent osMajorVersion={ osMajorVersion } /> }
                         emptyStateComponent={ <EmptyState osMajorVersion={ osMajorVersion } /> }
-                        columns={[
-                            Columns.Name,
-                            Columns.OperatingSystem
-                        ]}
+                        columns={[{
+                            ...Columns.Name,
+                            props: {
+                                width: 40
+                            },
+                            sortBy: ['name']
+                        }, {
+                            ...Columns.OperatingSystem,
+                            props: {},
+                            sortBy: ['osMajorVersion', 'osMinorVersion']
+                        }]}
                         remediationsEnabled={false}
                         compact
                         showActions={ false }

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
@@ -17,20 +17,26 @@ exports[`EditPolicySystems expect to render without error 1`] = `
         columns={
           Array [
             Object {
+              "key": "name",
               "props": Object {
-                "isStatic": true,
                 "width": 40,
               },
               "renderExport": [Function],
               "renderFunc": [Function],
+              "sortBy": Array [
+                "name",
+              ],
               "title": "Name",
             },
             Object {
-              "props": Object {
-                "isStatic": true,
-              },
+              "key": "operatingSystem",
+              "props": Object {},
               "renderExport": [Function],
               "renderFunc": [Function],
+              "sortBy": Array [
+                "osMajorVersion",
+                "osMinorVersion",
+              ],
               "title": "Operating system",
               "transforms": Array [
                 [Function],
@@ -111,6 +117,20 @@ exports[`EditPolicySystems expect to render without error 1`] = `
                             "name": Object {
                               "kind": "Name",
                               "value": "page",
+                            },
+                          },
+                        },
+                        Object {
+                          "kind": "Argument",
+                          "name": Object {
+                            "kind": "Name",
+                            "value": "sortBy",
+                          },
+                          "value": Object {
+                            "kind": "Variable",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "sortBy",
                             },
                           },
                         },
@@ -490,12 +510,37 @@ exports[`EditPolicySystems expect to render without error 1`] = `
                       },
                     },
                   },
+                  Object {
+                    "defaultValue": undefined,
+                    "directives": Array [],
+                    "kind": "VariableDefinition",
+                    "type": Object {
+                      "kind": "ListType",
+                      "type": Object {
+                        "kind": "NonNullType",
+                        "type": Object {
+                          "kind": "NamedType",
+                          "name": Object {
+                            "kind": "Name",
+                            "value": "String",
+                          },
+                        },
+                      },
+                    },
+                    "variable": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "sortBy",
+                      },
+                    },
+                  },
                 ],
               },
             ],
             "kind": "Document",
             "loc": Object {
-              "end": 825,
+              "end": 862,
               "start": 0,
             },
           }

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -6,6 +6,7 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
     columns={
       Array [
         Object {
+          "key": "name",
           "props": Object {
             "isStatic": true,
             "width": 40,
@@ -15,6 +16,7 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
           "title": "Name",
         },
         Object {
+          "key": "operatingSystem",
           "props": Object {
             "isStatic": true,
           },
@@ -99,6 +101,20 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
                         "name": Object {
                           "kind": "Name",
                           "value": "page",
+                        },
+                      },
+                    },
+                    Object {
+                      "kind": "Argument",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "sortBy",
+                      },
+                      "value": Object {
+                        "kind": "Variable",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "sortBy",
                         },
                       },
                     },
@@ -478,12 +494,37 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
                   },
                 },
               },
+              Object {
+                "defaultValue": undefined,
+                "directives": Array [],
+                "kind": "VariableDefinition",
+                "type": Object {
+                  "kind": "ListType",
+                  "type": Object {
+                    "kind": "NonNullType",
+                    "type": Object {
+                      "kind": "NamedType",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "String",
+                      },
+                    },
+                  },
+                },
+                "variable": Object {
+                  "kind": "Variable",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "sortBy",
+                  },
+                },
+              },
             ],
           },
         ],
         "kind": "Document",
         "loc": Object {
-          "end": 825,
+          "end": 862,
           "start": 0,
         },
       }
@@ -523,6 +564,7 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
     columns={
       Array [
         Object {
+          "key": "name",
           "props": Object {
             "isStatic": true,
             "width": 40,
@@ -532,6 +574,7 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
           "title": "Name",
         },
         Object {
+          "key": "operatingSystem",
           "props": Object {
             "isStatic": true,
           },
@@ -616,6 +659,20 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
                         "name": Object {
                           "kind": "Name",
                           "value": "page",
+                        },
+                      },
+                    },
+                    Object {
+                      "kind": "Argument",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "sortBy",
+                      },
+                      "value": Object {
+                        "kind": "Variable",
+                        "name": Object {
+                          "kind": "Name",
+                          "value": "sortBy",
                         },
                       },
                     },
@@ -995,12 +1052,37 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
                   },
                 },
               },
+              Object {
+                "defaultValue": undefined,
+                "directives": Array [],
+                "kind": "VariableDefinition",
+                "type": Object {
+                  "kind": "ListType",
+                  "type": Object {
+                    "kind": "NonNullType",
+                    "type": Object {
+                      "kind": "NamedType",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "String",
+                      },
+                    },
+                  },
+                },
+                "variable": Object {
+                  "kind": "Variable",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "sortBy",
+                  },
+                },
+              },
             ],
           },
         ],
         "kind": "Document",
         "loc": Object {
-          "end": 825,
+          "end": 862,
           "start": 0,
         },
       }

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
@@ -5,6 +5,7 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
   columns={
     Array [
       Object {
+        "key": "name",
         "props": Object {
           "isStatic": true,
           "showLink": true,
@@ -27,6 +28,7 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
         ],
       },
       Object {
+        "key": "operatingSystem",
         "props": Object {
           "isStatic": true,
         },
@@ -106,6 +108,20 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
                       },
                     },
                   },
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "sortBy",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "sortBy",
+                      },
+                    },
+                  },
                 ],
                 "directives": Array [],
                 "kind": "Field",
@@ -537,12 +553,37 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
                 },
               },
             },
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "ListType",
+                "type": Object {
+                  "kind": "NonNullType",
+                  "type": Object {
+                    "kind": "NamedType",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "String",
+                    },
+                  },
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "sortBy",
+                },
+              },
+            },
           ],
         },
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 997,
+        "end": 1034,
         "start": 0,
       },
     }
@@ -564,6 +605,7 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
   columns={
     Array [
       Object {
+        "key": "name",
         "props": Object {
           "isStatic": true,
           "showLink": true,
@@ -586,6 +628,7 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
         ],
       },
       Object {
+        "key": "operatingSystem",
         "props": Object {
           "isStatic": true,
         },
@@ -665,6 +708,20 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
                       },
                     },
                   },
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "sortBy",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "sortBy",
+                      },
+                    },
+                  },
                 ],
                 "directives": Array [],
                 "kind": "Field",
@@ -1096,12 +1153,37 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
                 },
               },
             },
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "ListType",
+                "type": Object {
+                  "kind": "NonNullType",
+                  "type": Object {
+                    "kind": "NamedType",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "String",
+                    },
+                  },
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "sortBy",
+                },
+              },
+            },
           ],
         },
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 997,
+        "end": 1034,
         "start": 0,
       },
     }

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -264,6 +264,7 @@ exports[`ReportDetails expect to render without error 1`] = `
             columns={
               Array [
                 Object {
+                  "key": "name",
                   "props": Object {
                     "isStatic": true,
                     "showLink": true,
@@ -290,6 +291,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
+                    "width": 5,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -302,6 +304,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
+                    "width": 5,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -314,6 +317,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
+                    "width": 10,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -386,6 +390,20 @@ exports[`ReportDetails expect to render without error 1`] = `
                                 "name": Object {
                                   "kind": "Name",
                                   "value": "page",
+                                },
+                              },
+                            },
+                            Object {
+                              "kind": "Argument",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "sortBy",
+                              },
+                              "value": Object {
+                                "kind": "Variable",
+                                "name": Object {
+                                  "kind": "Name",
+                                  "value": "sortBy",
                                 },
                               },
                             },
@@ -820,12 +838,37 @@ exports[`ReportDetails expect to render without error 1`] = `
                           },
                         },
                       },
+                      Object {
+                        "defaultValue": undefined,
+                        "directives": Array [],
+                        "kind": "VariableDefinition",
+                        "type": Object {
+                          "kind": "ListType",
+                          "type": Object {
+                            "kind": "NonNullType",
+                            "type": Object {
+                              "kind": "NamedType",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "String",
+                              },
+                            },
+                          },
+                        },
+                        "variable": Object {
+                          "kind": "Variable",
+                          "name": Object {
+                            "kind": "Name",
+                            "value": "sortBy",
+                          },
+                        },
+                      },
                     ],
                   },
                 ],
                 "kind": "Document",
                 "loc": Object {
-                  "end": 997,
+                  "end": 1034,
                   "start": 0,
                 },
               }
@@ -1111,6 +1154,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
             columns={
               Array [
                 Object {
+                  "key": "name",
                   "props": Object {
                     "isStatic": true,
                     "showLink": true,
@@ -1137,6 +1181,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
+                    "width": 5,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -1149,6 +1194,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
+                    "width": 5,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -1161,6 +1207,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
+                    "width": 10,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -1233,6 +1280,20 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                                 "name": Object {
                                   "kind": "Name",
                                   "value": "page",
+                                },
+                              },
+                            },
+                            Object {
+                              "kind": "Argument",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "sortBy",
+                              },
+                              "value": Object {
+                                "kind": "Variable",
+                                "name": Object {
+                                  "kind": "Name",
+                                  "value": "sortBy",
                                 },
                               },
                             },
@@ -1667,12 +1728,37 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                           },
                         },
                       },
+                      Object {
+                        "defaultValue": undefined,
+                        "directives": Array [],
+                        "kind": "VariableDefinition",
+                        "type": Object {
+                          "kind": "ListType",
+                          "type": Object {
+                            "kind": "NonNullType",
+                            "type": Object {
+                              "kind": "NamedType",
+                              "name": Object {
+                                "kind": "Name",
+                                "value": "String",
+                              },
+                            },
+                          },
+                        },
+                        "variable": Object {
+                          "kind": "Variable",
+                          "name": Object {
+                            "kind": "Name",
+                            "value": "sortBy",
+                          },
+                        },
+                      },
                     ],
                   },
                 ],
                 "kind": "Document",
                 "loc": Object {
-                  "end": 997,
+                  "end": 1034,
                   "start": 0,
                 },
               }

--- a/src/SmartComponents/SystemsTable/Cells.js
+++ b/src/SmartComponents/SystemsTable/Cells.js
@@ -152,3 +152,11 @@ export const LastScanned = ({ testResultProfiles: profiles }) => {
 LastScanned.propTypes = {
     testResultProfiles: propTypes.array
 };
+
+export const operatingSystemString = ({ osMinorVersion, osMajorVersion }) => (
+    `RHEL ${osMajorVersion}.${osMinorVersion}`
+);
+
+export const OperatingSystem = (system) => (
+    operatingSystemString(system)
+);

--- a/src/SmartComponents/SystemsTable/Columns.js
+++ b/src/SmartComponents/SystemsTable/Columns.js
@@ -6,16 +6,27 @@ import { renderComponent } from 'Utilities/helpers';
 import {
     Name as NameCell, ComplianceScore as ComplianceScoreCell, DetailsLink as DetailsLinkCell,
     FailedRules as FailedRulesCell, LastScanned as LastScannedCell, Policies as PoliciesCell,
-    SSGVersions as SsgVersionCell, complianceScoreData, lastScanned
+    SSGVersions as SsgVersionCell, complianceScoreData, lastScanned, operatingSystemString,
+    OperatingSystem as OperatingSystemCell
 } from './Cells';
 
 const disableSorting = { isStatic: true };
 
-const operatingSystemString = ({ osMinorVersion, osMajorVersion }) => (
-    `RHEL ${osMajorVersion}.${osMinorVersion}`
-);
+export const compileColumnRenderFunc = ({ cell, ...column }) => ({
+    ...column,
+    renderFunc: renderComponent(cell, column.props)
+});
 
-export const Name = {
+export const customColumn = (column, props) => compileColumnRenderFunc({
+    ...column,
+    props: {
+        ...column.props,
+        ...props
+    }
+});
+
+export const Name = compileColumnRenderFunc({
+    key: 'name',
     title: 'Name',
     props: {
         width: 40,
@@ -24,8 +35,8 @@ export const Name = {
     renderExport: (system) => (
         `${ system.name } (${ operatingSystemString(system) })`
     ),
-    renderFunc: renderComponent(NameCell)
-};
+    cell: NameCell
+});
 
 export const customName = (props) => ({
     ...Name,
@@ -39,8 +50,8 @@ export const customName = (props) => ({
 export const SsgVersion = {
     title: 'SSG version',
     transforms: [nowrap],
-    props: disableSorting,
     exportKey: 'testResultProfiles',
+    props: disableSorting,
     renderExport: (testResultProfiles) => (
         testResultProfiles.map(({ supported, ssgVersion }) =>(
             `${ !supported ? '!' : '' }${ ssgVersion }`
@@ -78,6 +89,7 @@ export const FailedRules = {
     exportKey: 'testResultProfiles',
     transforms: [nowrap],
     props: {
+        width: 5,
         ...disableSorting
     },
     renderExport: (testResultProfiles) => (
@@ -91,6 +103,7 @@ export const ComplianceScore = {
     exportKey: 'testResultProfiles',
     transforms: [nowrap],
     props: {
+        width: 5,
         ...disableSorting
     },
     renderExport: (testResultProfiles) => (
@@ -104,6 +117,7 @@ export const LastScanned = {
     transforms: [nowrap],
     exportKey: 'testResultProfiles',
     props: {
+        width: 10,
         ...disableSorting
     },
     renderExport: (testResultProfiles) => (
@@ -112,14 +126,13 @@ export const LastScanned = {
     renderFunc: renderComponent(LastScannedCell)
 };
 
-export const OperatingSystem  = {
+export const OperatingSystem  = compileColumnRenderFunc({
     title: 'Operating system',
+    key: 'operatingSystem',
     transforms: [nowrap],
     props: disableSorting,
     renderExport: (cell) => (
         operatingSystemString(cell)
     ),
-    renderFunc: (_data, _id, system) => (
-        operatingSystemString(system)
-    )
-};
+    cell: OperatingSystemCell
+});

--- a/src/SmartComponents/SystemsTable/Columns.test.js
+++ b/src/SmartComponents/SystemsTable/Columns.test.js
@@ -1,0 +1,25 @@
+import { customColumn, compileColumnRenderFunc } from './Columns';
+
+const TestCell = () => (<span>Test Cell</span>);
+const column = {
+    key: 'columnKey',
+    title: 'Column title',
+    props: {
+        width: 40
+    },
+    cell: TestCell
+};
+
+describe('compileColumnRenderFunc', () => {
+    it('a column with a renderFunc', () => {
+        const compiledColumn = compileColumnRenderFunc(column);
+        expect(compiledColumn).toMatchSnapshot();
+    });
+});
+
+describe('compileColumnRenderFunc', () => {
+    it('a column with custom props appended', () => {
+        const customColumnResult = customColumn(column, { isStatic: true });
+        expect(customColumnResult).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/SystemsTable/InventoryTable.js
+++ b/src/SmartComponents/SystemsTable/InventoryTable.js
@@ -80,7 +80,7 @@ export const InventoryTable = ({
             ...policyId && { policyId }
         }
     });
-    const getEntities = useGetEntities(fetchSystems, { selected: selectedSystems });
+    const getEntities = useGetEntities(fetchSystems, { selected: selectedSystems, columns });
     const exportConfig = useSystemsExport({
         columns,
         filter: systemsFilter,

--- a/src/SmartComponents/SystemsTable/__snapshots__/Columns.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/Columns.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compileColumnRenderFunc a column with a renderFunc 1`] = `
+Object {
+  "key": "columnKey",
+  "props": Object {
+    "width": 40,
+  },
+  "renderFunc": [Function],
+  "title": "Column title",
+}
+`;
+
+exports[`compileColumnRenderFunc a column with custom props appended 1`] = `
+Object {
+  "key": "columnKey",
+  "props": Object {
+    "isStatic": true,
+    "width": 40,
+  },
+  "renderFunc": [Function],
+  "title": "Column title",
+}
+`;

--- a/src/SmartComponents/SystemsTable/__snapshots__/hooks.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/hooks.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`useGetEntities returns a getEntities function 1`] = `[Function]`;
+
+exports[`useGetEntities the returned function calls mockFetch 1`] = `
+Object {
+  "orderBy": "name",
+  "orderDirection": "ASC",
+  "results": Array [
+    Object {
+      "id": 1,
+      "name": "TEST ENTITY NAME",
+      "selected": false,
+    },
+  ],
+  "total": 0,
+}
+`;
+
 exports[`useSystemsExport returns a export configuration 1`] = `
 Object {
   "isDisabled": false,

--- a/src/SmartComponents/SystemsTable/constants.js
+++ b/src/SmartComponents/SystemsTable/constants.js
@@ -7,8 +7,8 @@ import { getRegistry } from '@redhat-cloud-services/frontend-components-utilitie
 import { entitiesReducer } from 'Store/Reducers/SystemStore';
 
 export const GET_SYSTEMS = gql`
-query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
-    systems(search: $filter, limit: $perPage, offset: $page) {
+query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int, $sortBy: [String!]) {
+    systems(search: $filter, limit: $perPage, offset: $page, sortBy: $sortBy) {
         totalCount
         edges {
             node {
@@ -45,8 +45,8 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
 `;
 
 export const GET_SYSTEMS_WITHOUT_FAILED_RULES = gql`
-query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int) {
-    systems(search: $filter, limit: $perPage, offset: $page) {
+query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int, $sortBy: [String!]) {
+    systems(search: $filter, limit: $perPage, offset: $page, sortBy: $sortBy) {
         totalCount
         edges {
             node {

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -94,8 +94,7 @@ export const useGetEntities = (fetchEntities, { selected, columns } = {}) => {
     );
 
     return async (_ids, { page = 1, per_page: perPage, orderBy, orderDirection, filters }) => {
-        const columnKey = orderBy.split(' ')[0];
-        const sortableColumn = findColumnByKey(columnKey);
+        const sortableColumn = findColumnByKey(orderBy);
         const sortBy = sortableColumn && sortableColumn.sortBy ?
             appendDirection(sortableColumn.sortBy, orderDirection) : undefined;
 

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -24,7 +24,8 @@ export const entitiesReducer = (INVENTORY_ACTION, columns) => applyReducerHash({
     }),
     ['RESET_PAGE']: (state) => ({
         ...state,
-        page: 1
+        page: 1,
+        columns: []
     }),
     ['SELECT_ENTITIES']: (state, { payload: { selected } }) => ({
         ...state,


### PR DESCRIPTION
This adds sorting to the SystemsTable. For now only for the name and operating system column, and only in the Wizard, but we can gradually add more columns when we implement the backend part for them.


https://user-images.githubusercontent.com/7757/122219630-e9150680-ceaf-11eb-9e7a-703117929705.mp4


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
