### PR TITLE
fix(EditPolicy): RHICOMPL-2190 Always show assigned hosts

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -45,7 +45,7 @@ PrependComponent.propTypes = {
 };
 
 const EditPolicySystemsTab = ({
-  policy: { osMajorVersion },
+  policy: { id: policyId, osMajorVersion },
   newRuleTabs,
   onSystemSelect,
   selectedSystems,
@@ -66,7 +66,10 @@ const EditPolicySystemsTab = ({
         compact
         showActions={false}
         query={GET_SYSTEMS_WITHOUT_FAILED_RULES}
-        defaultFilter={osMajorVersion && `os_major_version = ${osMajorVersion}`}
+        defaultFilter={
+          osMajorVersion &&
+          `os_major_version = ${osMajorVersion} or policy_id = ${policyId}`
+        }
         enableExport={false}
         remediationsEnabled={false}
         preselectedSystems={selectedSystems}

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
@@ -11,6 +11,7 @@ jest.mock('react-router-dom', () => ({
 describe('EditPolicySystemsTab', () => {
   const defaultProps = {
     policy: {
+      id: '12345abcde',
       osMajorVersion: '7',
       policyOsMinorVersions: [1, 2, 3],
     },

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -32,7 +32,7 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
     }
     compact={true}
     compliantFilter={false}
-    defaultFilter="os_major_version = 7"
+    defaultFilter="os_major_version = 7 or policy_id = 12345abcde"
     emptyStateComponent={
       <EmptyState
         osMajorVersion="7"
@@ -678,7 +678,7 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
     }
     compact={true}
     compliantFilter={false}
-    defaultFilter="os_major_version = 7"
+    defaultFilter="os_major_version = 7 or policy_id = 12345abcde"
     emptyStateComponent={
       <EmptyState
         osMajorVersion="7"


### PR DESCRIPTION
Always show assigned hosts in the edit policy -> systems modal, even if
hosts are upgraded to a new major version. This allows users to remove
hosts that no longer belong in their policy. We could handle this better
in the future.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices