### PR TITLE
feat(TabSwitcher): RHICOMPL-1777 - Implement and use default fallback tabs

### DIFF
--- a/src/PresentationalComponents/TabSwitcher/TabSwitcher.test.js
+++ b/src/PresentationalComponents/TabSwitcher/TabSwitcher.test.js
@@ -1,9 +1,10 @@
+import { useLocation } from 'react-router-dom';
+import { Tab } from '@patternfly/react-core';
 import TabSwitcher, {
   ContentTab,
   RoutedTabSwitcher,
   RoutedTabs,
 } from './TabSwitcher';
-import { Tab } from '@patternfly/react-core';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -19,9 +20,9 @@ jest.mock('react-router-dom', () => ({
 describe('TabSwitcher', () => {
   it('expect to render first tab', () => {
     const wrapper = shallow(
-      <TabSwitcher activeKey={0}>
-        <Tab eventKey={0}>First Tab</Tab>
-        <Tab tabId={1}>Second Tab</Tab>
+      <TabSwitcher activeKey="0">
+        <Tab eventKey="0">First Tab</Tab>
+        <Tab tabId="1">Second Tab</Tab>
       </TabSwitcher>
     );
 
@@ -30,9 +31,31 @@ describe('TabSwitcher', () => {
 
   it('expect to render second tab', () => {
     const wrapper = shallow(
-      <TabSwitcher activeKey={1}>
-        <Tab eventKey={0}>First Tab</Tab>
-        <Tab eventKey={1}>Second Tab</Tab>
+      <TabSwitcher activeKey="1">
+        <Tab eventKey="0">First Tab</Tab>
+        <Tab eventKey="1">Second Tab</Tab>
+      </TabSwitcher>
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('expect to render second default tab', () => {
+    const wrapper = shallow(
+      <TabSwitcher defaultTab="1" activeKey="101">
+        <Tab eventKey="0">First Tab</Tab>
+        <Tab eventKey="1">Second Tab</Tab>
+      </TabSwitcher>
+    );
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('expect to render first as default tab', () => {
+    const wrapper = shallow(
+      <TabSwitcher activeKey="101">
+        <Tab eventKey="0">First Tab</Tab>
+        <Tab eventKey="1">Second Tab</Tab>
       </TabSwitcher>
     );
 
@@ -41,9 +64,13 @@ describe('TabSwitcher', () => {
 });
 
 describe('TabSwitcher', () => {
-  it('expect to render first tab', () => {
+  it('expect to set systems as activeKey', () => {
+    useLocation.mockImplementation(() => ({
+      hash: '#system',
+      path: '/current/location',
+    }));
     const wrapper = shallow(
-      <RoutedTabSwitcher defaultTab="system">
+      <RoutedTabSwitcher defaultTab="details">
         <ContentTab eventKey="details">DETAILS</ContentTab>
         <ContentTab eventKey="rules">RULES</ContentTab>
         <ContentTab eventKey="systems">SYSTEMS</ContentTab>
@@ -53,12 +80,16 @@ describe('TabSwitcher', () => {
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
-  it('expect to render second tab', () => {
+  it('expect to set 1 as active tab', () => {
+    useLocation.mockImplementation(() => ({
+      hash: '#1',
+      path: '/current/location',
+    }));
     const wrapper = shallow(
-      <TabSwitcher activeKey={1}>
-        <Tab eventKey={0}>First Tab</Tab>
-        <Tab eventKey={1}>Second Tab</Tab>
-      </TabSwitcher>
+      <RoutedTabSwitcher defaultTab="0">
+        <Tab eventKey="0">First Tab</Tab>
+        <Tab eventKey="1">Second Tab</Tab>
+      </RoutedTabSwitcher>
     );
 
     expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/PresentationalComponents/TabSwitcher/__snapshots__/TabSwitcher.test.js.snap
+++ b/src/PresentationalComponents/TabSwitcher/__snapshots__/TabSwitcher.test.js.snap
@@ -70,28 +70,73 @@ exports[`RoutedTabs expect to render second tab 1`] = `
 </Tabs>
 `;
 
-exports[`TabSwitcher expect to render first tab 1`] = `
+exports[`TabSwitcher expect to render first as default tab 1`] = `
 <Tab
-  eventKey={0}
+  eventKey="0"
 >
   First Tab
 </Tab>
 `;
 
-exports[`TabSwitcher expect to render first tab 2`] = `null`;
-
-exports[`TabSwitcher expect to render second tab 1`] = `
+exports[`TabSwitcher expect to render first tab 1`] = `
 <Tab
-  eventKey={1}
+  eventKey="0"
+>
+  First Tab
+</Tab>
+`;
+
+exports[`TabSwitcher expect to render second default tab 1`] = `
+<Tab
+  eventKey="1"
 >
   Second Tab
 </Tab>
 `;
 
-exports[`TabSwitcher expect to render second tab 2`] = `
+exports[`TabSwitcher expect to render second tab 1`] = `
 <Tab
-  eventKey={1}
+  eventKey="1"
 >
   Second Tab
 </Tab>
+`;
+
+exports[`TabSwitcher expect to set 1 as active tab 1`] = `
+<TabSwitcher
+  activeKey="1"
+>
+  <Tab
+    eventKey="0"
+  >
+    First Tab
+  </Tab>
+  <Tab
+    eventKey="1"
+  >
+    Second Tab
+  </Tab>
+</TabSwitcher>
+`;
+
+exports[`TabSwitcher expect to set systems as activeKey 1`] = `
+<TabSwitcher
+  activeKey="system"
+>
+  <ContentTab
+    eventKey="details"
+  >
+    DETAILS
+  </ContentTab>
+  <ContentTab
+    eventKey="rules"
+  >
+    RULES
+  </ContentTab>
+  <ContentTab
+    eventKey="systems"
+  >
+    SYSTEMS
+  </ContentTab>
+</TabSwitcher>
 `;


### PR DESCRIPTION
This properly implements a fallback to a default tab if the active one does not exist, for example when an unknown anchor is set.

**How to test**

1. Go to any page, for example the policy details or edit policy
2. Verify tabs still work
3. Manually change the anchor/hash in the URL to something random/unknown
4. Verify that the default/first tab is shown

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
