### PR TITLE
fix(ReportedSystemRow): RHICOMPL-2745 Add dark boarders

### DIFF
--- a/src/SmartComponents/ReportDetails/Components/ReportedSystemRow.js
+++ b/src/SmartComponents/ReportDetails/Components/ReportedSystemRow.js
@@ -5,7 +5,15 @@ import { RowWrapper } from '@patternfly/react-table';
 const ReportedSystemRow = ({ row, children }) => (
   <RowWrapper
     style={
-      row.testResultProfiles?.length === 0 ? { background: '#F0F0F0' } : {}
+      row.testResultProfiles?.length === 0
+        ? {
+            background: '#F0F0F0',
+            borderLeft:
+              'var(--pf-c-table--border-width--base) solid var(--pf-c-table--BorderColor)',
+            borderRight:
+              'var(--pf-c-table--border-width--base) solid var(--pf-c-table--BorderColor)',
+          }
+        : {}
     }
   >
     {children}


### PR DESCRIPTION
- Sign in with an account that has reports.
- Select a report that has at least one system that never reported.

Before, this row would have left and right borders that are the same color as the
background. With this fix, the left and right borders should be the same
color as the top and bottom borders of the row.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
