### PR TITLE
feat(SystemsTable): RHICOMPL-2446 - Implement empty state for OS filter

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -110,6 +110,26 @@ button.pf-c-button.pf-m-plain {
     text-align: left;
 }
 
-.ins-c-primary-toolbar__group-filter .pf-c-menu-toggle {
+button.pf-c-menu-toggle {
    padding: 6px 8px;
+
+   &.ins-c-tagfilter {
+     padding: 0;
+   }
  }
+
+.ins-c-primary-toolbar__group-filter button.ins-c-osfilter__os-filter-button {
+  background: #FFF;
+
+  label {
+    cursor: default;
+  }
+
+  input {
+    display: none;
+  }
+
+  .ins-c-osfilter__no-os {
+    color: #000;
+  }
+}

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -94,6 +94,7 @@ exports[`SystemsTable returns 1`] = `
               "type": "text",
             },
             Object {
+              "className": undefined,
               "filterValues": Object {
                 "groups": Array [
                   Object {
@@ -312,6 +313,7 @@ exports[`SystemsTable returns compact 1`] = `
               "type": "text",
             },
             Object {
+              "className": undefined,
               "filterValues": Object {
                 "groups": Array [
                   Object {
@@ -629,6 +631,7 @@ exports[`SystemsTable returns with a showComplianceSystemsInfo 1`] = `
               "type": "text",
             },
             Object {
+              "className": undefined,
               "filterValues": Object {
                 "groups": Array [
                   Object {
@@ -895,6 +898,7 @@ exports[`SystemsTable returns with compliantFilter 1`] = `
               "type": "checkbox",
             },
             Object {
+              "className": undefined,
               "filterValues": Object {
                 "groups": Array [
                   Object {
@@ -1113,6 +1117,7 @@ exports[`SystemsTable returns with showOnlySystemsWithTestResults 1`] = `
               "type": "text",
             },
             Object {
+              "className": undefined,
               "filterValues": Object {
                 "groups": Array [
                   Object {
@@ -1323,6 +1328,7 @@ exports[`SystemsTable returns without actions 1`] = `
               "type": "text",
             },
             Object {
+              "className": undefined,
               "filterValues": Object {
                 "groups": Array [
                   Object {
@@ -1535,6 +1541,7 @@ exports[`SystemsTable returns without remediations 1`] = `
               "type": "text",
             },
             Object {
+              "className": undefined,
               "filterValues": Object {
                 "groups": Array [
                   Object {

--- a/src/Utilities/hooks/useTableTools/Components/__snapshots__/TableToolsTable.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/Components/__snapshots__/TableToolsTable.test.js.snap
@@ -111,6 +111,7 @@ exports[`TableToolsTable expect to render without error 1`] = `
             "type": "radio",
           },
           Object {
+            "className": undefined,
             "filterValues": Object {
               "groups": Array [
                 Object {

--- a/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterConfigBuilder.js
+++ b/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterConfigBuilder.js
@@ -83,10 +83,13 @@ class FilterConfigBuilder {
     type: conditionalFilterType.group,
     label: item.label,
     id: stringToId(item.label),
+    className: item.className,
     filterValues: {
       selected: value,
-      onChange: (_event, selectedValues) => {
-        handler(stringToId(item.label), selectedValues);
+      onChange: (_event, selectedValues, _group, item) => {
+        if (item.meta) {
+          handler(stringToId(item.label), selectedValues);
+        }
       },
       groups: item.items.map((item) => ({
         ...item,

--- a/src/Utilities/hooks/useTableTools/__snapshots__/useFilterConfig.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__snapshots__/useFilterConfig.test.js.snap
@@ -324,6 +324,7 @@ Object {
           "type": "radio",
         },
         Object {
+          "className": undefined,
           "filterValues": Object {
             "groups": Array [
               Object {

--- a/src/constants.js
+++ b/src/constants.js
@@ -115,6 +115,22 @@ const toSystemsOsMinorFilterConfigurationItem =
     })),
   });
 
+const emptyFilterDropDownItem = {
+  value: '',
+  isDisabled: true,
+  items: [
+    {
+      value: '',
+      label: (
+        <div className="ins-c-osfilter__no-os">No OS versions available</div>
+      ),
+      isDisabled: true,
+      items: [],
+      className: 'ins-c-osfilter__os-filter-button',
+    },
+  ],
+};
+
 export const systemsOsMinorFilterConfiguration = (osMajorVersions) => {
   const filterString = (value) => [
     Object.keys(value)
@@ -128,9 +144,12 @@ export const systemsOsMinorFilterConfiguration = (osMajorVersions) => {
       .filter((v) => !!v)
       .join(' OR '),
   ];
-  const items = Object.keys(osMajorVersions).map(
-    toSystemsOsMinorFilterConfigurationItem(osMajorVersions)
-  );
+  const osVersions = Object.keys(osMajorVersions);
+
+  const items =
+    osVersions.length > 0
+      ? osVersions.map(toSystemsOsMinorFilterConfigurationItem(osMajorVersions))
+      : [emptyFilterDropDownItem];
 
   return [
     {


### PR DESCRIPTION
When there are no systems assigned to a policy the results for the operating system versions are empty.

Before the dropdown would appear without items:

![Screenshot 2021-11-05 at 04 48 39](https://user-images.githubusercontent.com/7757/140455239-503e8419-2db7-4b7f-b715-2c81eb0192c0.png)


This adds an item similar to what is in the tags filter with no tags available:


![Screenshot 2021-11-05 at 04 44 09](https://user-images.githubusercontent.com/7757/140455279-ad82ad8d-15f4-443e-a66f-2f0261512e26.png)



**How to test**

1. Create and/or edit a policy to have no systems
2. Vist the systems tab on the policy details
3. Select the OS filter and verify

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
