### PR TITLE
feat(Policies): RHICOMPL-2116 - Limit systems by minor version too

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -69,6 +69,7 @@ PrependComponent.propTypes = {
 };
 
 export const EditPolicySystems = ({
+  policy,
   change,
   osMajorVersion,
   selectedSystems,
@@ -77,7 +78,9 @@ export const EditPolicySystems = ({
     change('systems', newSelectedSystems);
     change('osMinorVersionCounts', countOsMinorVersions(newSelectedSystems));
   };
-
+  const osMinorVersions = policy.supportedOsVersions.map(
+    (version) => version.split('.')[1]
+  );
   return (
     <React.Fragment>
       <TextContent className="pf-u-mb-md">
@@ -107,7 +110,10 @@ export const EditPolicySystems = ({
             showActions={false}
             query={GET_SYSTEMS_WITHOUT_FAILED_RULES}
             defaultFilter={
-              osMajorVersion && `os_major_version = ${osMajorVersion}`
+              osMajorVersion &&
+              `os_major_version = ${osMajorVersion} AND os_minor_version ^ (${osMinorVersions.join(
+                ','
+              )})`
             }
             enableExport={false}
             preselectedSystems={selectedSystems}
@@ -121,6 +127,7 @@ export const EditPolicySystems = ({
 
 EditPolicySystems.propTypes = {
   osMajorVersion: propTypes.string,
+  policy: propTypes.object,
   selectedSystems: propTypes.array,
   change: reduxFormPropTypes.change,
 };
@@ -131,6 +138,7 @@ EditPolicySystems.defaultProps = {
 
 const selector = formValueSelector('policyForm');
 const mapStateToProps = (state) => ({
+  policy: selector(state, 'profile'),
   osMajorVersion: selector(state, 'osMajorVersion'),
   selectedSystems: selector(state, 'systems'),
 });

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.test.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.test.js
@@ -10,8 +10,8 @@ describe('EditPolicySystems', () => {
       <EditPolicySystems
         {...defaultProps}
         osMajorVersion="7"
-        osMinorVersionCounts={[]}
         selectedSystemIds={[]}
+        policy={{ supportedOsVersions: ['1.2', '1.1', '1.3', '1.4'] }}
       />
     );
     expect(toJson(component)).toMatchSnapshot();

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
@@ -48,7 +48,7 @@ exports[`EditPolicySystems expect to render without error 1`] = `
         }
         compact={true}
         compliantFilter={false}
-        defaultFilter="os_major_version = 7"
+        defaultFilter="os_major_version = 7 AND os_minor_version ^ (2,1,3,4)"
         emptyStateComponent={
           <EmptyState
             osMajorVersion="7"

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -26,6 +26,7 @@ export const MULTIVERSION_QUERY = gql`
       complianceThreshold
       majorOsVersion
       osMajorVersion
+      supportedOsVersions
       lastScanned
       policyType
       policy {

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -45,12 +45,24 @@ PrependComponent.propTypes = {
 };
 
 const EditPolicySystemsTab = ({
-  policy: { id: policyId, osMajorVersion },
+  policy,
   newRuleTabs,
   onSystemSelect,
   selectedSystems,
 }) => {
   const { push, location } = useHistory();
+  const { id: policyId, osMajorVersion, supportedOsVersions } = policy;
+  const osMinorVersions = supportedOsVersions.map(
+    (version) => version.split('.')[1]
+  );
+  const osFilter =
+    osMajorVersion &&
+    `os_major_version = ${osMajorVersion} AND os_minor_version ^ (${osMinorVersions.join(
+      ','
+    )})`;
+  const defaultFilter = osFilter
+    ? `${osFilter} or policy_id = ${policyId}`
+    : `policy_id = ${policyId}`;
 
   return (
     <React.Fragment>
@@ -66,10 +78,7 @@ const EditPolicySystemsTab = ({
         compact
         showActions={false}
         query={GET_SYSTEMS_WITHOUT_FAILED_RULES}
-        defaultFilter={
-          osMajorVersion &&
-          `os_major_version = ${osMajorVersion} or policy_id = ${policyId}`
-        }
+        defaultFilter={defaultFilter}
         enableExport={false}
         remediationsEnabled={false}
         preselectedSystems={selectedSystems}

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
@@ -13,7 +13,7 @@ describe('EditPolicySystemsTab', () => {
     policy: {
       id: '12345abcde',
       osMajorVersion: '7',
-      policyOsMinorVersions: [1, 2, 3],
+      supportedOsVersions: ['1.2', '1.1', '1.3', '1.4'],
     },
     newRuleTabs: false,
   };

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -37,7 +37,7 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
     }
     compact={true}
     compliantFilter={false}
-    defaultFilter="os_major_version = 7 or policy_id = 12345abcde"
+    defaultFilter="os_major_version = 7 AND os_minor_version ^ (2,1,3,4) or policy_id = 12345abcde"
     emptyStateComponent={
       <EmptyState
         osMajorVersion="7"
@@ -743,7 +743,7 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
     }
     compact={true}
     compliantFilter={false}
-    defaultFilter="os_major_version = 7 or policy_id = 12345abcde"
+    defaultFilter="os_major_version = 7 AND os_minor_version ^ (2,1,3,4) or policy_id = 12345abcde"
     emptyStateComponent={
       <EmptyState
         osMajorVersion="7"


### PR DESCRIPTION
This updates the queries for the systems in the Create Policy wizard and the Edit Policy modal to also include the specific minor versions of the selected/edited policy in addition just the major OS version.


**How to test:**

1. Open the Create policy wizard 
2. Select a policy and advance to the "Systems" step
3. Verify on the Systems step that only systems specific to the supported OS minor versions are shown.
4. Finish the Wizard
5. Open the "Edit Policy" modal for the policy created
6. Switch to the "Systems" tab
7. Verify that only systems for the specific OS version of that policy are shown.



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
