### PR TITLE
fix(devtools): Disable local node_module resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ HOT_RELOAD=false
 # WEBPACK_BIND=192.168.0.2
 # WEBPACK_DEBUG=true
 # USE_CLOUD=true # if using cloud.redhat.com instead of console.redhat.com
+# LOCAL_NODE_MODULES=true # Use to resolve any node_modules (even for frontend-components) in node_modules this directory
 
 # Enable/uncomment this to run chrome locally
 # CHROME_DIR=../insights-chrome

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -62,7 +62,7 @@ webpackConfig.resolve.alias = {
 
 webpackConfig.resolve = {
     ...webpackConfig.resolve,
-    modules: [resolve('./node_modules')],
+    ...process.env.LOCAL_NODE_MODULES === 'true' && { modules: [resolve('./node_modules')] },
 }
 
 webpackConfig.devServer = {

--- a/src/PresentationalComponents/SystemPolicyCards/SystemPolicyCards.test.js
+++ b/src/PresentationalComponents/SystemPolicyCards/SystemPolicyCards.test.js
@@ -8,12 +8,16 @@ jest.mock('react-content-loader', () => ({
 }));
 
 describe('SystemPolicyCards component', () => {
+  const currentTime = new Date('2021-03-06T06:20:13Z');
+  const pastTime = new Date('2021-03-06T06:20:13Z');
+  pastTime.setYear(pastTime.getFullYear() - 2);
+
   const policies = [
     {
       rulesPassed: 30,
       rulesFailed: 10,
       score: 75,
-      lastScanned: '2019-03-06T06:20:13Z',
+      lastScanned: pastTime.toISOString(),
       refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
       name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
       compliant: false,
@@ -32,6 +36,15 @@ describe('SystemPolicyCards component', () => {
       ssgVersion: '0.1.45',
     },
   ];
+
+  beforeAll(() => {
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(currentTime);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   it('should render loading state', () => {
     const wrappper = mount(

--- a/src/PresentationalComponents/SystemPolicyCards/__snapshots__/SystemPolicyCards.test.js.snap
+++ b/src/PresentationalComponents/SystemPolicyCards/__snapshots__/SystemPolicyCards.test.js.snap
@@ -16,7 +16,7 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
       Array [
         Object {
           "compliant": false,
-          "lastScanned": "2019-03-06T06:20:13Z",
+          "lastScanned": "2019-03-06T06:20:13.000Z",
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
           "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
           "rulesFailed": 10,
@@ -59,7 +59,7 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
               policy={
                 Object {
                   "compliant": false,
-                  "lastScanned": "2019-03-06T06:20:13Z",
+                  "lastScanned": "2019-03-06T06:20:13.000Z",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rulesFailed": 10,
@@ -560,7 +560,7 @@ exports[`SystemPolicyCards component should render real table 1`] = `
       Array [
         Object {
           "compliant": false,
-          "lastScanned": "2019-03-06T06:20:13Z",
+          "lastScanned": "2019-03-06T06:20:13.000Z",
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
           "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
           "rulesFailed": 10,
@@ -603,7 +603,7 @@ exports[`SystemPolicyCards component should render real table 1`] = `
               policy={
                 Object {
                   "compliant": false,
-                  "lastScanned": "2019-03-06T06:20:13Z",
+                  "lastScanned": "2019-03-06T06:20:13.000Z",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rulesFailed": 10,


### PR DESCRIPTION
The local node module resolution should not be needed anymore and currently causes issues locally linking the `frontend-components` packages.

We initially added this because of the react/react-dom issues resolving for our inventory-compliance package, this should not be needed anymore since we are not using that package anymore and these issues have been resolved in general.

This still leaves it in, but doesn't enable it by default.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices