### PR TITLE
fix(ReportPDF): RHICOMPL-2943 - Only require report:read permission

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -40,10 +40,7 @@ const reportsRoutes = [
   {
     path: '/reports/:report_id/pdf',
     title: `Export report - ${defaultReportTitle}`,
-    requiredPermissions: [
-      ...defaultPermissions,
-      'compliance:report_export:read',
-    ],
+    requiredPermissions: [...defaultPermissions, 'compliance:report:read'],
     defaultTitle: defaultReportTitle,
     modal: true,
     component: lazy(() =>

--- a/src/Utilities/__snapshots__/Router.test.js.snap
+++ b/src/Utilities/__snapshots__/Router.test.js.snap
@@ -154,7 +154,7 @@ exports[`Router expect to render without error 1`] = `
         "path": "/reports/:report_id/pdf",
         "requiredPermissions": Array [
           "compliance:*:*",
-          "compliance:report_export:read",
+          "compliance:report:read",
         ],
         "title": "Export report - Reports",
       },
@@ -592,7 +592,7 @@ exports[`Router expect to render without error 1`] = `
       requiredPermissions={
         Array [
           "compliance:*:*",
-          "compliance:report_export:read",
+          "compliance:report:read",
         ]
       }
     >
@@ -613,7 +613,7 @@ exports[`Router expect to render without error 1`] = `
             "path": "/reports/:report_id/pdf",
             "requiredPermissions": Array [
               "compliance:*:*",
-              "compliance:report_export:read",
+              "compliance:report:read",
             ],
             "setTitle": [Function],
             "title": "Export report - Reports",


### PR DESCRIPTION
Downloading a PDF should, like other export formats only require read permissions.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
