### PR TITLE
fix(ReportDownload): RHICOMPL-2455 - Pass filter for test results

### DIFF
--- a/src/SmartComponents/ReportDownload/hooks/useQueryExportData.js
+++ b/src/SmartComponents/ReportDownload/hooks/useQueryExportData.js
@@ -58,7 +58,7 @@ const useQueryExportData = (
       variables: {
         perPage,
         page,
-        filter: '',
+        filter: `with_results_for_policy_id = ${policyId}`,
         policyId,
       },
     });


### PR DESCRIPTION
With this filter hosts for the export are properly returned. Before this it could occur that the PDF report fails when a report has only a few hosts and there are (at least +100) hosts before these hosts in the database.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
