### PR TITLE
fix(ReportPDF): Added a query parameter for the rulesFailed

### DIFF
--- a/src/SmartComponents/ReportDownload/constants.js
+++ b/src/SmartComponents/ReportDownload/constants.js
@@ -33,6 +33,7 @@ export const GET_SYSTEMS = gql`
           osMajorVersion
           osMinorVersion
           insightsId
+          rulesFailed
           testResultProfiles(policyId: $policyId) {
             lastScanned
             compliant


### PR DESCRIPTION
Added a rulesFailed to the GraphQL request. That was the last part missing, everything else works fine.
Now PDF report contains the rules failed number.
(Don't look at the N/A - this patch is not merged yet)
![image](https://user-images.githubusercontent.com/62722417/180437899-d38c2673-5fa4-4ce7-9285-5abfd460d5fc.png)
