### PR TITLE
feat(SystemDetails): RHICOMPL-1449 NoPolicies, NoReports empty states

### DIFF
--- a/src/SmartComponents/SystemDetails/ComplianceDetail.js
+++ b/src/SmartComponents/SystemDetails/ComplianceDetail.js
@@ -10,6 +10,8 @@ import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
 import './compliance.scss';
 import { ErrorCard } from 'PresentationalComponents/ErrorCard/ErrorCard';
 import { IntlProvider } from 'react-intl';
+import NoReportsState from './NoReportsState';
+import NoPoliciesState from './NoPoliciesState';
 
 const COMPLIANCE_API_ROOT = '/api/compliance';
 
@@ -18,6 +20,10 @@ const QUERY = gql`
     system(id: $systemId) {
       id
       name
+      hasPolicy
+      policies {
+        id
+      }
       testResultProfiles {
         id
         name
@@ -56,38 +62,46 @@ const SystemQuery = ({ data: { system }, loading, hidePassed }) => (
       policies={system?.testResultProfiles}
       loading={loading}
     />
+    <NoPoliciesState system={system} />
+    <NoReportsState system={system} />
     <br />
-    <RulesTable
-      remediationAvailableFilter
-      handleSelect={() => undefined}
-      hidePassed={hidePassed}
-      system={{
-        ...system,
-        supported:
-          (system?.testResultProfiles || []).filter(
-            (profile) => profile.supported
-          ).length > 0,
-      }}
-      profileRules={system?.testResultProfiles.map((profile) => ({
-        system,
-        profile,
-        rules: profile.rules,
-      }))}
-      loading={loading}
-      options={{
-        sortBy: {
-          index: 4,
-          direction: 'asc',
-          property: 'severity',
-        },
-      }}
-    />
+    {system?.testResultProfiles?.length ? (
+      <RulesTable
+        remediationAvailableFilter
+        handleSelect={() => undefined}
+        hidePassed={hidePassed}
+        system={{
+          ...system,
+          supported:
+            (system?.testResultProfiles || []).filter(
+              (profile) => profile.supported
+            ).length > 0,
+        }}
+        profileRules={system?.testResultProfiles.map((profile) => ({
+          system,
+          profile,
+          rules: profile.rules,
+        }))}
+        loading={loading}
+        options={{
+          sortBy: {
+            index: 4,
+            direction: 'asc',
+            property: 'severity',
+          },
+        }}
+      />
+    ) : undefined}
   </React.Fragment>
 );
 
 SystemQuery.propTypes = {
   data: propTypes.shape({
     system: propTypes.shape({
+      hasPolicy: propTypes.bool,
+      policies: propTypes.shape({
+        id: propTypes.string,
+      }),
       profiles: propTypes.array,
       testResultProfiles: propTypes.array,
     }),

--- a/src/SmartComponents/SystemDetails/NoPoliciesState.js
+++ b/src/SmartComponents/SystemDetails/NoPoliciesState.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { BackgroundLink } from 'PresentationalComponents';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import {
+  Title,
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStatePrimary,
+  EmptyStateSecondaryActions,
+  EmptyStateIcon,
+} from '@patternfly/react-core';
+
+const NoPoliciesState = ({ system }) =>
+  system?.hasPolicy ? (
+    <></>
+  ) : (
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateIcon icon={PlusCircleIcon} />
+        <Title headingLevel="h1" size="lg">
+          This system is not part of any SCAP policies defined within
+          Compliance.
+        </Title>
+        <EmptyStateBody>
+          To assess and monitor compliance against a SCAP policy for this
+          system, add it to an existing policy or create a new policy.
+        </EmptyStateBody>
+        <EmptyStatePrimary>
+          <BackgroundLink to="/scappolicies/new">
+            <Button variant="primary" ouiaId="CreateNewPolicyButton">
+              Create new policy
+            </Button>
+          </BackgroundLink>
+        </EmptyStatePrimary>
+        <EmptyStateSecondaryActions>
+          <Button
+            variant="link"
+            component="a"
+            href="/insights/compliance/scappolicies"
+          >
+            View compliance policies
+          </Button>
+        </EmptyStateSecondaryActions>
+      </EmptyState>
+    </Bullseye>
+  );
+
+NoPoliciesState.propTypes = {
+  system: propTypes.shape({
+    hasPolicy: propTypes.bool,
+  }),
+};
+
+export default NoPoliciesState;

--- a/src/SmartComponents/SystemDetails/NoPoliciesState.test.js
+++ b/src/SmartComponents/SystemDetails/NoPoliciesState.test.js
@@ -1,0 +1,21 @@
+import NoPoliciesState from './NoPoliciesState';
+
+describe('NoPoliciesState', () => {
+  it('with a system having policies', () => {
+    const wrapper = shallow(<NoPoliciesState system={{ hasPolicy: true }} />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('with a system having no policies', () => {
+    const wrapper = shallow(<NoPoliciesState system={{ hasPolicy: false }} />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('with a system having missing hasPolicy prop', () => {
+    const wrapper = shallow(<NoPoliciesState system={{}} />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/SmartComponents/SystemDetails/NoReportsState.js
+++ b/src/SmartComponents/SystemDetails/NoReportsState.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { CloudSecurityIcon } from '@patternfly/react-icons';
+import {
+  Title,
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+} from '@patternfly/react-core';
+
+const NoReportsState = ({ system }) =>
+  system?.hasPolicy && !system?.testResultProfiles?.length ? (
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateIcon
+          icon={CloudSecurityIcon}
+          title="Compliance"
+          size="xl"
+          style={{
+            fontWeight: '500',
+            color: 'var(--pf-global--primary-color--100)',
+          }}
+        />
+        <Title headingLevel="h1" size="lg">
+          No results reported
+        </Title>
+        <EmptyStateBody>
+          This system is part of {system?.policies?.length}
+          {system?.policies?.length > 1 ? ' policies' : ' policy'}, but has not
+          returned any results.
+        </EmptyStateBody>
+        <EmptyStateBody>
+          Reports are returned when the system checks into Insights. By default,
+          systems check in every 24 hours.
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  ) : (
+    <></>
+  );
+
+NoReportsState.propTypes = {
+  system: propTypes.shape({
+    hasPolicy: propTypes.bool,
+    testResultProfiles: propTypes.array,
+    policies: propTypes.array,
+  }),
+};
+
+export default NoReportsState;

--- a/src/SmartComponents/SystemDetails/NoReportsState.test.js
+++ b/src/SmartComponents/SystemDetails/NoReportsState.test.js
@@ -1,0 +1,55 @@
+import NoReportsState from './NoReportsState';
+
+describe('NoReportsState', () => {
+  it('with a system having multiple policies', () => {
+    const wrapper = shallow(
+      <NoReportsState system={{ hasPolicy: true, policies: [{}, {}] }} />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('with a system having policies', () => {
+    const wrapper = shallow(
+      <NoReportsState system={{ hasPolicy: true, policies: [{}] }} />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('with a system having no policies', () => {
+    const wrapper = shallow(
+      <NoReportsState system={{ hasPolicy: false, policies: [] }} />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('with a system missing policies prop', () => {
+    const wrapper = shallow(<NoReportsState system={{ hasPolicy: false }} />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('with a system having missing hasPolicy prop', () => {
+    const wrapper = shallow(<NoReportsState system={{}} />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('with a system having a policy but missing test results', () => {
+    const wrapper = shallow(
+      <NoReportsState system={{ testResultProfiles: [] }} />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('with a system having a policy and test results', () => {
+    const wrapper = shallow(
+      <NoReportsState system={{ testResultProfiles: [{}] }} />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/SmartComponents/SystemDetails/__snapshots__/NoPoliciesState.test.js.snap
+++ b/src/SmartComponents/SystemDetails/__snapshots__/NoPoliciesState.test.js.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoPoliciesState with a system having missing hasPolicy prop 1`] = `
+<Bullseye>
+  <EmptyState>
+    <EmptyStateIcon
+      icon={[Function]}
+    />
+    <Title
+      headingLevel="h1"
+      size="lg"
+    >
+      This system is not part of any SCAP policies defined within Compliance.
+    </Title>
+    <EmptyStateBody>
+      To assess and monitor compliance against a SCAP policy for this system, add it to an existing policy or create a new policy.
+    </EmptyStateBody>
+    <EmptyStatePrimary>
+      <BackgroundLink
+        to="/scappolicies/new"
+      >
+        <Button
+          ouiaId="CreateNewPolicyButton"
+          variant="primary"
+        >
+          Create new policy
+        </Button>
+      </BackgroundLink>
+    </EmptyStatePrimary>
+    <EmptyStateSecondaryActions>
+      <Button
+        component="a"
+        href="/insights/compliance/scappolicies"
+        variant="link"
+      >
+        View compliance policies
+      </Button>
+    </EmptyStateSecondaryActions>
+  </EmptyState>
+</Bullseye>
+`;
+
+exports[`NoPoliciesState with a system having no policies 1`] = `
+<Bullseye>
+  <EmptyState>
+    <EmptyStateIcon
+      icon={[Function]}
+    />
+    <Title
+      headingLevel="h1"
+      size="lg"
+    >
+      This system is not part of any SCAP policies defined within Compliance.
+    </Title>
+    <EmptyStateBody>
+      To assess and monitor compliance against a SCAP policy for this system, add it to an existing policy or create a new policy.
+    </EmptyStateBody>
+    <EmptyStatePrimary>
+      <BackgroundLink
+        to="/scappolicies/new"
+      >
+        <Button
+          ouiaId="CreateNewPolicyButton"
+          variant="primary"
+        >
+          Create new policy
+        </Button>
+      </BackgroundLink>
+    </EmptyStatePrimary>
+    <EmptyStateSecondaryActions>
+      <Button
+        component="a"
+        href="/insights/compliance/scappolicies"
+        variant="link"
+      >
+        View compliance policies
+      </Button>
+    </EmptyStateSecondaryActions>
+  </EmptyState>
+</Bullseye>
+`;
+
+exports[`NoPoliciesState with a system having policies 1`] = `<Fragment />`;

