### PR TITLE
fix(editPolicyInline): fixing a bug with inline edits

### DIFF
--- a/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
+++ b/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
@@ -55,22 +55,23 @@ const EditPolicyDetailsInline = ({
   const [dirty, setDirty] = useState(false);
   const constructData =
     propertyName === 'businessObjective'
-      ? { ...copiedData, [propertyName]: { title: setValue } }
+      ? { ...copiedData, [propertyName]: { title: value } }
       : {
           ...copiedData,
-          [propertyName]: setValue,
+          [propertyName]: value,
         };
 
   const [isSaving, onSave] = useOnSavePolicyDetails(
-    value,
+    policy,
     constructData,
     handleCloseEdit,
-    value.id
+    policy.id
   );
 
   const [isEditOpen, setIsEditOpen] = useState(false);
   const handleToggle = () => {
     setIsEditOpen(!isEditOpen);
+    setValue(text);
   };
   const useInputFocus = useRef();
   useEffect(() => {


### PR DESCRIPTION
Found a bug that was breaking the save function. 
PLUS
A small improvement
I added a logic that removes unsaved changes if the user closes inline edit by pressing on the "pencil" icon-button.