### PR TITLE
fix(GraphQL): RHICOMPL-2142 - Set no-cache as fetchPolicy

### DIFF
--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -73,6 +73,7 @@ export const ReportDetails = ({ route }) => {
   const { report_id: policyId } = useParams();
   const { data, error, loading } = useQuery(QUERY, {
     variables: { policyId },
+    fetchPolicy: 'no-cache',
   });
   let donutValues = [];
   let donutId = 'loading-donut';

--- a/src/SmartComponents/SystemDetails/ComplianceDetail.js
+++ b/src/SmartComponents/SystemDetails/ComplianceDetail.js
@@ -102,6 +102,7 @@ const SystemDetails = ({ inventoryId, hidePassed, client }) => {
   let { data, error, loading } = useQuery(QUERY, {
     variables: { systemId: inventoryId },
     client,
+    fetchPolicy: 'no-cache',
   });
   const is404 = error?.networkError?.statusCode === 404;
 


### PR DESCRIPTION
Disabling the cache should in the best case solve the issue of outdated data or at least allow us to rule it out as a culprit if it does not solve the issue. The only side effect to this is that it will query the API and disregard any values in the (apollo) cache.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
