### PR TITLE
feat(SystemsTable): Enable tags and tag filtering

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -44,6 +44,7 @@ export const ComplianceSystems = () => {
                                     showLink: true,
                                     showOsInfo: true
                                 }),
+                                Columns.inventoryColumn('tags'),
                                 Columns.Policies,
                                 Columns.DetailsLink
                             ]}

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -73,7 +73,9 @@ export const EditPolicySystems = ({ change, osMajorVersion, selectedSystems }) =
                                 width: 40
                             },
                             sortBy: ['name']
-                        }, {
+                        },
+                        Columns.inventoryColumn('tags'),
+                        {
                             ...Columns.OperatingSystem,
                             props: {},
                             sortBy: ['osMajorVersion', 'osMinorVersion']

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
@@ -28,6 +28,7 @@ exports[`EditPolicySystems expect to render without error 1`] = `
               ],
               "title": "Name",
             },
+            "tags",
             Object {
               "key": "operatingSystem",
               "props": Object {},
@@ -419,6 +420,54 @@ exports[`EditPolicySystems expect to render without error 1`] = `
                                           ],
                                         },
                                       },
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "tags",
+                                        },
+                                        "selectionSet": Object {
+                                          "kind": "SelectionSet",
+                                          "selections": Array [
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "namespace",
+                                              },
+                                              "selectionSet": undefined,
+                                            },
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "key",
+                                              },
+                                              "selectionSet": undefined,
+                                            },
+                                            Object {
+                                              "alias": undefined,
+                                              "arguments": Array [],
+                                              "directives": Array [],
+                                              "kind": "Field",
+                                              "name": Object {
+                                                "kind": "Name",
+                                                "value": "value",
+                                              },
+                                              "selectionSet": undefined,
+                                            },
+                                          ],
+                                        },
+                                      },
                                     ],
                                   },
                                 },
