### PR TITLE
devel: useProxy in webpack with docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN npm install
 EXPOSE 8002
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "start:proxy"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run the container setup either Podman or Docker and their compose commands ca
 
 ```shell
   $ cp .env.example .env # Can be used to enable a local backend and other services
-  $ podman-compose up # Starts up the insights-proxy and the compliance frontend
+  $ podman-compose up # Starts up the compliance frontend with a webpack proxy
 ```
 
 This will build the image if it is not yet available locally and run the containers to make the frontend available at [https://ci.foo.redhat.com:1337/insights/compliance/](https://ci.foo.redhat.com:1337/insights/compliance/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,29 +4,6 @@ services:
         env_file: .env
         build: .
         image: compliance-frontend_frontend
-        ports:
-            - 8002:8002
-        volumes:
-            - .:/compliance:z
-            - /compliance/node_modules
-
-    # Enable/uncomment this if you want to run chrome locally
-    # chrome:
-    #     env_file: .env
-    #     image: compliance-frontend_frontend
-    #     working_dir: /insights-chrome
-    #     entrypoint: /bin/sh
-    #     command: -c '
-    #         npm i;
-    #         npm run start'
-    #     volumes:
-    #         - ${CHROME_DIR}:/insights-chrome:z
-    #         - /insights-chrome/node_modules
-
-    proxy:
-        env_file: .env
-        image: docker.io/redhatinsights/insights-proxy
         network_mode: host
         volumes:
-          - ./config/spandx.config.js:/config/spandx.config.js:z
-          # - ${CHROME_DIR}/build:/chrome:z # local chrome
+            - .:/compliance:z


### PR DESCRIPTION
This removes the insights-proxy from our docker-compose devel setup

Related/tested with https://github.com/RedHatInsights/compliance-frontend/pull/1315

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices