### PR TITLE
fix(SystemsTable): RHICOMPL-1799 - Use nowrap instead of fitcontent

### DIFF
--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
@@ -24,9 +24,6 @@ exports[`EditPolicySystems expect to render without error 1`] = `
               "renderExport": [Function],
               "renderFunc": [Function],
               "title": "Name",
-              "transforms": Array [
-                [Function],
-              ],
             },
             Object {
               "props": Object {

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -13,9 +13,6 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
           "renderExport": [Function],
           "renderFunc": [Function],
           "title": "Name",
-          "transforms": Array [
-            [Function],
-          ],
         },
         Object {
           "props": Object {
@@ -533,9 +530,6 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
           "renderExport": [Function],
           "renderFunc": [Function],
           "title": "Name",
-          "transforms": Array [
-            [Function],
-          ],
         },
         Object {
           "props": Object {

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
@@ -13,9 +13,6 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
         "renderExport": [Function],
         "renderFunc": [Function],
         "title": "Name",
-        "transforms": Array [
-          [Function],
-        ],
       },
       Object {
         "exportKey": "testResultProfiles",
@@ -575,9 +572,6 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
         "renderExport": [Function],
         "renderFunc": [Function],
         "title": "Name",
-        "transforms": Array [
-          [Function],
-        ],
       },
       Object {
         "exportKey": "testResultProfiles",

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -273,9 +273,6 @@ exports[`ReportDetails expect to render without error 1`] = `
                   "renderExport": [Function],
                   "renderFunc": [Function],
                   "title": "Name",
-                  "transforms": Array [
-                    [Function],
-                  ],
                 },
                 Object {
                   "exportKey": "testResultProfiles",
@@ -293,7 +290,6 @@ exports[`ReportDetails expect to render without error 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
-                    "width": 5,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -306,7 +302,6 @@ exports[`ReportDetails expect to render without error 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
-                    "width": 5,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -316,13 +311,9 @@ exports[`ReportDetails expect to render without error 1`] = `
                   ],
                 },
                 Object {
-                  "cellTransforms": Array [
-                    [Function],
-                  ],
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
-                    "width": 10,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -1129,9 +1120,6 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "renderExport": [Function],
                   "renderFunc": [Function],
                   "title": "Name",
-                  "transforms": Array [
-                    [Function],
-                  ],
                 },
                 Object {
                   "exportKey": "testResultProfiles",
@@ -1149,7 +1137,6 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
-                    "width": 5,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -1162,7 +1149,6 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
-                    "width": 5,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],
@@ -1172,13 +1158,9 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   ],
                 },
                 Object {
-                  "cellTransforms": Array [
-                    [Function],
-                  ],
                   "exportKey": "testResultProfiles",
                   "props": Object {
                     "isStatic": true,
-                    "width": 10,
                   },
                   "renderExport": [Function],
                   "renderFunc": [Function],

--- a/src/SmartComponents/SystemsTable/Columns.js
+++ b/src/SmartComponents/SystemsTable/Columns.js
@@ -1,4 +1,4 @@
-import { fitContent } from '@patternfly/react-table';
+import { nowrap } from '@patternfly/react-table';
 import { complianceScoreString } from 'PresentationalComponents';
 import { profilesRulesFailed } from 'Utilities/ruleHelpers';
 import { renderComponent } from 'Utilities/helpers';
@@ -17,7 +17,6 @@ const operatingSystemString = ({ osMinorVersion, osMajorVersion }) => (
 
 export const Name = {
     title: 'Name',
-    transforms: [fitContent],
     props: {
         width: 40,
         ...disableSorting
@@ -39,7 +38,7 @@ export const customName = (props) => ({
 
 export const SsgVersion = {
     title: 'SSG version',
-    transforms: [fitContent],
+    transforms: [nowrap],
     props: disableSorting,
     exportKey: 'testResultProfiles',
     renderExport: (testResultProfiles) => (
@@ -52,7 +51,7 @@ export const SsgVersion = {
 
 export const Policies = {
     title: 'Policies',
-    transforms: [fitContent],
+    transforms: [nowrap],
     exportKey: 'policies',
     renderExport: (policies) => (
         policies.map(({ name }) => (name)).join(', ')
@@ -76,10 +75,9 @@ export const DetailsLink = {
 
 export const FailedRules = {
     title: 'Failed rules',
-    transforms: [fitContent],
     exportKey: 'testResultProfiles',
+    transforms: [nowrap],
     props: {
-        width: 5,
         ...disableSorting
     },
     renderExport: (testResultProfiles) => (
@@ -90,10 +88,9 @@ export const FailedRules = {
 
 export const ComplianceScore = {
     title: 'Compliance score',
-    transforms: [fitContent],
     exportKey: 'testResultProfiles',
+    transforms: [nowrap],
     props: {
-        width: 5,
         ...disableSorting
     },
     renderExport: (testResultProfiles) => (
@@ -104,11 +101,9 @@ export const ComplianceScore = {
 
 export const LastScanned = {
     title: 'Last scanned',
-    transforms: [fitContent],
-    cellTransforms: [fitContent],
+    transforms: [nowrap],
     exportKey: 'testResultProfiles',
     props: {
-        width: 10,
         ...disableSorting
     },
     renderExport: (testResultProfiles) => (
@@ -119,7 +114,7 @@ export const LastScanned = {
 
 export const OperatingSystem  = {
     title: 'Operating system',
-    transforms: [fitContent],
+    transforms: [nowrap],
     props: disableSorting,
     renderExport: (cell) => (
         operatingSystemString(cell)


### PR DESCRIPTION
Using `fitcontent` would cause columns to unneccesaarily shrink and lead to undesired column widths especially with the last column:

![Screenshot 2021-06-04 at 15 37 29](https://user-images.githubusercontent.com/7757/120810454-5b4e2880-c54b-11eb-965a-b2fc072c4ea0.png)
 
Using `nowrap` instead still mitigates column headers to not truncate, but does not cause odd column widths:

![Screenshot 2021-06-04 at 15 36 40](https://user-images.githubusercontent.com/7757/120810593-7c167e00-c54b-11eb-8051-eb1f2b931a91.png)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices