### PR TITLE
fix(SystemsTable): RHICOMPL-2306 - Still include insightsId/_id for connected info

### DIFF
--- a/src/SmartComponents/ReportDownload/constants.js
+++ b/src/SmartComponents/ReportDownload/constants.js
@@ -32,6 +32,7 @@ export const GET_SYSTEMS = gql`
           name
           osMajorVersion
           osMinorVersion
+          insightsId
           testResultProfiles(policyId: $policyId) {
             id
             name

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -66,9 +66,11 @@ const renameInventoryAttributes = ({
   culledTimestamp,
   staleWarningTimestamp,
   staleTimestamp,
+  insightsId,
   ...system
 }) => ({
   ...system,
+  insights_id: insightsId,
   culled_timestamp: culledTimestamp,
   stale_warning_timestamp: staleWarningTimestamp,
   stale_timestamp: staleTimestamp,


### PR DESCRIPTION
When not passing the insights_id to the `LastSeen` component it will mistakenly show a "Not connected" icon. This will fix the issue and only show the icon if there is indeed no insights_id for a system.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
