### PR TITLE
fix(CreatePolicy): RHICOMPL-1815 - Remove style props to fix aligment

### DIFF
--- a/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
+++ b/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
@@ -29,7 +29,9 @@ const SSGVersionText = ({ profile, newOsMinorVersion }) => (
             position='right'
             bodyContent={ <SSGPopoverBody { ...{ profile, newOsMinorVersion } } /> }
             footerContent={ <SupportedSSGVersionsLink /> }>
-            <OutlinedQuestionCircleIcon style={ { cursor: 'pointer' } } />
+            <span style={ { cursor: 'pointer' } }>
+                <OutlinedQuestionCircleIcon className="grey-icon" />
+            </span>
         </Popover>
     </Text>
 );

--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy.js
@@ -53,7 +53,7 @@ const PolicyTooltip = () => (
         position="right"
         content="Policy types are OpenSCAP policies that are supported by RHEL.
         For each major version of RHEL, users can create one policy of each type.">
-        <OutlinedQuestionCircleIcon style={{ opacity: 0.5 }}/>
+        <OutlinedQuestionCircleIcon className="grey-icon"/>
     </Tooltip>
 );
 


### PR DESCRIPTION
Similar to https://github.com/RedHatInsights/compliance-frontend/pull/1264, this removes the style prop to fix the alignment of the icon.

Before:

![Screenshot 2021-06-04 at 16 55 09](https://user-images.githubusercontent.com/7757/120822016-43c86d00-c556-11eb-8c43-509a48d365f4.png)

After:

![Screenshot 2021-06-04 at 16 55 35](https://user-images.githubusercontent.com/7757/120822026-462ac700-c556-11eb-84ea-0bb020679451.png)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
