### PR TITLE
fix(TableTools): RHICOMPL-1778 - Set no sortBy when there are no items

### DIFF
--- a/src/Utilities/hooks/useTableTools/useTableSort.js
+++ b/src/Utilities/hooks/useTableTools/useTableSort.js
@@ -56,4 +56,16 @@ const useTableSort = (columns, options = {}) => {
   };
 };
 
+export const useTableSortWithItems = (items, columns, options) => {
+  const { tableProps, sorter } = useTableSort(columns, options);
+
+  return {
+    tableProps: {
+      ...tableProps,
+      sortBy: items.length > 0 ? tableProps.sortBy : undefined,
+    },
+    sorter,
+  };
+};
+
 export default useTableSort;

--- a/src/Utilities/hooks/useTableTools/useTableSort.test.js
+++ b/src/Utilities/hooks/useTableTools/useTableSort.test.js
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
-import useTableSort from './useTableSort';
+import useTableSort, { useTableSortWithItems } from './useTableSort';
 import columns from './__fixtures__/columns';
 
 describe('useTableSort', () => {
@@ -19,5 +19,20 @@ describe('useTableSort', () => {
       })
     );
     expect(result.current.tableProps.sortBy).toEqual(sortBy);
+  });
+});
+
+describe('useTableSortWithItems', () => {
+  it('returns no sortBy when there are no items', () => {
+    const sortBy = {
+      index: 3,
+      direction: 'asc',
+    };
+    const { result } = renderHook(() =>
+      useTableSortWithItems([], columns, {
+        sortBy,
+      })
+    );
+    expect(result.current.tableProps.sortBy).toEqual(undefined);
   });
 });

--- a/src/Utilities/hooks/useTableTools/useTableTools.js
+++ b/src/Utilities/hooks/useTableTools/useTableTools.js
@@ -1,5 +1,5 @@
 import useFilterConfig from './useFilterConfig';
-import useTableSort from './useTableSort';
+import { useTableSortWithItems } from './useTableSort';
 import usePaginate from './usePaginate';
 import useRowsBuilder from './useRowsBuilder';
 import { useBulkSelectWithItems } from './useBulkSelect';
@@ -13,11 +13,6 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     options;
 
   const identifiedItems = useItemIdentify(items, options);
-
-  const { tableProps: sortableTableProps, sorter } = useTableSort(
-    columns,
-    options
-  );
 
   const {
     toolbarProps: pagintionToolbarProps,
@@ -36,6 +31,12 @@ const useTableTools = (items = [], columns = [], options = {}) => {
 
   const { transformer: openItem, tableProps: expandableProps } =
     useExpandable(options);
+
+  const { tableProps: sortableTableProps, sorter } = useTableSortWithItems(
+    filter ? filter(items) : items,
+    columns,
+    options
+  );
 
   const {
     transformer: selectItem,


### PR DESCRIPTION
When no items are present there should be no sorting set on the table:


**Before:**

https://user-images.githubusercontent.com/7757/140058734-3f2816b0-2580-4ab9-af73-6b6947124fa0.mp4


**After:**

https://user-images.githubusercontent.com/7757/140058486-1b51e848-e105-4f01-b004-ae4099920af7.mp4


**How to test**

1. Visit any systems details page with rules
2. Apply a filter that would yield no results and verify no sorting is set.


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
