### PR TITLE
fix{RulesTable): Pass on custom table options

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -25,6 +25,7 @@ const RulesTable = ({
     handleSelect,
     selectedRefIds = [],
     hidePassed = false,
+    options,
     ...rulesTableProps
 }) => {
     const rules = toRulesArrayWithProfile(profileRules);
@@ -51,6 +52,7 @@ const RulesTable = ({
             }
         }}
         options={{
+            ...options,
             identifier: (item) => (item.refId),
             selectable: !!handleSelect || remediationsEnabled,
             onSelect: handleSelect,
@@ -82,7 +84,8 @@ RulesTable.propTypes = {
     selectedRefIds: propTypes.array,
     selectedFilter: propTypes.bool,
     handleSelect: propTypes.func,
-    columns: propTypes.array
+    columns: propTypes.array,
+    options: propTypes.object
 };
 
 export default RulesTable;

--- a/src/PresentationalComponents/RulesTable/RulesTable.test.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.test.js
@@ -3,11 +3,29 @@ import { policies } from '@/__fixtures__/policies';
 import RulesTable from './RulesTable';
 
 describe('RulesTable', () => {
-    it('expect to render without error', () => {
-        const profile = policies.edges[0].node.policy.profiles;
+    const profiles = policies.edges[0].node.policy.profiles;
+    const defaultProps = {
+        profileRules: profiles,
+        system: {
+            id: 1
+        }
+    };
 
+    it('expect to render without error', () => {
         let wrapper = shallow(
-            <RulesTable profileRules={ profile } system={ { id: 1 } } />
+            <RulesTable { ...defaultProps } />
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to pass on options', () => {
+        let wrapper = shallow(
+            <RulesTable { ...{
+                ...defaultProps,
+                options: {
+                    additionalTableToolsOption: true
+                }
+            } } />
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/PresentationalComponents/RulesTable/__snapshots__/RulesTable.test.js.snap
+++ b/src/PresentationalComponents/RulesTable/__snapshots__/RulesTable.test.js.snap
@@ -1,5 +1,259 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RulesTable expect to pass on options 1`] = `
+<TableToolsTable
+  aria-label="Rules Table"
+  columns={
+    Array [
+      Object {
+        "renderFunc": [Function],
+        "sortByProp": "title",
+        "title": "Name",
+      },
+      Object {
+        "renderFunc": [Function],
+        "sortByFunction": [Function],
+        "title": "Policy",
+      },
+      Object {
+        "renderFunc": [Function],
+        "sortByArray": Array [
+          "high",
+          "medium",
+          "low",
+          "unknown",
+        ],
+        "sortByProp": "severity",
+        "title": "Severity",
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "renderFunc": [Function],
+        "sortByProp": "compliant",
+        "title": "Passed",
+      },
+      Object {
+        "original": "Ansible",
+        "props": Object {
+          "tooltip": "Ansible",
+        },
+        "renderFunc": [Function],
+        "sortByProp": "remediationAvailable",
+        "title": <span>
+          <AnsibeTowerIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+           Ansible
+        </span>,
+        "transforms": Array [
+          [Function],
+        ],
+      },
+    ]
+  }
+  filters={
+    Object {
+      "activeFilters": Object {
+        "passed": undefined,
+      },
+      "filterConfig": Array [
+        Object {
+          "filter": [Function],
+          "label": "Name",
+          "type": "text",
+        },
+        Object {
+          "filter": [Function],
+          "items": Array [
+            Object {
+              "label": <span>
+                <ExclamationCircleIcon
+                  className="ins-u-failed"
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                />
+                 High
+              </span>,
+              "value": "high",
+            },
+            Object {
+              "label": <span>
+                <ExclamationTriangleIcon
+                  className="ins-u-warning"
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                />
+                 Medium
+              </span>,
+              "value": "medium",
+            },
+            Object {
+              "label": <span>
+                <LowSeverityIcon />
+                 Low
+              </span>,
+              "value": "low",
+            },
+            Object {
+              "label": <span>
+                <QuestionCircleIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                />
+                 Unknown
+              </span>,
+              "value": "unknown",
+            },
+          ],
+          "label": "Severity",
+          "type": "checkbox",
+        },
+        Object {
+          "filter": [Function],
+          "items": Array [
+            Object {
+              "label": "Passed rules",
+              "value": "passed",
+            },
+            Object {
+              "label": "Failed rules",
+              "value": "failed",
+            },
+          ],
+          "label": "Passed",
+          "type": "checkbox",
+        },
+      ],
+    }
+  }
+  items={
+    Array [
+      Object {
+        "__typename": "Rule",
+        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+        "identifier": null,
+        "profile": undefined,
+        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+        "references": Array [],
+        "remediationAvailable": false,
+        "severity": "medium",
+        "title": "Record Attempts to Alter the localtime File",
+      },
+      Object {
+        "__typename": "Rule",
+        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+        "identifier": null,
+        "profile": undefined,
+        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+        "references": Array [],
+        "remediationAvailable": false,
+        "severity": "medium",
+        "title": "Record Attempts to Alter Time Through clock_settime",
+      },
+      Object {
+        "__typename": "Rule",
+        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+        "identifier": null,
+        "profile": undefined,
+        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+        "references": Array [],
+        "remediationAvailable": false,
+        "severity": "medium",
+        "title": "Record Attempts to Alter the localtime File",
+      },
+      Object {
+        "__typename": "Rule",
+        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+        "identifier": null,
+        "profile": undefined,
+        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+        "references": Array [],
+        "remediationAvailable": false,
+        "severity": "medium",
+        "title": "Record Attempts to Alter Time Through clock_settime",
+      },
+      Object {
+        "__typename": "Rule",
+        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+        "identifier": null,
+        "profile": undefined,
+        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+        "references": Array [],
+        "remediationAvailable": false,
+        "severity": "medium",
+        "title": "Record Attempts to Alter the localtime File",
+      },
+      Object {
+        "__typename": "Rule",
+        "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+        "identifier": null,
+        "profile": undefined,
+        "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+        "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+        "references": Array [],
+        "remediationAvailable": false,
+        "severity": "medium",
+        "title": "Record Attempts to Alter Time Through clock_settime",
+      },
+    ]
+  }
+  options={
+    Object {
+      "additionalTableToolsOption": true,
+      "dedicatedAction": [Function],
+      "detailsComponent": [Function],
+      "emptyRows": Array [
+        Object {
+          "cells": Array [
+            Object {
+              "props": Object {
+                "colSpan": 5,
+              },
+              "title": <EmptyTable>
+                <Bullseye>
+                  <EmptyState
+                    variant="full"
+                  >
+                    <Title
+                      headingLevel="h5"
+                      size="lg"
+                    >
+                      No matching rules found
+                    </Title>
+                    <EmptyStateBody>
+                      This filter criteria matches no rules. 
+                      <br />
+                       Try changing your filter settings.
+                    </EmptyStateBody>
+                  </EmptyState>
+                </Bullseye>
+              </EmptyTable>,
+            },
+          ],
+        },
+      ],
+      "identifier": [Function],
+      "onSelect": undefined,
+      "preselected": Array [],
+      "selectable": true,
+      "selectedFilter": false,
+    }
+  }
+/>
+`;
+
 exports[`RulesTable expect to render without error 1`] = `
 <TableToolsTable
   aria-label="Rules Table"


### PR DESCRIPTION
The `RulesTable` is not passing on custom options for the table properly, which caused the options being overwritten via the `rulesTableProps` when a custom `options` prop is passed in.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
