### PR TITLE
feat(PoliciesTable): RHICOMPL-2436 - Enable default export notifications

### DIFF
--- a/src/PresentationalComponents/PoliciesTable/PoliciesTable.js
+++ b/src/PresentationalComponents/PoliciesTable/PoliciesTable.js
@@ -2,6 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
+import { COMPLIANCE_TABLE_DEFAULTS } from '@/constants';
 import { BackgroundLink, emptyRows } from 'PresentationalComponents';
 import { TableToolsTable } from 'Utilities/hooks/useTableTools';
 import columns, { exportableColumns } from './Columns';
@@ -57,8 +58,10 @@ export const PoliciesTable = ({ policies, location, history }) => {
         filterConfig: filters,
       }}
       options={{
+        ...COMPLIANCE_TABLE_DEFAULTS,
         dedicatedAction: DedicatedAction,
         exportable: {
+          ...COMPLIANCE_TABLE_DEFAULTS.exportable,
           columns: exportableColumns,
         },
       }}

--- a/src/PresentationalComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/PresentationalComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -605,6 +605,8 @@ exports[`PoliciesTable expect to render SystemsCountWarning 1`] = `
             "title": "Compliance threshold",
           },
         ],
+        "onComplete": [Function],
+        "onStart": [Function],
       },
     }
   }
@@ -742,6 +744,8 @@ exports[`PoliciesTable expect to render emptystate 1`] = `
             "title": "Compliance threshold",
           },
         ],
+        "onComplete": [Function],
+        "onStart": [Function],
       },
     }
   }
@@ -1354,6 +1358,8 @@ exports[`PoliciesTable expect to render without error 1`] = `
             "title": "Compliance threshold",
           },
         ],
+        "onComplete": [Function],
+        "onStart": [Function],
       },
     }
   }


### PR DESCRIPTION
This adds the table defaults to the policies table and enables the notifications.

**How to test**

See #1464, and verify notifications are fired.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
