### PR TITLE
fix(RulesTable): RHICOMPL-2479 - Adapt rule selection to include profile

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -18,12 +18,14 @@ const RulesTable = ({
   remediationAvailableFilter = false,
   selectedFilter = false,
   handleSelect,
-  selectedRefIds = [],
+  selectedRules = [],
   hidePassed = false,
   options,
   ...rulesTableProps
 }) => {
   const rules = toRulesArrayWithProfile(profileRules);
+  const selectedRulesWithRemediations = (selectedRules) =>
+    (selectedRules || []).filter((rule) => rule.remediationAvailable);
   const showPassFailFilter =
     columns.filter((c) => c.title === 'Passed').length > 0;
   const policies = profileRules
@@ -33,7 +35,7 @@ const RulesTable = ({
       name: profile.name,
     }));
 
-  const remediationAction = ({ selected: selectedRules }) => (
+  const remediationAction = ({ selected }) => (
     <ComplianceRemediationButton
       allSystems={[
         {
@@ -43,9 +45,7 @@ const RulesTable = ({
           supported: system.supported,
         },
       ]}
-      selectedRules={(selectedRules || []).filter(
-        (rule) => rule.remediationAvailable
-      )}
+      selectedRules={selectedRulesWithRemediations(selected)}
     />
   );
 
@@ -70,10 +70,10 @@ const RulesTable = ({
       options={{
         ...COMPLIANCE_TABLE_DEFAULTS,
         ...options,
-        identifier: (item) => `${item.profile.id}_${item.refId}`,
+        identifier: (item) => `${item.profile.id}|${item.refId}`,
         selectable: !!handleSelect || remediationsEnabled,
         onSelect: handleSelect,
-        preselected: selectedRefIds,
+        preselected: selectedRules,
         detailsComponent: RuleDetailsRow,
         emptyRows: emptyRows(columns),
         selectedFilter,
@@ -91,7 +91,7 @@ RulesTable.propTypes = {
   system: propTypes.object,
   remediationsEnabled: propTypes.bool,
   remediationAvailableFilter: propTypes.bool,
-  selectedRefIds: propTypes.array,
+  selectedRules: propTypes.array,
   selectedFilter: propTypes.bool,
   handleSelect: propTypes.func,
   columns: propTypes.array,

--- a/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
+++ b/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
@@ -131,11 +131,19 @@ const ProfileTabContent = ({
             remediationsEnabled={false}
             columns={columns}
             profileRules={[{ profile, rules: rules || [] }]}
-            selectedRefIds={selectedRuleRefIds}
+            selectedRules={selectedRuleRefIds.map(
+              (refId) => `${profile.id}|${refId}`
+            )}
             handleSelect={
               handleSelect &&
               ((selectedRuleRefIds) =>
-                handleSelect(profile, newOsMinorVersion, selectedRuleRefIds))
+                handleSelect(
+                  profile,
+                  newOsMinorVersion,
+                  selectedRuleRefIds.map(
+                    (profileRuleRefId) => profileRuleRefId.split('|')[1]
+                  )
+                ))
             }
             {...rulesTableProps}
           />


### PR DESCRIPTION
https://github.com/RedHatInsights/compliance-frontend/commit/f1a64fb40df7a6aa7c3c34e6ecec052ed21c6373#diff-f3088209a94cef4be43a8666799ccd2cb4b52fed78c2d58f4e078d310bdba6a7 Introduced the profile as a prefix for the identifier to address selection issues in reports with multiple policies, but it introduced issues with preselecting items in the table, which would render the rules tables in the wizard and the edit policy empty.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
