### PR TITLE
fix: RHICOMPL-2196 Add missing quotes toast notification

### DIFF
--- a/src/SmartComponents/DeletePolicy/DeletePolicy.js
+++ b/src/SmartComponents/DeletePolicy/DeletePolicy.js
@@ -28,7 +28,7 @@ const DeletePolicy = () => {
       dispatchAction(
         addNotification({
           variant: 'success',
-          title: `Deleted ${name} and its associated reports`,
+          title: `Deleted "${name}" and its associated reports`,
         })
       );
       onClose();


### PR DESCRIPTION
According to the [Toast alert doc](https://docs.google.com/document/d/1_5Gkfz9SaggEk7l5Cln4oGitHyRd8D1LO5Yu9KM40Ag/edit#heading=h.9gwfmbx3r6vn) we are missing double quotes for Policy delete toast notification.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
