### PR TITLE
fix(EditPolicy): RHICOMPL-741 restrict entering of long floats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "compliance-frontend",
       "version": "1.1.0",
       "dependencies": {
         "@apollo/client": "^3.4.16",

--- a/src/PresentationalComponents/ComplianceThresholdHelperText/ComplianceThresholdHelperText.js
+++ b/src/PresentationalComponents/ComplianceThresholdHelperText/ComplianceThresholdHelperText.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import { hasMaxDecimals } from '../../SmartComponents/CreatePolicy/validate';
+
+const ComplianceThresholdHelperText = ({ threshold }) => {
+  const parsedThreshold = parseFloat(threshold);
+
+  return (
+    <React.Fragment>
+      <HelperText>
+        {(parsedThreshold < 0 ||
+          parsedThreshold > 100 ||
+          isNaN(parsedThreshold)) && (
+          <HelperTextItem variant="error">
+            Threshold has to be a number between 0 and 100
+          </HelperTextItem>
+        )}
+        {!hasMaxDecimals(parsedThreshold, 1) && (
+          <HelperTextItem variant="error">
+            Threshold values can have a maximum of one decimal place
+          </HelperTextItem>
+        )}
+      </HelperText>
+    </React.Fragment>
+  );
+};
+
+ComplianceThresholdHelperText.propTypes = {
+  threshold: propTypes.string,
+};
+
+export default ComplianceThresholdHelperText;

--- a/src/PresentationalComponents/ComplianceThresholdHelperText/ComplianceThresholdHelperText.test.js
+++ b/src/PresentationalComponents/ComplianceThresholdHelperText/ComplianceThresholdHelperText.test.js
@@ -1,0 +1,15 @@
+import ComplianceThresholdHelperText from './ComplianceThresholdHelperText';
+
+describe('ComplianceThresholdHelperText', () => {
+  const defaultProps = {
+    threshold: 100,
+  };
+
+  it('expect to render without error', () => {
+    const wrapper = shallow(
+      <ComplianceThresholdHelperText {...defaultProps} />
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/PresentationalComponents/ComplianceThresholdHelperText/__snapshots__/ComplianceThresholdHelperText.test.js.snap
+++ b/src/PresentationalComponents/ComplianceThresholdHelperText/__snapshots__/ComplianceThresholdHelperText.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ComplianceThresholdHelperText expect to render without error 1`] = `
+<Fragment>
+  <HelperText />
+</Fragment>
+`;

--- a/src/PresentationalComponents/ProfileThresholdField/ProfileThresholdField.js
+++ b/src/PresentationalComponents/ProfileThresholdField/ProfileThresholdField.js
@@ -3,21 +3,24 @@ import { Field, reduxForm } from 'redux-form';
 import { FormGroup } from '@patternfly/react-core';
 import { ReduxFormTextInput } from 'PresentationalComponents/ReduxFormWrappers/ReduxFormWrappers';
 import propTypes from 'prop-types';
-import round from 'lodash/round';
 import { thresholdValid } from '../../SmartComponents/CreatePolicy/validate';
-import { PolicyThresholdTooltip } from 'PresentationalComponents';
+import {
+  PolicyThresholdTooltip,
+  ComplianceThresholdHelperText,
+} from 'PresentationalComponents';
 
 export class ProfileThresholdField extends React.Component {
   state = {
     validThreshold: thresholdValid(this.props.previousThreshold),
-    threshold: round(this.props.previousThreshold || 100, 1),
+    threshold: this.props.previousThreshold,
   };
 
-  handleThresholdChange = (threshold) =>
+  handleThresholdChange = (threshold) => {
     this.setState({
       validThreshold: thresholdValid(threshold),
-      threshold: round(threshold, 1),
+      threshold: threshold,
     });
+  };
 
   render() {
     const { threshold, validThreshold } = this.state;
@@ -27,7 +30,9 @@ export class ProfileThresholdField extends React.Component {
         <FormGroup
           fieldId="policy-threshold"
           validated={validThreshold ? 'default' : 'error'}
-          helperTextInvalid="Threshold has to be a number between 0 and 100"
+          helperTextInvalid={
+            <ComplianceThresholdHelperText threshold={threshold} />
+          }
           helperText="A value of 95% or higher is recommended"
           labelIcon={<PolicyThresholdTooltip />}
           label="Compliance threshold (%)"

--- a/src/PresentationalComponents/ProfileThresholdField/__snapshots__/ProfileThresholdField.test.js.snap
+++ b/src/PresentationalComponents/ProfileThresholdField/__snapshots__/ProfileThresholdField.test.js.snap
@@ -26,7 +26,11 @@ exports[`ProfileThresholdField expect to render without error 1`] = `
   <FormGroup
     fieldId="policy-threshold"
     helperText="A value of 95% or higher is recommended"
-    helperTextInvalid="Threshold has to be a number between 0 and 100"
+    helperTextInvalid={
+      <ComplianceThresholdHelperText
+        threshold={10}
+      />
+    }
     label="Compliance threshold (%)"
     labelIcon={<PolicyThresholdTooltip />}
     validated="default"

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -42,6 +42,7 @@ export {
 } from './NoResultsTable/NoResultsTable';
 export { default as PoliciesTable } from './PoliciesTable/PoliciesTable';
 export { default as ProfileThresholdField } from './ProfileThresholdField/ProfileThresholdField';
+export { default as ComplianceThresholdHelperText } from './ComplianceThresholdHelperText/ComplianceThresholdHelperText';
 export { default as SupportedSSGVersionsLink } from './SupportedSSGVersionsLink/SupportedSSGVersionsLink';
 export { default as UnsupportedSSGVersion } from './UnsupportedSSGVersion/UnsupportedSSGVersion';
 export { default as SubPageTitle } from './SubPageTitle/SubPageTitle';

--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -147,7 +147,7 @@ export default connect((state) => ({
   osMajorVersion: selector(state, 'osMajorVersion'),
   osMinorVersionCounts: selector(state, 'osMinorVersionCounts'),
   businessObjective: selector(state, 'businessObjective'),
-  complianceThreshold: selector(state, 'complianceThreshold') || '100.0',
+  complianceThreshold: selector(state, 'complianceThreshold') || 100,
   name: selector(state, 'name'),
   profile: selector(state, 'profile'),
   refId: selector(state, 'refId'),

--- a/src/SmartComponents/CreatePolicy/validate.js
+++ b/src/SmartComponents/CreatePolicy/validate.js
@@ -6,7 +6,19 @@ export const validateBenchmarkPage = (benchmark, osMajorVersion, profile) => {
   }
 };
 
-export const thresholdValid = (threshold) => threshold < 101 && threshold >= 0;
+export const hasMaxDecimals = (num, dec) =>
+  new RegExp(`^[-]?\\d+(\\.\\d{1${dec > 1 ? ',' + dec : ''}})?$`, 'g').test(
+    num.toString()
+  );
+
+export const thresholdValid = (threshold) => {
+  const parsedThreshold = parseFloat(threshold);
+  return (
+    parsedThreshold <= 100 &&
+    parsedThreshold >= 0 &&
+    hasMaxDecimals(parsedThreshold, 1)
+  );
+};
 
 export const validateDetailsPage = (name, refId, complianceThreshold) =>
   !name ||

--- a/src/SmartComponents/EditPolicy/EditPolicyDetailsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyDetailsTab.js
@@ -4,6 +4,7 @@ import { FormGroup, TextArea, TextInput } from '@patternfly/react-core';
 import {
   PolicyThresholdTooltip,
   PolicyBusinessObjectiveTooltip,
+  ComplianceThresholdHelperText,
 } from 'PresentationalComponents';
 import { thresholdValid } from '../CreatePolicy/validate';
 
@@ -19,7 +20,7 @@ export const useThresholdValidate = () => {
   ];
 };
 
-const EditPolicyDetailsTab = ({ policy, setUpdatedPolicy }) => {
+const EditPolicyDetailsTab = ({ policy, updatedPolicy, setUpdatedPolicy }) => {
   const [validThreshold, validateThreshold] = useThresholdValidate();
 
   return (
@@ -71,7 +72,15 @@ const EditPolicyDetailsTab = ({ policy, setUpdatedPolicy }) => {
         label="Compliance threshold (%)"
         labelIcon={<PolicyThresholdTooltip />}
         fieldId="policy-threshold"
-        helperTextInvalid="Threshold has to be a number between 0 and 100"
+        helperTextInvalid={
+          <ComplianceThresholdHelperText
+            threshold={
+              updatedPolicy
+                ? updatedPolicy.complianceThreshold
+                : policy.complianceThreshold
+            }
+          />
+        }
         helperText="A value of 95% or higher is recommended"
       >
         <TextInput
@@ -84,7 +93,7 @@ const EditPolicyDetailsTab = ({ policy, setUpdatedPolicy }) => {
           onChange={(value) => {
             setUpdatedPolicy((policy) => ({
               ...policy,
-              complianceThreshold: value,
+              complianceThreshold: parseFloat(value),
               complianceThresholdValid: validateThreshold(value),
             }));
           }}
@@ -102,6 +111,11 @@ EditPolicyDetailsTab.propTypes = {
       propTypes.string,
       propTypes.number,
     ]),
+  }),
+  updatedPolicy: propTypes.shape({
+    description: propTypes.string,
+    businessObjective: propTypes.object,
+    complianceThreshold: propTypes.number,
   }),
   setUpdatedPolicy: propTypes.func,
 };

--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -7,6 +7,7 @@ import EditPolicyRulesTab from './EditPolicyRulesTab';
 import EditPolicySystemsTab from './EditPolicySystemsTab';
 import { mapCountOsMinorVersions } from 'Store/Reducers/SystemStore';
 import { profilesWithRulesToSelection } from 'PresentationalComponents/TabbedRules';
+import { thresholdValid } from '../CreatePolicy/validate';
 
 const profilesToOsMinorMap = (profiles, hosts) =>
   (profiles || []).reduce((acc, profile) => {
@@ -22,6 +23,7 @@ const profilesToOsMinorMap = (profiles, hosts) =>
 
 export const EditPolicyForm = ({
   policy,
+  updatedPolicy,
   setUpdatedPolicy,
   selectedRuleRefIds,
   setSelectedRuleRefIds,
@@ -52,8 +54,9 @@ export const EditPolicyForm = ({
 
   useEffect(() => {
     if (policy) {
-      const complianceThresholdValid =
-        policy.complianceThreshold < 101 && policy.complianceThreshold > 0;
+      const complianceThresholdValid = thresholdValid(
+        policy.complianceThreshold
+      );
       setUpdatedPolicy({
         ...policy,
         complianceThresholdValid,
@@ -73,6 +76,7 @@ export const EditPolicyForm = ({
         >
           <EditPolicyDetailsTab
             policy={policy}
+            updatedPolicy={updatedPolicy}
             setUpdatedPolicy={setUpdatedPolicy}
           />
         </Tab>
@@ -110,6 +114,7 @@ export const EditPolicyForm = ({
 
 EditPolicyForm.propTypes = {
   policy: propTypes.object,
+  updatedPolicy: propTypes.object,
   setUpdatedPolicy: propTypes.func,
   selectedRuleRefIds: propTypes.arrayOf(propTypes.object),
   setSelectedRuleRefIds: propTypes.func,

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyDetailsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyDetailsTab.test.js.snap
@@ -46,7 +46,11 @@ exports[`EditPolicyDetailsTab expect to render without error 1`] = `
   <FormGroup
     fieldId="policy-threshold"
     helperText="A value of 95% or higher is recommended"
-    helperTextInvalid="Threshold has to be a number between 0 and 100"
+    helperTextInvalid={
+      <ComplianceThresholdHelperText
+        threshold="30"
+      />
+    }
     label="Compliance threshold (%)"
     labelIcon={<PolicyThresholdTooltip />}
     validated="default"


### PR DESCRIPTION
I had to modify how useValidateThreshold hook works, because i could not think of any other solution to how to differentiate between the two error states that can happen
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