@@ -540,7 +589,7 @@ exports[`EditPolicySystems expect to render without error 1`] = `
             ],
             "kind": "Document",
             "loc": Object {
-              "end": 862,
+              "end": 983,
               "start": 0,
             },
           }

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -48,6 +48,7 @@ const EditPolicySystemsTab = ({ policy: { osMajorVersion }, newRuleTabs, onSyste
             <InventoryTable
                 columns={[
                     Columns.Name,
+                    Columns.inventoryColumn('tags'),
                     Columns.OperatingSystem
                 ]}
                 showOsMinorVersionFilter={ [osMajorVersion] }

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -15,6 +15,7 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
           "renderFunc": [Function],
           "title": "Name",
         },
+        "tags",
         Object {
           "key": "operatingSystem",
           "props": Object {
@@ -403,6 +404,54 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
                                       ],
                                     },
                                   },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "tags",
+                                    },
+                                    "selectionSet": Object {
+                                      "kind": "SelectionSet",
+                                      "selections": Array [
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "namespace",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "key",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "value",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                      ],
+                                    },
+                                  },
                                 ],
                               },
                             },
@@ -524,7 +573,7 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
         ],
         "kind": "Document",
         "loc": Object {
-          "end": 862,
+          "end": 983,
           "start": 0,
         },
       }
@@ -573,6 +622,7 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
           "renderFunc": [Function],
           "title": "Name",
         },
+        "tags",
         Object {
           "key": "operatingSystem",
           "props": Object {
@@ -961,6 +1011,54 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
                                       ],
                                     },
                                   },
+                                  Object {
+                                    "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "tags",
+                                    },
+                                    "selectionSet": Object {
+                                      "kind": "SelectionSet",
+                                      "selections": Array [
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "namespace",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "key",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                        Object {
+                                          "alias": undefined,
+                                          "arguments": Array [],
+                                          "directives": Array [],
+                                          "kind": "Field",
+                                          "name": Object {
+                                            "kind": "Name",
+                                            "value": "value",
+                                          },
+                                          "selectionSet": undefined,
+                                        },
+                                      ],
+                                    },
+                                  },
                                 ],
                               },
                             },
@@ -1082,7 +1180,7 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
         ],
         "kind": "Document",
         "loc": Object {
-          "end": 862,
+          "end": 983,
           "start": 0,
         },
       }

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -12,6 +12,7 @@ const PolicySystemsTab = ({ policy }) => (
             Columns.customName({
                 showLink: true
             }),
+            Columns.inventoryColumn('tags'),
             Columns.SsgVersion,
             Columns.OperatingSystem
         ]}

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
@@ -15,6 +15,7 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
         "renderFunc": [Function],
         "title": "Name",
       },
+      "tags",
       Object {
         "exportKey": "testResultProfiles",
         "props": Object {
@@ -462,6 +463,54 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
                                     ],
                                   },
                                 },
+                                Object {
+                                  "alias": undefined,
+                                  "arguments": Array [],
+                                  "directives": Array [],
+                                  "kind": "Field",
+                                  "name": Object {
+                                    "kind": "Name",
+                                    "value": "tags",
+                                  },
+                                  "selectionSet": Object {
+                                    "kind": "SelectionSet",
+                                    "selections": Array [
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "namespace",
+                                        },
+                                        "selectionSet": undefined,
+                                      },
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "key",
+                                        },
+                                        "selectionSet": undefined,
+                                      },
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "value",
+                                        },
+                                        "selectionSet": undefined,
+                                      },
+                                    ],
+                                  },
+                                },
                               ],
                             },
                           },
@@ -583,7 +632,7 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 1034,
+        "end": 1155,
         "start": 0,
       },
     }
@@ -615,6 +664,7 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
         "renderFunc": [Function],
         "title": "Name",
       },
+      "tags",
       Object {
         "exportKey": "testResultProfiles",
         "props": Object {
@@ -1062,6 +1112,54 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
                                     ],
                                   },
                                 },
+                                Object {
+                                  "alias": undefined,
+                                  "arguments": Array [],
+                                  "directives": Array [],
+                                  "kind": "Field",
+                                  "name": Object {
+                                    "kind": "Name",
+                                    "value": "tags",
+                                  },
+                                  "selectionSet": Object {
+                                    "kind": "SelectionSet",
+                                    "selections": Array [
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "namespace",
+                                        },
+                                        "selectionSet": undefined,
+                                      },
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "key",
+                                        },
+                                        "selectionSet": undefined,
+                                      },
+                                      Object {
+                                        "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "value",
+                                        },
+                                        "selectionSet": undefined,
+                                      },
+                                    ],
+                                  },
+                                },
                               ],
                             },
                           },
@@ -1183,7 +1281,7 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 1034,
+        "end": 1155,
         "start": 0,
       },
     }

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -171,6 +171,7 @@ export const ReportDetails = ({ route }) => {
                                     showLink: true,
                                     showOsInfo: true
                                 }),
+                                Columns.inventoryColumn('tags'),
                                 Columns.SsgVersion,
                                 Columns.FailedRules,
                                 Columns.ComplianceScore,

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -275,6 +275,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                   "renderFunc": [Function],
                   "title": "Name",
                 },
+                "tags",
                 Object {
                   "exportKey": "testResultProfiles",
                   "props": Object {
@@ -747,6 +748,54 @@ exports[`ReportDetails expect to render without error 1`] = `
                                               ],
                                             },
                                           },
+                                          Object {
+                                            "alias": undefined,
+                                            "arguments": Array [],
+                                            "directives": Array [],
+                                            "kind": "Field",
+                                            "name": Object {
+                                              "kind": "Name",
+                                              "value": "tags",
+                                            },
+                                            "selectionSet": Object {
+                                              "kind": "SelectionSet",
+                                              "selections": Array [
+                                                Object {
+                                                  "alias": undefined,
+                                                  "arguments": Array [],
+                                                  "directives": Array [],
+                                                  "kind": "Field",
+                                                  "name": Object {
+                                                    "kind": "Name",
+                                                    "value": "namespace",
+                                                  },
+                                                  "selectionSet": undefined,
+                                                },
+                                                Object {
+                                                  "alias": undefined,
+                                                  "arguments": Array [],
+                                                  "directives": Array [],
+                                                  "kind": "Field",
+                                                  "name": Object {
+                                                    "kind": "Name",
+                                                    "value": "key",
+                                                  },
+                                                  "selectionSet": undefined,
+                                                },
+                                                Object {
+                                                  "alias": undefined,
+                                                  "arguments": Array [],
+                                                  "directives": Array [],
+                                                  "kind": "Field",
+                                                  "name": Object {
+                                                    "kind": "Name",
+                                                    "value": "value",
+                                                  },
+                                                  "selectionSet": undefined,
+                                                },
+                                              ],
+                                            },
+                                          },
                                         ],
                                       },
                                     },
@@ -868,7 +917,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                 ],
                 "kind": "Document",
                 "loc": Object {
-                  "end": 1034,
+                  "end": 1155,
                   "start": 0,
                 },
               }
