### PR TITLE
fix(devtools): RHIF-6 - Make example .env defaults file

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,9 +1,8 @@
 # Comment out to enable
 DEFAULT_HOST=stage.foo.redhat.com
+WEBPACK_BIND=0.0.0.0
 
-# GOOD_GUY=true # Enable longer request timeouts; helpful on slow connections in development
 # HOT_RELOAD=false
-# WEBPACK_BIND=192.168.0.2
 # WEBPACK_DEBUG=true
 # FILE_HASH=true # Enable URL asset hashes in development
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm run start:proxy:beta # Will run the UI with beta chrome
 To run the container setup either Podman or Docker and their compose commands can be used to
 
 ```shell
-  $ cp .env.example .env # Can be used to enable a local backend and other services
+  $ cp .env.defaults .env # Can be used to enable a local backend and other services
   $ podman-compose up # Starts up the compliance frontend with a webpack proxy
 ```
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-require('dotenv').config();
+require('dotenv').config({ path: '.env.defaults' });
 
 const defaults = {
   LOCAL_CHROME: 'false',
@@ -29,7 +29,7 @@ const { devserverConfig } = require('./devserver.config');
 const { aliases } = require('./alias.webpack.config');
 
 const useLocalChrome = () =>
-  withDefault('LOCAL_CHROME') === 'true'
+  withDefault('LOCAL_CHROME')
     ? {
         localChrome: withDefault('CHROME_DIR'),
       }


### PR DESCRIPTION
With this the `npm run start:proxy` and `npm run start:proxy:beta` should work out of the box.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
