### PR TITLE
fix(ReportsTable):fixed the n/a in the table

### DIFF
--- a/src/PresentationalComponents/ComplianceScore/ComplianceScore.test.js
+++ b/src/PresentationalComponents/ComplianceScore/ComplianceScore.test.js
@@ -14,6 +14,19 @@ describe('auxiliary functions to reducer', () => {
     expect(toJson(dangerIcon)).toMatchSnapshot();
   });
 
+  it('should show 0% score instead if the system score is 0', () => {
+    const system = {
+      rulesPassed: 30,
+      rulesFailed: 300,
+      score: 0,
+      supported: true,
+      compliant: false,
+    };
+
+    const dangerIcon = mount(<ComplianceScore {...system} />);
+    expect(toJson(dangerIcon)).toMatchSnapshot();
+  });
+
   it('should show a success icon if the host is compliant', () => {
     const system = {
       rulesPassed: 30,

--- a/src/PresentationalComponents/ComplianceScore/__snapshots__/ComplianceScore.test.js.snap
+++ b/src/PresentationalComponents/ComplianceScore/__snapshots__/ComplianceScore.test.js.snap
@@ -1,5 +1,148 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`auxiliary functions to reducer should show 0% score instead if the system score is 0 1`] = `
+<ComplianceScore
+  compliant={false}
+  rulesFailed={300}
+  rulesPassed={30}
+  score={0}
+  supported={true}
+>
+  <Text>
+    <p
+      className=""
+      data-ouia-component-id="OUIA-Generated-Text-2"
+      data-ouia-component-type="PF4/Text"
+      data-ouia-safe={true}
+      data-pf-content={true}
+    >
+      <Tooltip
+        content="The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy."
+      >
+        <Popper
+          appendTo={[Function]}
+          distance={15}
+          enableFlip={true}
+          flipBehavior={
+            Array [
+              "top",
+              "right",
+              "bottom",
+              "left",
+              "top",
+              "right",
+              "bottom",
+            ]
+          }
+          isVisible={false}
+          onBlur={[Function]}
+          onDocumentClick={false}
+          onDocumentKeyDown={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onPopperMouseEnter={[Function]}
+          onPopperMouseLeave={[Function]}
+          onTriggerEnter={[Function]}
+          placement="top"
+          popper={
+            <div
+              aria-live="off"
+              className="pf-c-tooltip"
+              id="pf-tooltip-2"
+              role="tooltip"
+              style={
+                Object {
+                  "maxWidth": null,
+                  "opacity": 0,
+                  "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                }
+              }
+            >
+              <TooltipArrow />
+              <TooltipContent
+                isLeftAligned={false}
+              >
+                The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy.
+              </TooltipContent>
+            </div>
+          }
+          popperMatchesTriggerWidth={false}
+          positionModifiers={
+            Object {
+              "bottom": "pf-m-bottom",
+              "bottom-end": "pf-m-bottom-right",
+              "bottom-start": "pf-m-bottom-left",
+              "left": "pf-m-left",
+              "left-end": "pf-m-left-bottom",
+              "left-start": "pf-m-left-top",
+              "right": "pf-m-right",
+              "right-end": "pf-m-right-bottom",
+              "right-start": "pf-m-right-top",
+              "top": "pf-m-top",
+              "top-end": "pf-m-top-right",
+              "top-start": "pf-m-top-left",
+            }
+          }
+          trigger={
+            Array [
+              <CompliantIcon
+                compliant={false}
+                rulesFailed={300}
+                rulesPassed={30}
+                score={0}
+                supported={true}
+              />,
+              " 0%",
+            ]
+          }
+          zIndex={9999}
+        >
+          <FindRefWrapper
+            onFoundRef={[Function]}
+          >
+            <CompliantIcon
+              compliant={false}
+              key="system-compliance-icon-undefined"
+              rulesFailed={300}
+              rulesPassed={30}
+              score={0}
+              supported={true}
+            >
+              <ExclamationCircleIcon
+                color="var(--pf-global--danger-color--100)"
+                noVerticalAlign={false}
+                size="sm"
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="var(--pf-global--danger-color--100)"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                  />
+                </svg>
+              </ExclamationCircleIcon>
+            </CompliantIcon>
+             0%
+          </FindRefWrapper>
+        </Popper>
+      </Tooltip>
+    </p>
+  </Text>
+</ComplianceScore>
+`;
+
 exports[`auxiliary functions to reducer should show a danger icon if the host is not compliant 1`] = `
 <ComplianceScore
   compliant={false}
@@ -151,7 +294,7 @@ exports[`auxiliary functions to reducer should show a question mark icon if the 
   <Text>
     <p
       className=""
-      data-ouia-component-id="OUIA-Generated-Text-3"
+      data-ouia-component-id="OUIA-Generated-Text-4"
       data-ouia-component-type="PF4/Text"
       data-ouia-safe={true}
       data-pf-content={true}
@@ -181,7 +324,7 @@ exports[`auxiliary functions to reducer should show a success icon if the host i
   <Text>
     <p
       className=""
-      data-ouia-component-id="OUIA-Generated-Text-2"
+      data-ouia-component-id="OUIA-Generated-Text-3"
       data-ouia-component-type="PF4/Text"
       data-ouia-safe={true}
       data-pf-content={true}

--- a/src/Utilities/TextHelper.js
+++ b/src/Utilities/TextHelper.js
@@ -1,8 +1,8 @@
 export const isNumberRange = (value) => value && !!value.match(/\d\d*-\d\d*/);
 
 export const fixedPercentage = (value, fixed = 0, withPercent = true) => {
-  const fixedValue = value ? parseFloat(value).toFixed(fixed) : undefined;
-  return fixedValue ? fixedValue + (withPercent ? '%' : '') : 'N/A';
+  const fixedValue = parseFloat(value)?.toFixed(fixed);
+  return fixedValue + (withPercent ? '%' : '');
 };
 
 export const pluralize = (value, singular, plural) => {


### PR DESCRIPTION
It was requested to show the "number%" instead of N/A even in cases when there is a 0 compliance score.
This function was utilized both by table and Donut Chart.

![image](https://user-images.githubusercontent.com/62722417/180239492-4a30e00a-87f1-4195-848c-85f544880809.png)
![image](https://user-images.githubusercontent.com/62722417/180239553-0dabaa4f-1576-4932-95c7-e35e20a56952.png)

