### PR TITLE
feat(SystemsTable): RHICOMPL-1808 - Use osVersions meta field for OS filter

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -109,3 +109,7 @@ button.pf-c-button.pf-m-plain {
     padding: 0;
     text-align: left;
 }
+
+.ins-c-primary-toolbar__group-filter .pf-c-menu-toggle {
+   padding: 6px 8px;
+ }

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -53,7 +53,13 @@ export const SystemsTable = ({
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
   const osMinorVersionFilter = useOsMinorVersionFilter(
-    showOsMinorVersionFilter
+    showOsMinorVersionFilter,
+    {
+      variables: {
+        filter: defaultFilter,
+        ...(policyId && { policyId }),
+      },
+    }
   );
   const {
     toolbarProps: conditionalFilter,

--- a/src/SmartComponents/SystemsTable/constants.js
+++ b/src/SmartComponents/SystemsTable/constants.js
@@ -170,6 +170,18 @@ export const GET_SYSTEMS_TAGS = gql`
   }
 `;
 
+export const GET_SYSTEMS_OSES = gql`
+  query getSystems($filter: String!) {
+    systems(search: $filter) {
+      osVersions {
+        name
+        major
+        minor
+      }
+    }
+  }
+`;
+
 export const policyFilter = (policies, osFilter) => [
   ...systemsPolicyFilterConfiguration(policies),
   ...(osFilter ? systemsOsFilterConfiguration(policies) : []),


### PR DESCRIPTION
This changes the OS filter on systems tables to only show OS version that are present in the set of systems, instead of all possible versions.

![Screenshot 2021-11-04 at 10 56 18](https://user-images.githubusercontent.com/7757/140294295-95e37cb8-b490-4aa5-aac3-84350e67acca.png)

**How to test**

1. Visit any page with a SystemsTable
2. Check the OS filter and verify only OS version are shown that have systems in the table


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
