### PR TITLE
fix(RemediationButton): Add loading fallback to avoid spinner

### DIFF
--- a/src/PresentationalComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
+++ b/src/PresentationalComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
@@ -1,10 +1,18 @@
 import React from 'react';
 import propTypes from 'prop-types';
+import { Button } from '@patternfly/react-core';
 import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
 import flatten from 'lodash/flatten';
 import { connect } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { AnsibeTowerIcon } from '@patternfly/react-icons';
+
+const FallbackButton = () => (
+  <Button variant="primary" isDisabled>
+    <AnsibeTowerIcon size="sm" color="var(--pf-c-button--m-primary--Color)" />
+    &nbsp;Remediate
+  </Button>
+);
 
 class ComplianceRemediationButton extends React.Component {
   formatRule = ({ title, refId }, profile, system, majorOsVersion) => ({
@@ -118,6 +126,7 @@ class ComplianceRemediationButton extends React.Component {
           buttonProps={{
             ouiaId: 'RemediateButton',
           }}
+          fallback={<FallbackButton />}
         >
           <AnsibeTowerIcon
             size="sm"


### PR DESCRIPTION
Adds a disabled fallback button to avoid a spinner when async loading the real button component.

*Before:*

https://user-images.githubusercontent.com/7757/140032112-0f1094ea-3e9a-4029-9eac-11895ce7e91b.mp4


*After:*

https://user-images.githubusercontent.com/7757/140032162-c9fc4ef3-a705-4b5a-a0ff-d7ddf24e9c20.mp4

*How to test?*

1. Visit a systems details page
2. Observe the loading behaviour, especially of the button

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