@@ -1165,6 +1214,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                   "renderFunc": [Function],
                   "title": "Name",
                 },
+                "tags",
                 Object {
                   "exportKey": "testResultProfiles",
                   "props": Object {
@@ -1637,6 +1687,54 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                                               ],
                                             },
                                           },
+                                          Object {
+                                            "alias": undefined,
+                                            "arguments": Array [],
+                                            "directives": Array [],
+                                            "kind": "Field",
+                                            "name": Object {
+                                              "kind": "Name",
+                                              "value": "tags",
+                                            },
+                                            "selectionSet": Object {
+                                              "kind": "SelectionSet",
+                                              "selections": Array [
+                                                Object {
+                                                  "alias": undefined,
+                                                  "arguments": Array [],
+                                                  "directives": Array [],
+                                                  "kind": "Field",
+                                                  "name": Object {
+                                                    "kind": "Name",
+                                                    "value": "namespace",
+                                                  },
+                                                  "selectionSet": undefined,
+                                                },
+                                                Object {
+                                                  "alias": undefined,
+                                                  "arguments": Array [],
+                                                  "directives": Array [],
+                                                  "kind": "Field",
+                                                  "name": Object {
+                                                    "kind": "Name",
+                                                    "value": "key",
+                                                  },
+                                                  "selectionSet": undefined,
+                                                },
+                                                Object {
+                                                  "alias": undefined,
+                                                  "arguments": Array [],
+                                                  "directives": Array [],
+                                                  "kind": "Field",
+                                                  "name": Object {
+                                                    "kind": "Name",
+                                                    "value": "value",
+                                                  },
+                                                  "selectionSet": undefined,
+                                                },
+                                              ],
+                                            },
+                                          },
                                         ],
                                       },
                                     },
@@ -1758,7 +1856,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 ],
                 "kind": "Document",
                 "loc": Object {
-                  "end": 1034,
+                  "end": 1155,
                   "start": 0,
                 },
               }

--- a/src/SmartComponents/SystemsTable/Columns.js
+++ b/src/SmartComponents/SystemsTable/Columns.js
@@ -136,3 +136,5 @@ export const OperatingSystem  = compileColumnRenderFunc({
     ),
     cell: OperatingSystemCell
 });
+
+export const inventoryColumn = (column) => (column);

--- a/src/SmartComponents/SystemsTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/InventoryTable.test.js.snap
@@ -44,6 +44,7 @@ exports[`InventoryTable returns 1`] = `
           "onSelect": false,
         }
       }
+      columns={[Function]}
       dedicatedAction={
         <Memo(Connect(ComplianceRemediationButton))
           allSystems={Array []}
@@ -235,6 +236,7 @@ exports[`InventoryTable returns compact 1`] = `
           "onSelect": false,
         }
       }
+      columns={[Function]}
       dedicatedAction={
         <Memo(Connect(ComplianceRemediationButton))
           allSystems={Array []}
@@ -420,6 +422,7 @@ exports[`InventoryTable returns showAllSystems 1`] = `
           "onSelect": false,
         }
       }
+      columns={[Function]}
       exportConfig={
         Object {
           "isDisabled": true,
@@ -498,6 +501,7 @@ exports[`InventoryTable returns with a showComplianceSystemsInfo 1`] = `
           "onSelect": false,
         }
       }
+      columns={[Function]}
       dedicatedAction={
         <Memo(Connect(ComplianceRemediationButton))
           allSystems={Array []}
@@ -689,6 +693,7 @@ exports[`InventoryTable returns with compliantFilter 1`] = `
           "onSelect": false,
         }
       }
+      columns={[Function]}
       dedicatedAction={
         <Memo(Connect(ComplianceRemediationButton))
           allSystems={Array []}
@@ -928,6 +933,7 @@ exports[`InventoryTable returns with showOnlySystemsWithTestResults 1`] = `
           "onSelect": false,
         }
       }
+      columns={[Function]}
       dedicatedAction={
         <Memo(Connect(ComplianceRemediationButton))
           allSystems={Array []}
@@ -1111,6 +1117,7 @@ exports[`InventoryTable returns without actions 1`] = `
           "onSelect": false,
         }
       }
+      columns={[Function]}
       dedicatedAction={
         <Memo(Connect(ComplianceRemediationButton))
           allSystems={Array []}
@@ -1302,6 +1309,7 @@ exports[`InventoryTable returns without remediations 1`] = `
           "onSelect": false,
         }
       }
