### PR TITLE
fix(EditPolicy): RHICOMPL-1783 - Correct behaviour of alert for new rules

### DIFF
--- a/src/PresentationalComponents/TabbedRules/TabbedRules.js
+++ b/src/PresentationalComponents/TabbedRules/TabbedRules.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import propTypes from 'prop-types';
 import { Tab, Badge } from '@patternfly/react-core';
 import { RoutedTabs } from 'PresentationalComponents';
@@ -39,23 +39,22 @@ const TabbedRules = ({
   ouiaId,
   ...rulesTableProps
 }) => {
-  const handleSelect = (
-    profile,
-    newOsMinorVersion,
-    profileSelectedRuleRefIds
-  ) => {
-    const filteredSelection = (selectedRuleRefIds || []).filter(
-      (selectionItem) =>
-        !matchesSelectionItem(selectionItem, profile, newOsMinorVersion)
-    );
+  const handleSelect = useCallback(
+    (profile, newOsMinorVersion, profileSelectedRuleRefIds) => {
+      const filteredSelection = (selectedRuleRefIds || []).filter(
+        (selectionItem) =>
+          !matchesSelectionItem(selectionItem, profile, newOsMinorVersion)
+      );
 
-    const newItem = {
-      id: profile.id,
-      osMinorVersion: newOsMinorVersion || profile.osMinorVersion,
-      ruleRefIds: profileSelectedRuleRefIds,
-    };
-    setSelectedRuleRefIds([newItem, ...filteredSelection]);
-  };
+      const newItem = {
+        id: profile.id,
+        osMinorVersion: newOsMinorVersion || profile.osMinorVersion,
+        ruleRefIds: profileSelectedRuleRefIds,
+      };
+      setSelectedRuleRefIds([newItem, ...filteredSelection]);
+    },
+    [selectedRuleRefIds]
+  );
 
   return (
     <RoutedTabs

--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -1,13 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import propTypes from 'prop-types';
 import { Form, Tab, TabTitleText } from '@patternfly/react-core';
 import { RoutedTabs } from 'PresentationalComponents';
 import EditPolicyDetailsTab from './EditPolicyDetailsTab';
 import EditPolicyRulesTab from './EditPolicyRulesTab';
 import EditPolicySystemsTab from './EditPolicySystemsTab';
+import NewRulesAlert from './components/NewRulesAlert';
 import { mapCountOsMinorVersions } from 'Store/Reducers/SystemStore';
 import { profilesWithRulesToSelection } from 'PresentationalComponents/TabbedRules';
 import { thresholdValid } from '../CreatePolicy/validate';
+import { useNewRulesAlertState } from './hooks/index';
 
 const profilesToOsMinorMap = (profiles, hosts) =>
   (profiles || []).reduce((acc, profile) => {
@@ -21,7 +23,7 @@ const profilesToOsMinorMap = (profiles, hosts) =>
     return acc;
   }, mapCountOsMinorVersions(hosts || []));
 
-export const EditPolicyForm = ({
+const EditPolicyForm = ({
   policy,
   updatedPolicy,
   setUpdatedPolicy,
@@ -32,43 +34,48 @@ export const EditPolicyForm = ({
 }) => {
   const policyProfiles = policy?.policy?.profiles || [];
   const [osMinorVersionCounts, setOsMinorVersionCounts] = useState({});
-  const [newRuleTabs, setNewRuleTabs] = useState(false);
+  const [newRulesAlert, setNewRulesAlert] = useNewRulesAlertState(false);
 
-  const handleSystemSelect = (selectedSystems) => {
-    setSelectedSystems(selectedSystems);
-
-    setOsMinorVersionCounts(
-      profilesToOsMinorMap(policyProfiles, selectedSystems)
-    );
-  };
-
-  const updateSelectedRuleRefIds = () => {
-    if (policy) {
-      // existing policy profiles and their rule sets
-      const profilesWithOsMinor = policyProfiles.filter(
-        ({ osMinorVersion }) => !!osMinorVersion
+  const handleSystemSelect = useCallback(
+    (newSelectedSystems) => {
+      const policyMinorVersions = policy.hosts.map(
+        ({ osMinorVersion }) => osMinorVersion
       );
-      setSelectedRuleRefIds(profilesWithRulesToSelection(profilesWithOsMinor));
-    }
-  };
+      const hasNewOsMinorVersions =
+        newSelectedSystems.filter(
+          ({ osMinorVersion }) => !policyMinorVersions.includes(osMinorVersion)
+        ).length > 0;
+
+      setSelectedSystems(newSelectedSystems);
+      setNewRulesAlert(hasNewOsMinorVersions);
+      setOsMinorVersionCounts(
+        profilesToOsMinorMap(policyProfiles, newSelectedSystems)
+      );
+    },
+    [policyProfiles, selectedRuleRefIds]
+  );
 
   useEffect(() => {
     if (policy) {
       const complianceThresholdValid = thresholdValid(
         policy.complianceThreshold
       );
+      const profilesWithOsMinor = policyProfiles.filter(
+        ({ osMinorVersion }) => !!osMinorVersion
+      );
       setUpdatedPolicy({
         ...policy,
         complianceThresholdValid,
       });
-      updateSelectedRuleRefIds();
+
+      setSelectedRuleRefIds(profilesWithRulesToSelection(profilesWithOsMinor));
       handleSystemSelect(policy.hosts);
     }
   }, [policy]);
 
   return (
     <Form>
-      <RoutedTabs ouiaId="EditPolicy" defaultTab="details">
+      <RoutedTabs ouiaId="EditPolicy" defaultTab="details" id="policy-tabs">
         <Tab
           eventKey="details"
           ouiaId="Details"
@@ -88,7 +95,6 @@ export const EditPolicyForm = ({
         >
           <EditPolicyRulesTab
             policy={policy}
-            setNewRuleTabs={setNewRuleTabs}
             setSelectedRuleRefIds={setSelectedRuleRefIds}
             selectedRuleRefIds={selectedRuleRefIds}
             osMinorVersionCounts={osMinorVersionCounts}
@@ -102,10 +108,10 @@ export const EditPolicyForm = ({
         >
           <EditPolicySystemsTab
             policy={policy}
-            newRuleTabs={newRuleTabs}
             selectedSystems={selectedSystems}
             onSystemSelect={handleSystemSelect}
           />
+          {newRulesAlert && <NewRulesAlert />}
         </Tab>
       </RoutedTabs>
     </Form>

--- a/src/SmartComponents/EditPolicy/EditPolicyForm.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.test.js
@@ -1,34 +1,89 @@
+import propTypes from 'prop-types';
+import { render } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+import { BENCHMARKS_QUERY } from './constants';
+
+import { policies } from '@/__fixtures__/policies.js';
+
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+
 import EditPolicyForm from './EditPolicyForm';
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(() => ({})),
-  useDispatch: jest.fn(() => ({})),
+import { useNewRulesAlertState } from './hooks';
+
+jest.mock('./hooks', () => ({
+  ...jest.requireActual('./hooks'),
+  useNewRulesAlertState: jest.fn(() => [false, () => false]),
 }));
 
-describe('EditPolicyForm', () => {
-  it('expect to render without error', () => {
-    const policy = {
-      id: '1',
-      refId: '121212',
-      name: 'profile1',
-      description: 'profile description',
-      totalHostCount: 1,
-      complianceThreshold: 1,
-      compliantHostCount: 1,
-      policy: {
-        name: 'parentpolicy',
-      },
-      businessObjective: {
-        id: '1',
-        title: 'BO 1',
-      },
-      benchmark: {
-        title: 'benchmark',
-        version: '0.1.5',
-      },
-    };
-    const wrapper = shallow(<EditPolicyForm {...policy} />);
+const initialState = {};
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    default:
+      return state;
+  }
+};
 
-    expect(toJson(wrapper)).toMatchSnapshot();
+const TestWrapper = ({ children, mocks = [] }) => {
+  const history = createMemoryHistory();
+  const store = createStore(reducer, initialState);
+
+  return (
+    <Provider store={store}>
+      <Router history={history}>
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      </Router>
+    </Provider>
+  );
+};
+
+TestWrapper.propTypes = {
+  children: propTypes.node,
+  mocks: propTypes.arra,
+};
+
+describe('EditPolicyForm', () => {
+  const policy = {
+    ...policies.edges[0].node,
+    supportedOsVersions: ['7.8', '7.9'],
+  };
+  const mocks = [
+    {
+      request: {
+        query: BENCHMARKS_QUERY,
+      },
+      result: {
+        data: {},
+      },
+    },
+  ];
+  const defaultProps = {
+    setUpdatedPolicy: () => ({}),
+    setSelectedRuleRefIds: () => ({}),
+    setSelectedSystems: () => ({}),
+    policy,
+  };
+
+  it('expect to render without error', () => {
+    useNewRulesAlertState.mockImplementation(() => [false, () => false]);
+    const { asFragment } = render(
+      <TestWrapper mocks={mocks}>
+        <EditPolicyForm {...defaultProps} />
+      </TestWrapper>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('expect to render with alter', () => {
+    useNewRulesAlertState.mockImplementation(() => [true, () => true]);
+    const { asFragment } = render(
+      <TestWrapper mocks={mocks}>
+        <EditPolicyForm {...defaultProps} />
+      </TestWrapper>
+    );
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -1,14 +1,8 @@
 import React from 'react';
-import {
-  Alert,
-  AlertActionLink,
-  Text,
-  TextContent,
-} from '@patternfly/react-core';
+import { Text, TextContent } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import { SystemsTable } from 'SmartComponents';
 import { GET_SYSTEMS_WITH_POLICIES } from '../SystemsTable/constants';
-import { useHistory } from 'react-router-dom';
 import * as Columns from '../SystemsTable/Columns';
 
 const EmptyState = ({ osMajorVersion }) => (
@@ -44,13 +38,7 @@ PrependComponent.propTypes = {
   osMajorVersion: propTypes.string,
 };
 
-const EditPolicySystemsTab = ({
-  policy,
-  newRuleTabs,
-  onSystemSelect,
-  selectedSystems,
-}) => {
-  const { push, location } = useHistory();
+const EditPolicySystemsTab = ({ policy, onSystemSelect, selectedSystems }) => {
   const { id: policyId, osMajorVersion, supportedOsVersions } = policy;
   const osMinorVersions = supportedOsVersions.map(
     (version) => version.split('.')[1]
@@ -84,25 +72,6 @@ const EditPolicySystemsTab = ({
         preselectedSystems={selectedSystems}
         onSelect={onSystemSelect}
       />
-      {newRuleTabs && (
-        <Alert
-          variant="info"
-          isInline
-          title="You selected a system that has a release version previously not included in this policy."
-          actionLinks={
-            <AlertActionLink
-              onClick={() => push({ ...location, hash: '#rules' })}
-            >
-              Open rule editing
-            </AlertActionLink>
-          }
-        >
-          <p>
-            If you have edited any rules for this policy, you will need to do so
-            for this release version as well.
-          </p>
-        </Alert>
-      )}
     </React.Fragment>
   );
 };

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyForm.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyForm.test.js.snap
@@ -1,67 +1,683 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EditPolicyForm expect to render without error 1`] = `
-<Form>
-  <RoutedTabs
-    defaultTab="details"
-    level={0}
-    ouiaId="EditPolicy"
+exports[`EditPolicyForm expect to render with alter 1`] = `
+<DocumentFragment>
+  <form
+    class="pf-c-form"
+    novalidate=""
   >
-    <Tab
-      eventKey="details"
-      ouiaId="Details"
-      title={
-        <TabTitleText>
-          Details
-        </TabTitleText>
-      }
+    <div
+      class="pf-c-tabs"
+      data-ouia-component-id="EditPolicy"
+      data-ouia-component-type="PF4/Tabs"
+      data-ouia-safe="true"
+      id="policy-tabs"
     >
-      <EditPolicyDetailsTab
-        policy={
-          Object {
-            "name": "parentpolicy",
-          }
-        }
-      />
-    </Tab>
-    <Tab
-      eventKey="rules"
-      ouiaId="Rules"
-      title={
-        <TabTitleText>
-          Rules
-        </TabTitleText>
-      }
+      <button
+        aria-hidden="true"
+        aria-label="Scroll left"
+        class="pf-c-tabs__scroll-button"
+        disabled=""
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+          />
+        </svg>
+      </button>
+      <ul
+        class="pf-c-tabs__list"
+        role="tablist"
+      >
+        <li
+          class="pf-c-tabs__item pf-m-current"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-details-policy-tabs"
+            aria-selected="true"
+            class="pf-c-tabs__link"
+            data-ouia-component-id="Details"
+            data-ouia-component-type="PF4/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-details-policy-tabs"
+            role="tab"
+          >
+            <span
+              class="pf-c-tabs__item-text"
+            >
+              Details
+            </span>
+          </button>
+        </li>
+        <li
+          class="pf-c-tabs__item"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-rules-policy-tabs"
+            aria-selected="false"
+            class="pf-c-tabs__link"
+            data-ouia-component-id="Rules"
+            data-ouia-component-type="PF4/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-rules-policy-tabs"
+            role="tab"
+          >
+            <span
+              class="pf-c-tabs__item-text"
+            >
+              Rules
+            </span>
+          </button>
+        </li>
+        <li
+          class="pf-c-tabs__item"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-systems-policy-tabs"
+            aria-selected="false"
+            class="pf-c-tabs__link"
+            data-ouia-component-id="Systems"
+            data-ouia-component-type="PF4/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-systems-policy-tabs"
+            role="tab"
+          >
+            <span
+              class="pf-c-tabs__item-text"
+            >
+              Systems
+            </span>
+          </button>
+        </li>
+      </ul>
+      <button
+        aria-hidden="true"
+        aria-label="Scroll right"
+        class="pf-c-tabs__scroll-button"
+        disabled=""
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+          />
+        </svg>
+      </button>
+    </div>
+    <section
+      aria-labelledby="pf-tab-details-policy-tabs"
+      class="pf-c-tab-content"
+      data-ouia-component-id="Details"
+      data-ouia-component-type="PF4/TabContent"
+      data-ouia-safe="true"
+      id="pf-tab-section-details-policy-tabs"
+      role="tabpanel"
+      tabindex="0"
     >
-      <EditPolicyRulesTab
-        osMinorVersionCounts={Object {}}
-        policy={
-          Object {
-            "name": "parentpolicy",
-          }
-        }
-        setNewRuleTabs={[Function]}
-      />
-    </Tab>
-    <Tab
-      eventKey="systems"
-      ouiaId="Systems"
-      title={
-        <TabTitleText>
-          Systems
-        </TabTitleText>
-      }
+      <div
+        class="pf-c-form"
+      >
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="description"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                Policy description
+              </span>
+              <span
+                aria-hidden="true"
+                class="pf-c-form__label-required"
+              >
+                 *
+              </span>
+            </label>
+             
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <textarea
+              aria-describedby="description"
+              aria-invalid="false"
+              class="pf-c-form-control"
+              id="description"
+              name="description"
+              required=""
+              style="width: 800px; height: 110px;"
+              type="text"
+            />
+          </div>
+        </div>
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="business-objective"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                Business objective
+              </span>
+            </label>
+             
+            <span>
+               
+              <svg
+                aria-hidden="true"
+                class="grey-icon"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <input
+              aria-describedby="business-objective"
+              aria-invalid="false"
+              class="pf-c-form-control"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-3"
+              data-ouia-component-type="PF4/TextInput"
+              data-ouia-safe="true"
+              id="business-objective"
+              name="business-objective"
+              style="width: 300px;"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="policy-threshold"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                Compliance threshold (%)
+              </span>
+            </label>
+             
+            <span>
+               
+              <svg
+                aria-hidden="true"
+                class="grey-icon"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <input
+              aria-describedby="policy-threshold"
+              aria-invalid="false"
+              class="pf-c-form-control"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+              data-ouia-component-type="PF4/TextInput"
+              data-ouia-safe="true"
+              id="compliance-threshold"
+              name="compliance-threshold"
+              style="width: 150px;"
+              type="number"
+              value="100"
+            />
+            <div
+              aria-live="polite"
+              class="pf-c-form__helper-text"
+              id="policy-threshold-helper"
+            >
+              A value of 95% or higher is recommended
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      aria-labelledby="pf-tab-rules-policy-tabs"
+      class="pf-c-tab-content"
+      data-ouia-component-id="Rules"
+      data-ouia-component-type="PF4/TabContent"
+      data-ouia-safe="true"
+      hidden=""
+      id="pf-tab-section-rules-policy-tabs"
+      role="tabpanel"
+      tabindex="0"
     >
-      <EditPolicySystemsTab
-        newRuleTabs={false}
-        onSystemSelect={[Function]}
-        policy={
-          Object {
-            "name": "parentpolicy",
-          }
-        }
-      />
-    </Tab>
-  </RoutedTabs>
-</Form>
+      <div
+        class="ins-c-table__empty"
+      >
+         
+        <div
+          class="ins-c-spinner"
+          role="status"
+        >
+          <span
+            class="pf-u-screen-reader"
+          >
+            Loading...
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      aria-labelledby="pf-tab-systems-policy-tabs"
+      class="pf-c-tab-content"
+      data-ouia-component-id="Systems"
+      data-ouia-component-type="PF4/TabContent"
+      data-ouia-safe="true"
+      hidden=""
+      id="pf-tab-section-systems-policy-tabs"
+      role="tabpanel"
+      tabindex="0"
+    >
+      <section
+        class="inventory"
+      >
+        <div>
+          <h1>
+            Inventory mock
+          </h1>
+        </div>
+      </section>
+    </section>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`EditPolicyForm expect to render without error 1`] = `
+<DocumentFragment>
+  <form
+    class="pf-c-form"
+    novalidate=""
+  >
+    <div
+      class="pf-c-tabs"
+      data-ouia-component-id="EditPolicy"
+      data-ouia-component-type="PF4/Tabs"
+      data-ouia-safe="true"
+      id="policy-tabs"
+    >
+      <button
+        aria-hidden="true"
+        aria-label="Scroll left"
+        class="pf-c-tabs__scroll-button"
+        disabled=""
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+          />
+        </svg>
+      </button>
+      <ul
+        class="pf-c-tabs__list"
+        role="tablist"
+      >
+        <li
+          class="pf-c-tabs__item pf-m-current"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-details-policy-tabs"
+            aria-selected="true"
+            class="pf-c-tabs__link"
+            data-ouia-component-id="Details"
+            data-ouia-component-type="PF4/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-details-policy-tabs"
+            role="tab"
+          >
+            <span
+              class="pf-c-tabs__item-text"
+            >
+              Details
+            </span>
+          </button>
+        </li>
+        <li
+          class="pf-c-tabs__item"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-rules-policy-tabs"
+            aria-selected="false"
+            class="pf-c-tabs__link"
+            data-ouia-component-id="Rules"
+            data-ouia-component-type="PF4/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-rules-policy-tabs"
+            role="tab"
+          >
+            <span
+              class="pf-c-tabs__item-text"
+            >
+              Rules
+            </span>
+          </button>
+        </li>
+        <li
+          class="pf-c-tabs__item"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-systems-policy-tabs"
+            aria-selected="false"
+            class="pf-c-tabs__link"
+            data-ouia-component-id="Systems"
+            data-ouia-component-type="PF4/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-systems-policy-tabs"
+            role="tab"
+          >
+            <span
+              class="pf-c-tabs__item-text"
+            >
+              Systems
+            </span>
+          </button>
+        </li>
+      </ul>
+      <button
+        aria-hidden="true"
+        aria-label="Scroll right"
+        class="pf-c-tabs__scroll-button"
+        disabled=""
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+          />
+        </svg>
+      </button>
+    </div>
+    <section
+      aria-labelledby="pf-tab-details-policy-tabs"
+      class="pf-c-tab-content"
+      data-ouia-component-id="Details"
+      data-ouia-component-type="PF4/TabContent"
+      data-ouia-safe="true"
+      id="pf-tab-section-details-policy-tabs"
+      role="tabpanel"
+      tabindex="0"
+    >
+      <div
+        class="pf-c-form"
+      >
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="description"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                Policy description
+              </span>
+              <span
+                aria-hidden="true"
+                class="pf-c-form__label-required"
+              >
+                 *
+              </span>
+            </label>
+             
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <textarea
+              aria-describedby="description"
+              aria-invalid="false"
+              class="pf-c-form-control"
+              id="description"
+              name="description"
+              required=""
+              style="width: 800px; height: 110px;"
+              type="text"
+            />
+          </div>
+        </div>
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="business-objective"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                Business objective
+              </span>
+            </label>
+             
+            <span>
+               
+              <svg
+                aria-hidden="true"
+                class="grey-icon"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <input
+              aria-describedby="business-objective"
+              aria-invalid="false"
+              class="pf-c-form-control"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+              data-ouia-component-type="PF4/TextInput"
+              data-ouia-safe="true"
+              id="business-objective"
+              name="business-objective"
+              style="width: 300px;"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="policy-threshold"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                Compliance threshold (%)
+              </span>
+            </label>
+             
+            <span>
+               
+              <svg
+                aria-hidden="true"
+                class="grey-icon"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <input
+              aria-describedby="policy-threshold"
+              aria-invalid="false"
+              class="pf-c-form-control"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+              data-ouia-component-type="PF4/TextInput"
+              data-ouia-safe="true"
+              id="compliance-threshold"
+              name="compliance-threshold"
+              style="width: 150px;"
+              type="number"
+              value="100"
+            />
+            <div
+              aria-live="polite"
+              class="pf-c-form__helper-text"
+              id="policy-threshold-helper"
+            >
+              A value of 95% or higher is recommended
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      aria-labelledby="pf-tab-rules-policy-tabs"
+      class="pf-c-tab-content"
+      data-ouia-component-id="Rules"
+      data-ouia-component-type="PF4/TabContent"
+      data-ouia-safe="true"
+      hidden=""
+      id="pf-tab-section-rules-policy-tabs"
+      role="tabpanel"
+      tabindex="0"
+    >
+      <div
+        class="ins-c-table__empty"
+      >
+         
+        <div
+          class="ins-c-spinner"
+          role="status"
+        >
+          <span
+            class="pf-u-screen-reader"
+          >
+            Loading...
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      aria-labelledby="pf-tab-systems-policy-tabs"
+      class="pf-c-tab-content"
+      data-ouia-component-id="Systems"
+      data-ouia-component-type="PF4/TabContent"
+      data-ouia-safe="true"
+      hidden=""
+      id="pf-tab-section-systems-policy-tabs"
+      role="tabpanel"
+      tabindex="0"
+    >
+      <section
+        class="inventory"
+      >
+        <div>
+          <h1>
+            Inventory mock
+          </h1>
+        </div>
+      </section>
+    </section>
+  </form>
+</DocumentFragment>
 `;

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicySystemsTab.test.js.snap
@@ -506,22 +506,6 @@ exports[`EditPolicySystemsTab expect to render with new tabs alert 1`] = `
       ]
     }
   />
-  <Alert
-    actionLinks={
-      <AlertActionLink
-        onClick={[Function]}
-      >
-        Open rule editing
-      </AlertActionLink>
-    }
-    isInline={true}
-    title="You selected a system that has a release version previously not included in this policy."
-    variant="info"
-  >
-    <p>
-      If you have edited any rules for this policy, you will need to do so for this release version as well.
-    </p>
-  </Alert>
 </Fragment>
 `;
 

--- a/src/SmartComponents/EditPolicy/components/NewRulesAlert.js
+++ b/src/SmartComponents/EditPolicy/components/NewRulesAlert.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+import { Alert, AlertActionLink } from '@patternfly/react-core';
+
+const NewRulesAlert = () => {
+  const history = useHistory();
+  const location = useLocation();
+
+  return (
+    <Alert
+      variant="info"
+      isInline
+      title="You selected a system that has a release version previously not included in this policy."
+      actionLinks={
+        <AlertActionLink
+          onClick={() => history.push({ ...location, hash: '#rules' })}
+        >
+          Open rule editing
+        </AlertActionLink>
+      }
+    >
+      <p>
+        If you have edited any rules for this policy, you will need to do so for
+        this release version as well.
+      </p>
+    </Alert>
+  );
+};
+
+export default NewRulesAlert;

--- a/src/SmartComponents/EditPolicy/constants.js
+++ b/src/SmartComponents/EditPolicy/constants.js
@@ -1,0 +1,54 @@
+import gql from 'graphql-tag';
+
+export const PROFILES_QUERY = gql`
+  query Profiles($filter: String!) {
+    profiles(search: $filter) {
+      edges {
+        node {
+          id
+          name
+          refId
+          osMinorVersion
+          osMajorVersion
+          policy {
+            id
+          }
+          policyType
+          benchmark {
+            id
+            refId
+            latestSupportedOsMinorVersions
+            osMajorVersion
+            version
+          }
+          rules {
+            id
+            title
+            severity
+            rationale
+            refId
+            description
+            remediationAvailable
+            identifier
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const BENCHMARKS_QUERY = gql`
+  query Benchmarks($filter: String!) {
+    benchmarks(search: $filter) {
+      nodes {
+        id
+        latestSupportedOsMinorVersions
+        profiles {
+          id
+          refId
+          ssgVersion
+        }
+      }
+    }
+  }
+`;

--- a/src/SmartComponents/EditPolicy/hooks/index.js
+++ b/src/SmartComponents/EditPolicy/hooks/index.js
@@ -1,0 +1,3 @@
+import { useState } from 'react';
+
+export const useNewRulesAlertState = (...args) => useState(...args);


### PR DESCRIPTION
This corrects the behaviour of the alert about new rules at the bottom of the "Systems" tab.
it now correctly identifies if there is a new set of rules to configure if a systems with a minor version is selected that had not yet been covered by a rule set.

*How to test:*

1. Find a profile with multiple supported RHEL minor versions
2. Select systems only of one minor version and create the policy
3. Edit the policy.
4. The modal on the Systems tab should not show the alert when first loaded.
5. Select systems of a different minor version
6. The Alert should appear and allow to switch to the "Rules" tab via the link
7. (When removing all systems of a specific minor version, the alert should disappear again)
8. After saving and reopening there should again not be any alert on the Systems tab


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
