### PR TITLE
fix(devtools): Remove offending client option

### DIFF
--- a/config/devserver.config.js
+++ b/config/devserver.config.js
@@ -26,7 +26,6 @@ const devserverConfig = {
   },
   liveReload: hotReload(),
   hot: hotReload(),
-  client: hotReload(),
   host: bindHost(),
   allowedHosts: [
     'stage.foo.redhat.com',


### PR DESCRIPTION
When `HOT_RELOAD` is set to true in the ENV/`.env` webpack would fail to start, since a boolean is not a supported option.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
