### PR TITLE
fix: RHICOMPL-1473 - Provide columns in fixed array

### DIFF
--- a/src/PresentationalComponents/LoadingPoliciesTable/LoadingPoliciesTable.js
+++ b/src/PresentationalComponents/LoadingPoliciesTable/LoadingPoliciesTable.js
@@ -1,18 +1,13 @@
 import React from 'react';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 import RowLoader from '@redhat-cloud-services/frontend-components-utilities/RowLoader';
+import columns from '../PoliciesTable/Columns';
 
 const LoadingPoliciesTable = () => (
   <Table
     aria-label="policies-table"
     ouiaId="PoliciesTable"
-    cells={[
-      { title: 'Policy name' },
-      { title: 'Operating system' },
-      { title: 'Systems' },
-      { title: 'Business initiative' },
-      { title: 'Compliance threshold' },
-    ]}
+    cells={columns}
     rows={[...Array(5)].map(() => ({
       cells: [
         {

--- a/src/PresentationalComponents/LoadingPoliciesTable/__snapshots__/LoadingPoliciesTable.test.js.snap
+++ b/src/PresentationalComponents/LoadingPoliciesTable/__snapshots__/LoadingPoliciesTable.test.js.snap
@@ -9,18 +9,40 @@ exports[`LoadingPoliciesTable expect to render without error 1`] = `
   cells={
     Array [
       Object {
-        "title": "Policy name",
+        "props": Object {
+          "width": 45,
+        },
+        "renderFunc": [Function],
+        "sortByProp": "name",
+        "title": "Name",
       },
       Object {
+        "props": Object {
+          "width": 15,
+        },
+        "renderFunc": [Function],
+        "sortByProp": "majorOsVersion",
         "title": "Operating system",
+        "transforms": Array [
+          [Function],
+        ],
       },
       Object {
+        "props": Object {
+          "width": 15,
+        },
+        "renderFunc": [Function],
+        "sortByProp": "totalHostCount",
         "title": "Systems",
       },
       Object {
-        "title": "Business initiative",
+        "renderFunc": [Function],
+        "sortByFunction": [Function],
+        "title": "Business objective",
       },
       Object {
+        "renderFunc": [Function],
+        "sortByProp": "complianceThreshold",
         "title": "Compliance threshold",
       },
     ]

--- a/src/PresentationalComponents/PoliciesTable/Columns.js
+++ b/src/PresentationalComponents/PoliciesTable/Columns.js
@@ -65,3 +65,11 @@ export const ComplianceThreshold = {
   sortByProp: 'complianceThreshold',
   renderFunc: (_data, _id, policy) => `${policy.complianceThreshold}%`,
 };
+
+export default [
+  Name,
+  OperatingSystem,
+  Systems,
+  BusinessObjective,
+  ComplianceThreshold,
+];

--- a/src/PresentationalComponents/PoliciesTable/PoliciesTable.js
+++ b/src/PresentationalComponents/PoliciesTable/PoliciesTable.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
 import { BackgroundLink, emptyRows } from 'PresentationalComponents';
 import { TableToolsTable } from 'Utilities/hooks/useTableTools';
-import * as Columns from './Columns';
+import columns from './Columns';
 import * as Filters from './Filters';
 
 const DedicatedAction = () => (
@@ -18,7 +18,6 @@ const DedicatedAction = () => (
 );
 
 export const PoliciesTable = ({ policies, location, history }) => {
-  const columns = Object.values(Columns);
   const filters = Object.values(Filters);
 
   const actionResolver = () => [

--- a/src/PresentationalComponents/ReportsTable/Columns.js
+++ b/src/PresentationalComponents/ReportsTable/Columns.js
@@ -35,3 +35,5 @@ export const CompliantSystems = {
   },
   renderFunc: renderComponent(CompliantSystemsCell),
 };
+
+export default [Name, OperatingSystem, CompliantSystems];

--- a/src/PresentationalComponents/ReportsTable/ReportsTable.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.js
@@ -3,7 +3,7 @@ import propTypes from 'prop-types';
 import { emptyRows } from 'PresentationalComponents';
 import { TableToolsTable } from 'Utilities/hooks/useTableTools';
 import { uniq } from 'Utilities/helpers';
-import * as Columns from './Columns';
+import columns from './Columns';
 import {
   policyNameFilter,
   policyTypeFilter,
@@ -12,7 +12,6 @@ import {
 } from './Filters';
 
 const ReportsTable = ({ profiles }) => {
-  const columns = Object.values(Columns);
   const policyTypes = uniq(
     profiles.map(({ policyType }) => policyType).filter((i) => !!i)
   );


### PR DESCRIPTION
In other environments it appears that columns are loaded out of order. Object.values should iterate over property values as they appear, so a more likely culprit might be webpack here. 

Providing the columns in a fixed array to define their order should avoid the input to Object.values being random.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
