### PR TITLE
Fix federated modules entries.

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -75,7 +75,7 @@ plugins.push(
         root: resolve(__dirname, '../'),
         useFileHash: false,
         exposes: {
-            './RootApp': resolve(__dirname, '../src/bootstrap-dev'),
+            './RootApp': resolve(__dirname, '../src/AppEntry'),
             './SystemDetail': resolve(
               __dirname,
               '../src/SmartComponents/SystemDetails/ComplianceDetail'

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -29,6 +29,13 @@ plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')(
     {
       root: resolve(__dirname, '../'),
+      exposes: {
+        './RootApp': resolve(__dirname, '../src/AppEntry'),
+        './SystemDetail': resolve(
+          __dirname,
+          '../src/SmartComponents/SystemDetails/ComplianceDetail'
+        ),
+      },
     }
   )
 );


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-16201

The inventory compliance was not loaded because the module was not exposed in prod webpack config.
Also, the RootApp in dev env was pointing to an incorrect js file. This is probably why there were two app instances in dev env.