### PR TITLE
fix(ReportDownload): RHICOMPL-2376 - Don't use link func directly as handler

### DIFF
--- a/src/SmartComponents/ReportDownload/ReportDownload.js
+++ b/src/SmartComponents/ReportDownload/ReportDownload.js
@@ -74,7 +74,7 @@ export const ReportDownload = () => {
       width="440px"
       ouiaId="DownloadReportModal"
       title="Compliance report"
-      onClose={linkToReport}
+      onClose={() => linkToReport()}
       actions={actions}
     >
       <StateViewWithError stateValues={{ error, data, loading }}>


### PR DESCRIPTION
When using the event handler as a event handler directly it will push the event object into the history state and cause issues with pendo and likely other parts.

**Screenrecording:**

https://user-images.githubusercontent.com/7757/138679300-86045da7-3fff-4cee-a288-e316a62881a4.mp4

**How to test:**

1. Try opening and closing and opening again the download modal on master (see also screen recording)
1.1. This should fail and (at least) raise an error about something not being possible to be cloned
2. Pull this PR and follow 1. again.
2.1. This time it should not raise any error and the modal should be possible to be opened any time. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