+      columns={[Function]}
       exportConfig={
         Object {
           "isDisabled": true,

--- a/src/SmartComponents/SystemsTable/constants.js
+++ b/src/SmartComponents/SystemsTable/constants.js
@@ -38,6 +38,11 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int, $so
                     id
                     name
                 }
+                tags {
+                    namespace
+                    key
+                    value
+                }
             }
         }
     }
@@ -70,6 +75,11 @@ query getSystems($filter: String!, $policyId: ID, $perPage: Int, $page: Int, $so
                 policies(policyId: $policyId) {
                     id
                     name
+                }
+                tags {
+                    namespace
+                    key
+                    value
                 }
             }
         }

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -84,6 +84,22 @@ export const useFetchSystems = ({
     );
 };
 
+const buildApiFilters = (filters = {}) => {
+    const { tagFilters, ...otherFilters } = filters;
+    const tagsApiFilter = tagFilters ? {
+        tags: tagFilters.flatMap((tagFilter) => (
+            tagFilter.values.map((tag) => (
+                `${ encodeURIComponent(tagFilter.key) }/${ encodeURIComponent(tag.tagKey) }=${ encodeURIComponent(tag.value) }`
+            ))
+        ))
+    } : {};
+
+    return {
+        ...otherFilters,
+        ...tagsApiFilter
+    };
+};
+
 export const useGetEntities = (fetchEntities, { selected, columns } = {}) => {
     const appendDirection = (attributes, direction) => (
         attributes.map((attribute) => `${attribute}:${direction}`)
@@ -97,9 +113,10 @@ export const useGetEntities = (fetchEntities, { selected, columns } = {}) => {
         const sortableColumn = findColumnByKey(orderBy);
         const sortBy = sortableColumn && sortableColumn.sortBy ?
             appendDirection(sortableColumn.sortBy, orderDirection) : undefined;
+        const filterForApi = buildApiFilters(filters);
 
         const fetchedEntities = await fetchEntities(perPage, page, {
-            filters,
+            ...filterForApi,
             sortBy
         });
         const { entities, meta: { totalCount } } = fetchedEntities || {};
@@ -251,3 +268,26 @@ export const useSystemsExport = ({
 
     return exportConfig;
 };
+
+export const useTags = (tagsEnabled) => (
+    tagsEnabled ? {
+        props: {
+            hideFilters: {
+                name: true,
+                tags: false,
+                registeredWith: true,
+                stale: true
+            },
+            showTags: true
+        }
+    } : {
+        props: {
+            hideFilters: {
+                name: true,
+                tags: true,
+                registeredWith: true,
+                stale: true
+            }
+        }
+    }
+);

--- a/src/constants.js
+++ b/src/constants.js
@@ -105,4 +105,6 @@ export const COMPLIANT_SYSTEMS_FILTER_CONFIGURATION = [
     }
 ];
 
-export const features = {};
+export const features = {
+    tags: false
+};

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -8,24 +8,14 @@ const selectRows = (rows, selected) => (
     }))
 );
 
-export const entitiesReducer = (INVENTORY_ACTION, columns) => applyReducerHash({
+export const entitiesReducer = () => applyReducerHash({
     ['INVENTORY_INIT']: () => ({
         rows: [],
-        total: 0,
-        columns
-    }),
-    [INVENTORY_ACTION.LOAD_ENTITIES_PENDING]: (state) => ({
-        ...state,
-        columns
-    }),
-    [INVENTORY_ACTION.LOAD_ENTITIES_FULFILLED]: (state) => ({
-        ...state,
-        columns: state.total > 0 ? columns : [{ title: '' }]
+        total: 0
     }),
     ['RESET_PAGE']: (state) => ({
         ...state,
-        page: 1,
-        columns: []
+        page: 1
     }),
     ['SELECT_ENTITIES']: (state, { payload: { selected } }) => ({
         ...state,


### PR DESCRIPTION
This adds the capability to filter systems by tags. This is dependent on https://github.com/RedHatInsights/compliance-backend/pull/927 for the filtering to be actually effective. 

![Screenshot 2021-07-28 at 13 35 09](https://user-images.githubusercontent.com/7757/127316202-b0457653-ae70-459f-af17-4829fff830e7.png)

Can be enabled via: https://qa.foo.redhat.com:1337/insights/compliance/systems?tags=enable

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
