### PR TITLE
fix(TableTools): RHICOMPL-942 - Sort items not orderArray

### DIFF
--- a/src/Utilities/__snapshots__/helpers.test.js.snap
+++ b/src/Utilities/__snapshots__/helpers.test.js.snap
@@ -13,3 +13,133 @@ exports[`camelCase should camelCase a string 5`] = `"TestCaseWithMultipleWords"`
 exports[`getPropery should return values of keys 1`] = `"value-level-3"`;
 
 exports[`getPropery should return values of keys 2`] = `"value-level-2"`;
+
+exports[`orderByArray sorts an array asc 1`] = `
+Array [
+  Object {
+    "description": "DESCRIPTION",
+    "id": 4,
+    "name": "TEST ITEM #4",
+    "severity": "high",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 8,
+    "name": "TEST ITEM #8",
+    "severity": "high",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 1,
+    "name": "TEST ITEM #1",
+    "severity": "medium",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 5,
+    "name": "TEST ITEM #5",
+    "severity": "medium",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 9,
+    "name": "TEST ITEM #9",
+    "severity": "medium",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 2,
+    "name": "TEST ITEM #2",
+    "severity": "low",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 6,
+    "name": "TEST ITEM #6",
+    "severity": "low",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 10,
+    "name": "TEST ITEM #10",
+    "severity": "low",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 3,
+    "name": "TEST ITEM #3",
+    "severity": "unknown",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 7,
+    "name": "TEST ITEM #7",
+    "severity": "unknown",
+  },
+]
+`;
+
+exports[`orderByArray sorts an array desc 1`] = `
+Array [
+  Object {
+    "description": "DESCRIPTION",
+    "id": 7,
+    "name": "TEST ITEM #7",
+    "severity": "unknown",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 3,
+    "name": "TEST ITEM #3",
+    "severity": "unknown",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 10,
+    "name": "TEST ITEM #10",
+    "severity": "low",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 6,
+    "name": "TEST ITEM #6",
+    "severity": "low",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 2,
+    "name": "TEST ITEM #2",
+    "severity": "low",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 9,
+    "name": "TEST ITEM #9",
+    "severity": "medium",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 5,
+    "name": "TEST ITEM #5",
+    "severity": "medium",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 1,
+    "name": "TEST ITEM #1",
+    "severity": "medium",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 8,
+    "name": "TEST ITEM #8",
+    "severity": "high",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 4,
+    "name": "TEST ITEM #4",
+    "severity": "high",
+  },
+]
+`;

--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -40,11 +40,12 @@ export const orderArrayByProp = (property, objects, direction) => (
     })
 );
 
-export const orderByArray = (objectArray, orderProp, orderArray, direction) => (
-    (direction !== 'asc' ? orderArray.reverse() : orderArray).flatMap((orderKey) => (
+export const orderByArray = (objectArray, orderProp, orderArray, direction) => {
+    const sortedObjectArray = orderArray.flatMap((orderKey) => (
         objectArray.filter((item) => (item[orderProp] === orderKey))
-    ))
-);
+    ));
+    return (direction !== 'asc' ? sortedObjectArray.reverse() : sortedObjectArray);
+};
 
 export const getProperty = (obj, path, fallback) => {
     const parts = path.split('.');

--- a/src/Utilities/helpers.test.js
+++ b/src/Utilities/helpers.test.js
@@ -1,4 +1,7 @@
-import { camelCase, getProperty, uniq, sortingByProp } from './helpers';
+import {
+    camelCase, getProperty, uniq, sortingByProp, orderByArray
+} from './helpers';
+import items, { severityLevels } from './hooks/useTableTools/__fixtures__/items';
 
 describe('uniq', () => {
     it('should deduplicate items', () => {
@@ -75,6 +78,22 @@ describe('sortingByProp', () => {
             { prop: 'c' },
             { prop: 'd' }
         ]);
+    });
+});
+
+describe('orderByArray', () => {
+    const exampleItems = items(10);
+
+    it('sorts an array asc', () => {
+        expect(orderByArray(
+            exampleItems, 'severity', severityLevels, 'asc'
+        )).toMatchSnapshot();
+    });
+
+    it('sorts an array desc', () => {
+        expect(orderByArray(
+            exampleItems, 'severity', severityLevels, 'desc'
+        )).toMatchSnapshot();
     });
 });
 


### PR DESCRIPTION
Sorting the `orderArray` instead of the array with items, apparently didn't work. 
I'm unsure why it doesn't work anymore or why it worked before. 🤷 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
