### PR TITLE
fix(InventoryTable): RHICOMPL-3304 use shared tags filter instead of custom one

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -20,7 +20,6 @@ import {
   useSystemsExport,
   useSystemsFilter,
   useSystemBulkSelect,
-  useTags,
 } from './hooks';
 import { constructQuery } from '../../Utilities/helpers';
 
@@ -55,6 +54,8 @@ export const SystemsTable = ({
   const [isLoaded, setIsLoaded] = useState(false);
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
+  const [currentTags, setCurrentTags] = useState([]);
+
   const osMinorVersionFilter = useOsMinorVersionFilter(
     showOsMinorVersionFilter,
     {
@@ -85,18 +86,6 @@ export const SystemsTable = ({
     showOnlySystemsWithTestResults,
     defaultFilter
   );
-
-  const {
-    props: tagsProps,
-    currentTags,
-    setCurrentTags,
-    getTags,
-  } = useTags({
-    variables: {
-      filter: systemsFilter,
-      ...(policyId && { policyId }),
-    },
-  });
 
   const constructedQuery = constructQuery(columns);
 
@@ -136,7 +125,6 @@ export const SystemsTable = ({
     setItems(result.entities);
     setIsLoaded(true);
     setCurrentTags && setCurrentTags(result.meta.tags);
-
     if (
       emptyStateComponent &&
       result.meta.totalCount === 0 &&
@@ -161,7 +149,6 @@ export const SystemsTable = ({
     selected: selectedIds,
     total,
     fetchArguments: {
-      tags: currentTags,
       ...systemFetchArguments,
     },
   });
@@ -211,13 +198,13 @@ export const SystemsTable = ({
         )}
         <InventoryTable
           {...systemProps}
-          {...tagsProps}
           disableDefaultColumns
           columns={mergedColumns}
           noSystemsTable={noSystemsTable}
           ref={inventory}
           getEntities={getEntities}
-          getTags={getTags}
+          hideFilters={{ all: true, tags: false }}
+          showTags
           onLoad={defaultOnLoad(columns)}
           tableProps={{
             ...bulkSelectTableProps,

--- a/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/SystemsTable.test.js.snap
@@ -195,13 +195,9 @@ exports[`SystemsTable returns 1`] = `
         }
       }
       getEntities={[Function]}
-      getTags={[Function]}
       hideFilters={
         Object {
-          "name": true,
-          "operatingSystem": true,
-          "registeredWith": true,
-          "stale": true,
+          "all": true,
           "tags": false,
         }
       }
@@ -415,13 +411,9 @@ exports[`SystemsTable returns compact 1`] = `
         }
       }
       getEntities={[Function]}
-      getTags={[Function]}
       hideFilters={
         Object {
-          "name": true,
-          "operatingSystem": true,
-          "registeredWith": true,
-          "stale": true,
+          "all": true,
           "tags": false,
         }
       }
@@ -509,13 +501,9 @@ exports[`SystemsTable returns showAllSystems 1`] = `
       }
       fallback={<Spinner />}
       getEntities={[Function]}
-      getTags={[Function]}
       hideFilters={
         Object {
-          "name": true,
-          "operatingSystem": true,
-          "registeredWith": true,
-          "stale": true,
+          "all": true,
           "tags": false,
         }
       }
@@ -735,13 +723,9 @@ exports[`SystemsTable returns with a showComplianceSystemsInfo 1`] = `
         }
       }
       getEntities={[Function]}
-      getTags={[Function]}
       hideFilters={
         Object {
-          "name": true,
-          "operatingSystem": true,
-          "registeredWith": true,
-          "stale": true,
+          "all": true,
           "tags": false,
         }
       }
@@ -1011,13 +995,9 @@ exports[`SystemsTable returns with compliantFilter 1`] = `
         }
       }
       getEntities={[Function]}
-      getTags={[Function]}
       hideFilters={
         Object {
-          "name": true,
-          "operatingSystem": true,
-          "registeredWith": true,
-          "stale": true,
+          "all": true,
           "tags": false,
         }
       }
@@ -1231,13 +1211,9 @@ exports[`SystemsTable returns with showOnlySystemsWithTestResults 1`] = `
         }
       }
       getEntities={[Function]}
-      getTags={[Function]}
       hideFilters={
         Object {
-          "name": true,
-          "operatingSystem": true,
-          "registeredWith": true,
-          "stale": true,
+          "all": true,
           "tags": false,
         }
       }
@@ -1443,13 +1419,9 @@ exports[`SystemsTable returns without actions 1`] = `
         }
       }
       getEntities={[Function]}
-      getTags={[Function]}
       hideFilters={
         Object {
-          "name": true,
-          "operatingSystem": true,
-          "registeredWith": true,
-          "stale": true,
+          "all": true,
           "tags": false,
         }
       }
@@ -1657,13 +1629,9 @@ exports[`SystemsTable returns without remediations 1`] = `
         }
       }
       getEntities={[Function]}
-      getTags={[Function]}
       hideFilters={
         Object {
-          "name": true,
-          "operatingSystem": true,
-          "registeredWith": true,
-          "stale": true,
+          "all": true,
           "tags": false,
         }
       }

--- a/src/SmartComponents/SystemsTable/constants.js
+++ b/src/SmartComponents/SystemsTable/constants.js
@@ -43,14 +43,6 @@ export const GET_MINIMAL_SYSTEMS = gql`
   }
 `;
 
-export const GET_SYSTEMS_TAGS = gql`
-  query getSystems($filter: String!, $limit: Int) {
-    systems(search: $filter, limit: $limit) {
-      tags
-    }
-  }
-`;
-
 export const GET_SYSTEMS_OSES = gql`
   query getSystems($filter: String!) {
     systems(search: $filter) {

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -3,11 +3,7 @@ import { useApolloClient, useQuery } from '@apollo/client';
 import { useDispatch } from 'react-redux';
 import debounce from '@redhat-cloud-services/frontend-components-utilities/debounce';
 import { systemsWithRuleObjectsFailed } from 'Utilities/ruleHelpers';
-import {
-  osMinorVersionFilter,
-  GET_SYSTEMS_TAGS,
-  GET_SYSTEMS_OSES,
-} from './constants';
+import { osMinorVersionFilter, GET_SYSTEMS_OSES } from './constants';
 import useExport from 'Utilities/hooks/useTableTools/useExport';
 import { useBulkSelect } from 'Utilities/hooks/useTableTools/useBulkSelect';
 import { dispatchNotification } from 'Utilities/Dispatcher';
@@ -366,86 +362,5 @@ export const useSystemBulkSelect = ({
   return {
     selectedSystems,
     ...bulkSelect,
-  };
-};
-
-const searchTags = (search, tags) =>
-  tags.filter((tagItem) => {
-    if (search || search === '') {
-      const tagString = `${tagItem?.key}=${tagItem?.value}`;
-      return tagString.indexOf(search) !== -1;
-    } else {
-      return true;
-    }
-  });
-
-const useFetchTag = () => {
-  const apiClient = useApolloClient();
-
-  return async (page, per_page, search, fetchArguments) => {
-    const fetchedTags = await apiClient
-      .query({
-        query: GET_SYSTEMS_TAGS,
-        ...fetchArguments,
-      })
-      .then(
-        ({
-          data: {
-            systems: { tags },
-          },
-        }) =>
-          searchTags(search, tags).map((tag) => ({
-            tag,
-          }))
-      );
-
-    const start = per_page * page - per_page;
-    const end = start + per_page;
-
-    return {
-      total: fetchedTags.length,
-      results: fetchedTags.slice(start, end),
-    };
-  };
-};
-
-export const useTags = (fetchArguments) => {
-  const [currentTags, setCurrentTags] = useState();
-  const fetchTags = useFetchTag();
-
-  const getTags = async (search, config) => {
-    const { page, perPage: per_page } = config.pagination || {
-      perPage: 10,
-      page: 1,
-    };
-    const { total, results: tagsList } = await fetchTags(
-      page,
-      per_page,
-      search,
-      fetchArguments
-    );
-
-    return {
-      page,
-      per_page,
-      total,
-      results: tagsList,
-    };
-  };
-
-  return {
-    props: {
-      hideFilters: {
-        name: true,
-        tags: false,
-        registeredWith: true,
-        operatingSystem: true,
-        stale: true,
-      },
-      showTags: true,
-    },
-    currentTags,
-    setCurrentTags,
-    getTags,
   };
 };


### PR DESCRIPTION
Resolves: [RHICOMPL-3304](https://issues.redhat.com/browse/RHICOMPL-3304)

As we are working on making tags filter consistent, using the shared filter is required. This PR removes the implementation of a custom tag filter and adopts the shared filter from the InventoryTable component.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
