### PR TITLE
fix(TableTools): RHICOMPL-2438 - Pass selected items to export if any

### DIFF
--- a/src/PresentationalComponents/RulesTable/Columns.js
+++ b/src/PresentationalComponents/RulesTable/Columns.js
@@ -13,7 +13,8 @@ import {
 export const Name = {
   title: 'Name',
   sortByProp: 'title',
-  renderExport: ({ title, identifier }) => `${title} - ${identifier.label}`,
+  renderExport: ({ title, identifier }) =>
+    `${title}${identifier ? ` - ${identifier.label}` : ''}`,
   renderFunc: renderComponent(Rule),
 };
 

--- a/src/Utilities/hooks/useTableTools/useTableTools.js
+++ b/src/Utilities/hooks/useTableTools/useTableTools.js
@@ -63,7 +63,11 @@ const useTableTools = (items = [], columns = [], options = {}) => {
   };
 
   const { toolbarProps: exportToolbarProps } = useExportWithItems(
-    filteredAndSortedItems(items, filter, sorter),
+    filteredAndSortedItems(
+      selectedItems?.length > 0 ? selectedItems : items,
+      filter,
+      sorter
+    ),
     columns,
     options
   );


### PR DESCRIPTION
On tables that use the bulk select and selected filter, items would not be exported if there were selected items and the filter activated.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
