### PR TITLE
chore(Reports): RHICOMPL-2410 - Remove PDF feature flag

### DIFF
--- a/src/PresentationalComponents/ReportsTable/Columns.js
+++ b/src/PresentationalComponents/ReportsTable/Columns.js
@@ -64,4 +64,4 @@ export const exportableColumns = [
   CompliantSystems,
 ];
 
-export default [Name, OperatingSystem, CompliantSystems];
+export default [Name, OperatingSystem, CompliantSystems, PDFExportDownload];

--- a/src/PresentationalComponents/ReportsTable/ReportsTable.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.js
@@ -3,8 +3,7 @@ import propTypes from 'prop-types';
 import { emptyRows } from 'PresentationalComponents';
 import { TableToolsTable } from 'Utilities/hooks/useTableTools';
 import { uniq } from 'Utilities/helpers';
-import useFeature from 'Utilities/hooks/useFeature';
-import columns, { exportableColumns, PDFExportDownload } from './Columns';
+import columns, { exportableColumns } from './Columns';
 import {
   policyNameFilter,
   policyTypeFilter,
@@ -13,7 +12,6 @@ import {
 } from './Filters';
 
 const ReportsTable = ({ profiles }) => {
-  const pdfReportEnabled = useFeature('pdfReport');
   const policyTypes = uniq(
     profiles.map(({ policyType }) => policyType).filter((i) => !!i)
   );
@@ -25,10 +23,7 @@ const ReportsTable = ({ profiles }) => {
     <TableToolsTable
       aria-label="Reports"
       ouiaId="ReportsTable"
-      columns={[
-        ...columns,
-        ...((pdfReportEnabled && [PDFExportDownload]) || []),
-      ]}
+      columns={columns}
       items={profiles}
       emptyRows={emptyRows}
       isStickyHeader

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -34,7 +34,6 @@ import {
   SubPageTitle,
 } from 'PresentationalComponents';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
-import useFeature from 'Utilities/hooks/useFeature';
 import { SystemsTable } from 'SmartComponents';
 import '@/Charts.scss';
 import './ReportDetails.scss';
@@ -72,7 +71,6 @@ export const QUERY = gql`
 
 export const ReportDetails = ({ route }) => {
   const { report_id: policyId } = useParams();
-  const pdfReportEnabled = useFeature('pdfReport');
   const { data, error, loading } = useQuery(QUERY, {
     variables: { policyId },
     fetchPolicy: 'no-cache',
@@ -159,20 +157,18 @@ export const ReportDetails = ({ route }) => {
               lg={3}
               xl={3}
             >
-              {pdfReportEnabled && (
-                <BackgroundLink
-                  state={{ profile }}
-                  to={`/reports/${profile.id}/pdf`}
+              <BackgroundLink
+                state={{ profile }}
+                to={`/reports/${profile.id}/pdf`}
+              >
+                <Button
+                  ouiaId="ReportDetailsDownloadReportPDFLink"
+                  variant="primary"
+                  className="pf-u-mr-md"
                 >
-                  <Button
-                    ouiaId="ReportDetailsDownloadReportPDFLink"
-                    variant="primary"
-                    className="pf-u-mr-md"
-                  >
-                    Download PDF
-                  </Button>
-                </BackgroundLink>
-              )}
+                  Download PDF
+                </Button>
+              </BackgroundLink>
               <BackgroundLink
                 state={{ profile }}
                 to={`/reports/${profile.id}/delete`}

--- a/src/constants.js
+++ b/src/constants.js
@@ -168,6 +168,4 @@ export const COMPLIANT_SYSTEMS_FILTER_CONFIGURATION = [
   },
 ];
 
-export const features = {
-  pdfReport: true,
-};
+export const features = {};


### PR DESCRIPTION
Remove the feature flag used for the report PDF download.

**How to test**

1. Open the report details page and/or the reports overview
2. Verify the "Download PDF" button is present (with and without the feature manually enabled  by adding `?pdfReport=enabled` or `?pdfReport=disabled`)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