--- a/src/SmartComponents/SystemDetails/__snapshots__/NoReportsState.test.js.snap
+++ b/src/SmartComponents/SystemDetails/__snapshots__/NoReportsState.test.js.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoReportsState with a system having a policy and test results 1`] = `<Fragment />`;
+
+exports[`NoReportsState with a system having a policy but missing test results 1`] = `<Fragment />`;
+
+exports[`NoReportsState with a system having missing hasPolicy prop 1`] = `<Fragment />`;
+
+exports[`NoReportsState with a system having multiple policies 1`] = `
+<Bullseye>
+  <EmptyState>
+    <EmptyStateIcon
+      icon={[Function]}
+      size="xl"
+      style={
+        Object {
+          "color": "var(--pf-global--primary-color--100)",
+          "fontWeight": "500",
+        }
+      }
+      title="Compliance"
+    />
+    <Title
+      headingLevel="h1"
+      size="lg"
+    >
+      No results reported
+    </Title>
+    <EmptyStateBody>
+      This system is part of 
+      2
+       policies
+      , but has not returned any results.
+    </EmptyStateBody>
+    <EmptyStateBody>
+      Reports are returned when the system checks into Insights. By default, systems check in every 24 hours.
+    </EmptyStateBody>
+  </EmptyState>
+</Bullseye>
+`;
+
+exports[`NoReportsState with a system having no policies 1`] = `<Fragment />`;
+
+exports[`NoReportsState with a system having policies 1`] = `
+<Bullseye>
+  <EmptyState>
+    <EmptyStateIcon
+      icon={[Function]}
+      size="xl"
+      style={
+        Object {
+          "color": "var(--pf-global--primary-color--100)",
+          "fontWeight": "500",
+        }
+      }
+      title="Compliance"
+    />
+    <Title
+      headingLevel="h1"
+      size="lg"
+    >
+      No results reported
+    </Title>
+    <EmptyStateBody>
+      This system is part of 
+      1
+       policy
+      , but has not returned any results.
+    </EmptyStateBody>
+    <EmptyStateBody>
+      Reports are returned when the system checks into Insights. By default, systems check in every 24 hours.
+    </EmptyStateBody>
+  </EmptyState>
+</Bullseye>
+`;
+
+exports[`NoReportsState with a system missing policies prop 1`] = `<Fragment />`;


### PR DESCRIPTION
Add the NoPoliciesState and NoReportsState empty state components to the SystemDetails page.

Replaces https://github.com/RedHatInsights/frontend-components/pull/1177

No policy:

![Screenshot from 2021-08-30 18-10-09](https://user-images.githubusercontent.com/761923/131412328-7ba4303e-faa5-4c55-ba5a-b0419b7b8a49.png)

Yes policy, no test results:

![Screenshot from 2021-08-30 18-07-53](https://user-images.githubusercontent.com/761923/131412197-c78470d8-1a98-4e63-8c39-57844244f9f0.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices