### PR TITLE
fix(TableTools): RHICOMPL-2432 - Apply filter and sorting to export

### DIFF
--- a/src/Utilities/hooks/useTableTools/helper.js
+++ b/src/Utilities/hooks/useTableTools/helper.js
@@ -1,2 +1,7 @@
 export const filterSelected = (items, selectedIds = []) =>
   items.filter((item) => selectedIds.includes(item.itemId));
+
+export const filteredAndSortedItems = (items, filter, sorter) => {
+  const filtered = filter ? filter(items) : items;
+  return sorter ? sorter(filtered) : filtered;
+};

--- a/src/Utilities/hooks/useTableTools/useTableTools.js
+++ b/src/Utilities/hooks/useTableTools/useTableTools.js
@@ -56,8 +56,13 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     additionalDedicatedActions: selectedFilterToolbarProps?.dedicatedAction,
   });
 
+  const filteredAndSortedItems = (items, filter, sorter) => {
+    const filtered = filter ? filter(items) : items;
+    return sorter ? sorter(filtered) : filtered;
+  };
+
   const { toolbarProps: exportToolbarProps } = useExportWithItems(
-    items,
+    filteredAndSortedItems(items, filter, sorter),
     columns,
     options
   );


### PR DESCRIPTION
This fixes an issue where filters won't be applied to the export.

*How to test?*

1. Visit any page that contains a rules table
2. Export a CSV/JSON and verify all rules are included
3. Apply filters
4. Export CSV/JSON and verify that only the filtered result is exported

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
