### PR TITLE
fix(SystemsTable): RHICOMPL-2306 - Use updated instead of lastScanned

### DIFF
--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
@@ -296,6 +296,17 @@ exports[`EditPolicySystems expect to render without error 1`] = `
                                       },
                                       Object {
                                         "alias": undefined,
+                                        "arguments": Array [],
+                                        "directives": Array [],
+                                        "kind": "Field",
+                                        "name": Object {
+                                          "kind": "Name",
+                                          "value": "updated",
+                                        },
+                                        "selectionSet": undefined,
+                                      },
+                                      Object {
+                                        "alias": undefined,
                                         "arguments": Array [
                                           Object {
                                             "kind": "Argument",
@@ -684,7 +695,7 @@ exports[`EditPolicySystems expect to render without error 1`] = `
             ],
             "kind": "Document",
             "loc": Object {
-              "end": 995,
+              "end": 1013,
               "start": 0,
             },
           }

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -284,6 +284,17 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
                                   },
                                   Object {
                                     "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "updated",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
                                     "arguments": Array [
                                       Object {
                                         "kind": "Argument",
@@ -672,7 +683,7 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
         ],
         "kind": "Document",
         "loc": Object {
-          "end": 995,
+          "end": 1013,
           "start": 0,
         },
       }
@@ -990,6 +1001,17 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
                                   },
                                   Object {
                                     "alias": undefined,
+                                    "arguments": Array [],
+                                    "directives": Array [],
+                                    "kind": "Field",
+                                    "name": Object {
+                                      "kind": "Name",
+                                      "value": "updated",
+                                    },
+                                    "selectionSet": undefined,
+                                  },
+                                  Object {
+                                    "alias": undefined,
                                     "arguments": Array [
                                       Object {
                                         "kind": "Argument",
@@ -1378,7 +1400,7 @@ exports[`EditPolicySystemsTab expect to render without error 1`] = `
         ],
         "kind": "Document",
         "loc": Object {
-          "end": 995,
+          "end": 1013,
           "start": 0,
         },
       }

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
@@ -304,6 +304,17 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
                                 },
                                 Object {
                                   "alias": undefined,
+                                  "arguments": Array [],
+                                  "directives": Array [],
+                                  "kind": "Field",
+                                  "name": Object {
+                                    "kind": "Name",
+                                    "value": "updated",
+                                  },
+                                  "selectionSet": undefined,
+                                },
+                                Object {
+                                  "alias": undefined,
                                   "arguments": Array [
                                     Object {
                                       "kind": "Argument",
@@ -747,7 +758,7 @@ exports[`PolicySystemsTab expect to render with no systems table 1`] = `
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 1121,
+        "end": 1139,
         "start": 0,
       },
     }
@@ -1068,6 +1079,17 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
                                 },
                                 Object {
                                   "alias": undefined,
+                                  "arguments": Array [],
+                                  "directives": Array [],
+                                  "kind": "Field",
+                                  "name": Object {
+                                    "kind": "Name",
+                                    "value": "updated",
+                                  },
+                                  "selectionSet": undefined,
+                                },
+                                Object {
+                                  "alias": undefined,
                                   "arguments": Array [
                                     Object {
                                       "kind": "Argument",
@@ -1511,7 +1533,7 @@ exports[`PolicySystemsTab expect to render without error 1`] = `
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 1121,
+        "end": 1139,
         "start": 0,
       },
     }

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -612,6 +612,17 @@ exports[`ReportDetails expect to render without error 1`] = `
                                           },
                                           Object {
                                             "alias": undefined,
+                                            "arguments": Array [],
+                                            "directives": Array [],
+                                            "kind": "Field",
+                                            "name": Object {
+                                              "kind": "Name",
+                                              "value": "updated",
+                                            },
+                                            "selectionSet": undefined,
+                                          },
+                                          Object {
+                                            "alias": undefined,
                                             "arguments": Array [
                                               Object {
                                                 "kind": "Argument",
@@ -1055,7 +1066,7 @@ exports[`ReportDetails expect to render without error 1`] = `
                 ],
                 "kind": "Document",
                 "loc": Object {
-                  "end": 1121,
+                  "end": 1139,
                   "start": 0,
                 },
               }
@@ -1689,6 +1700,17 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                                           },
                                           Object {
                                             "alias": undefined,
+                                            "arguments": Array [],
+                                            "directives": Array [],
+                                            "kind": "Field",
+                                            "name": Object {
+                                              "kind": "Name",
+                                              "value": "updated",
+                                            },
+                                            "selectionSet": undefined,
+                                          },
+                                          Object {
+                                            "alias": undefined,
                                             "arguments": Array [
                                               Object {
                                                 "kind": "Argument",
@@ -2132,7 +2154,7 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 ],
                 "kind": "Document",
                 "loc": Object {
-                  "end": 1121,
+                  "end": 1139,
                   "start": 0,
                 },
               }

--- a/src/SmartComponents/SystemsTable/constants.js
+++ b/src/SmartComponents/SystemsTable/constants.js
@@ -36,6 +36,7 @@ export const GET_SYSTEMS = gql`
           staleTimestamp
           insightsId
           lastScanned
+          updated
           testResultProfiles(policyId: $policyId) {
             id
             name
@@ -97,6 +98,7 @@ export const GET_SYSTEMS_WITHOUT_FAILED_RULES = gql`
           staleTimestamp
           insightsId
           lastScanned
+          updated
           testResultProfiles(policyId: $policyId) {
             id
             name
@@ -152,6 +154,7 @@ export const GET_MINIMAL_SYSTEMS = gql`
           staleTimestamp
           insightsId
           lastScanned
+          updated
         }
       }
     }

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -66,11 +66,9 @@ const renameInventoryAttributes = ({
   culledTimestamp,
   staleWarningTimestamp,
   staleTimestamp,
-  lastScanned,
   ...system
 }) => ({
   ...system,
-  updated: lastScanned,
   culled_timestamp: culledTimestamp,
   stale_warning_timestamp: staleWarningTimestamp,
   stale_timestamp: staleTimestamp,


### PR DESCRIPTION
**Note:** Before merging, please test in Chrome as well as FireFox to verify the date works in both as there are difference in support of date formats. \o/

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
