### PR TITLE
fix(ReportsTable): Give compliant systems progress an aria-label

### DIFF
--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -71,6 +71,7 @@ export const CompliantSystems = ({
   return (
     <React.Fragment>
       <Progress
+        aria-label="Compliant systems"
         measureLocation={'outside'}
         value={
           testResultHostCount

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CompliantSystems expect to render with unsupported hosts 1`] = `
 <Fragment>
   <Progress
-    aria-label={null}
+    aria-label="Compliant systems"
     aria-labelledby={null}
     className=""
     id=""
@@ -43,7 +43,7 @@ exports[`CompliantSystems expect to render with unsupported hosts 1`] = `
 exports[`CompliantSystems expect to render without error 1`] = `
 <Fragment>
   <Progress
-    aria-label={null}
+    aria-label="Compliant systems"
     aria-labelledby={null}
     className=""
     id=""


### PR DESCRIPTION
Also removes the complaint in tests/console like:
```
console.warn
      One of aria-label or aria-labelledby properties should be passed when using the progress component without a title.

      at Progress.render (node_modules/@patternfly/react-core/src/components/Progress/Progress.tsx:111:15)
      at finishClassComponent (node_modules/react-dom/cjs/react-dom.development.js:17485:31)
      at updateClassComponent (node_modules/react-dom/cjs/react-dom.development.js:17435:24)
      at beginWork (node_modules/react-dom/cjs/react-dom.development.js:19073:16)
      at beginWork$1 (node_modules/react-dom/cjs/react-dom.development.js:23940:14)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:22779:12)
      at workLoopSync (node_modules/react-dom/cjs/react-dom.development.js:22707:5)
      at renderRootSync (node_modules/react-dom/cjs/react-dom.development.js:22670:7)
``` 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
