### PR TITLE
Update filters to support selectable groups

### DIFF
--- a/src/Utilities/hooks/useTableTools/FilterConfigBuilder/ChipBuilder.js
+++ b/src/Utilities/hooks/useTableTools/FilterConfigBuilder/ChipBuilder.js
@@ -44,7 +44,17 @@ class ChipBuilder {
 
         return Object.keys(currentValue[groupValue]).map((itemValue) =>
           currentValue[groupValue][itemValue]
-            ? group?.items.find(findWithString(itemValue))
+            ? [
+                ...(group.groupSelectable
+                  ? [
+                      {
+                        label: group.label,
+                        value: group.value,
+                      },
+                    ]
+                  : []),
+                ...(group?.items || []),
+              ].find(findWithString(itemValue))
             : null
         );
       })

--- a/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterConfigBuilder.js
+++ b/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterConfigBuilder.js
@@ -86,10 +86,8 @@ class FilterConfigBuilder {
     className: item.className,
     filterValues: {
       selected: value,
-      onChange: (_event, selectedValues, _group, item) => {
-        if (item.meta) {
-          handler(stringToId(item.label), selectedValues);
-        }
+      onChange: (_event, selectedValues) => {
+        handler(stringToId(item.label), selectedValues);
       },
       groups: item.items.map((item) => ({
         ...item,

--- a/src/Utilities/hooks/useTableTools/useFilterConfig.js
+++ b/src/Utilities/hooks/useTableTools/useFilterConfig.js
@@ -26,10 +26,10 @@ const useFilterConfig = (options = {}) => {
     filterConfigBuilder.initialDefaultState(initialActiveFilters, filterConfig)
   );
   const onFilterUpdate = (filter, value) => {
-    setActiveFilters({
-      ...activeFilters,
+    setActiveFilters((prevFilters) => ({
+      ...prevFilters,
       [filter]: value,
-    });
+    }));
 
     setPage && setPage(1);
   };


### PR DESCRIPTION
### OS conditional filter group

OS filter supports selectable groups. Currently this is broken because the conditional filter went trough some changes, this PR fixes such issue, bye sending the change event to parent component everytime and by mapping the selected values correctly.

* This feature will be fully supported once https://github.com/RedHatInsights/frontend-components/pull/1310 is merged. However since the conditional filter is part of inventory it's not required to wait for 1310 to be merged. We can freely merge this one and once FEC PR is merged and inventory updated it will start working as it should.

### Without frontend PR

![Screenshot from 2021-11-15 10-59-27](https://user-images.githubusercontent.com/3439771/141761587-76454411-f83f-4fa9-abe3-f5ef2ede8c53.png)

### With updated PR

![Screenshot from 2021-11-15 10-53-45](https://user-images.githubusercontent.com/3439771/141761369-ed05eaf0-65de-4636-9724-709cfb6a7857.png)




