### PR TITLE
[JSFIX] Major version upgrade of react-redux from version 7.2.3 to 8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "react-content-loader": "^5.1.2",
         "react-dom": "^17.0.2",
         "react-intl": "^5.15.8",
-        "react-redux": "^7.2.3",
+        "react-redux": "^8.0.2",
         "react-router-dom": "^5.2.0",
         "react-show-more-text": "^1.4.4",
         "redux": "^4.0.5",
@@ -4897,20 +4897,9 @@
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.10.tgz",
       "integrity": "sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-redux": {
-      "version": "7.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.20.tgz",
-      "integrity": "sha512-q42es4c8iIeTgcnB+yJgRTTzftv3eYYvCZOh1Ckn2eX/3o5TdsQYKUWpLoLuGlcY/p+VAhV9IOEZJcWk/vfkXw==",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/react-test-renderer": {
@@ -5005,6 +4994,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/webpack": {
       "version": "4.41.31",
@@ -16637,7 +16631,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/react-reconciler": {
       "version": "0.24.0",
@@ -16657,28 +16652,47 @@
       }
     },
     "node_modules/react-redux": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17"
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
         "react-dom": {
           "optional": true
         },
         "react-native": {
           "optional": true
+        },
+        "redux": {
+          "optional": true
         }
       }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-router": {
       "version": "5.2.1",
@@ -19335,6 +19349,14 @@
       "dev": true,
       "dependencies": {
         "fast-url-parser": "^1.1.3"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {
@@ -24341,20 +24363,9 @@
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.10.tgz",
       "integrity": "sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
-      }
-    },
-    "@types/react-redux": {
-      "version": "7.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.20.tgz",
-      "integrity": "sha512-q42es4c8iIeTgcnB+yJgRTTzftv3eYYvCZOh1Ckn2eX/3o5TdsQYKUWpLoLuGlcY/p+VAhV9IOEZJcWk/vfkXw==",
-      "requires": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
       }
     },
     "@types/react-test-renderer": {
@@ -24448,6 +24459,11 @@
           "dev": true
         }
       }
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/webpack": {
       "version": "4.41.31",
@@ -33426,7 +33442,8 @@
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "react-reconciler": {
       "version": "0.24.0",
@@ -33440,16 +33457,23 @@
       }
     },
     "react-redux": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
       "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
       }
     },
     "react-router": {
@@ -35538,6 +35562,12 @@
       "requires": {
         "fast-url-parser": "^1.1.3"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util": {
       "version": "0.12.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-content-loader": "^5.1.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.15.8",
-    "react-redux": "^7.2.3",
+    "react-redux": "^8.0.2",
     "react-router-dom": "^5.2.0",
     "react-show-more-text": "^1.4.4",
     "redux": "^4.0.5",


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It upgrades react-redux to version 8.0.2.

The JSFIX tool used advanced program analysis to determine how react-redux is used by compliance-frontend and how it is affected by breaking changes in react-redux version 8.0.2 (see details below). JSFIX checked for the 3 breaking changes affecting react-redux version 8.0.2 and found 1 occurrences in compliance-frontend. 1 of the occurrences must be manually audited. 

<strong>Install the [JSFIX GitHub app](https://github.com/apps/jsfix-updater) to receive other package upgrades from JSFIX.</strong>

***

<h3>Breaking change details</h3>

<details open><summary><strong> 🚧 - Not automatically fixed breaking changes (please check before merging)</strong></summary><blockquote class="pr-blockquote"><details open>
<summary>Affects all applications (not related to specific API usages in your code).</summary>

* If you are using Typescript, React-Redux is now written in TS and includes its own types. You should remove any dependencies on @types/react-redux.
</details>

</blockquote></details><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* The connectAdvanced API is now deprecated 
* The pure option for connect has been removed.
</details>



***

<strong>Visit [https://jsfix.live/about-jsfix](https://jsfix.live/about-jsfix) to learn more about how JSFIX works.</strong>


If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.