### PR TITLE
fix(ComplianceDetails): Allow routing to root app from fed module

### DIFF
--- a/config/fedMods.js
+++ b/config/fedMods.js
@@ -5,8 +5,5 @@ module.exports = {
     __dirname,
     `../src/${process.env.NODE_ENV === 'development' ? 'Dev' : ''}AppEntry`
   ),
-  './SystemDetail': resolve(
-    __dirname,
-    '../src/SmartComponents/SystemDetails/ComplianceDetail'
-  ),
+  './SystemDetail': resolve(__dirname, '../src/Modules/ComplianceDetails'),
 };

--- a/src/Modules/ComplianceDetails.js
+++ b/src/Modules/ComplianceDetails.js
@@ -1,0 +1,32 @@
+import React, { useRef } from 'react';
+import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-boost';
+import { ApolloProvider } from '@apollo/client';
+import { Provider } from 'react-redux';
+import { init } from 'Store';
+import { FederatedModuleRouter } from '../Utilities/Router';
+import Details from '../SmartComponents/SystemDetails/ComplianceDetail';
+
+const ComplianceDetails = (props) => {
+  const store = useRef(init().getStore());
+  const client = useRef(
+    new ApolloClient({
+      link: new HttpLink({
+        uri: '/api/compliance/graphql',
+        credentials: 'include',
+      }),
+      cache: new InMemoryCache(),
+    })
+  );
+
+  return (
+    <FederatedModuleRouter>
+      <ApolloProvider client={client.current}>
+        <Provider store={store.current}>
+          <Details {...props} />
+        </Provider>
+      </ApolloProvider>
+    </FederatedModuleRouter>
+  );
+};
+
+export default ComplianceDetails;

--- a/src/SmartComponents/SystemDetails/ComplianceDetail.js
+++ b/src/SmartComponents/SystemDetails/ComplianceDetail.js
@@ -5,19 +5,12 @@ import RulesTable from '@/PresentationalComponents/RulesTable/RulesTable';
 import ComplianceEmptyState from 'PresentationalComponents/ComplianceEmptyState';
 import { useQuery } from '@apollo/client';
 import gql from 'graphql-tag';
-import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-boost';
-import { ApolloProvider } from '@apollo/client';
 
 import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
 import './compliance.scss';
 import { ErrorCard } from 'PresentationalComponents';
-import { IntlProvider } from 'react-intl';
-import { BrowserRouter as Router } from 'react-router-dom';
-import { Provider } from 'react-redux';
-import { init } from 'Store';
-import EmptyState from './EmptyState';
 
-const COMPLIANCE_API_ROOT = '/api/compliance';
+import EmptyState from './EmptyState';
 
 const QUERY = gql`
   query System($systemId: String!) {
@@ -169,7 +162,7 @@ SystemQuery.defaultProps = {
   loading: true,
 };
 
-export const SystemDetails = ({ inventoryId, hidePassed, ...props }) => {
+export const Details = ({ inventoryId, hidePassed, ...props }) => {
   let { data, error, loading } = useQuery(QUERY, {
     variables: { systemId: inventoryId },
     fetchPolicy: 'no-cache',
@@ -201,50 +194,9 @@ export const SystemDetails = ({ inventoryId, hidePassed, ...props }) => {
   );
 };
 
-SystemDetails.propTypes = {
+Details.propTypes = {
   inventoryId: propTypes.string,
   hidePassed: propTypes.bool,
 };
 
-const WrappedSystemDetails = ({
-  customItnl,
-  customRouter,
-  intlProps,
-  client,
-  ...props
-}) => {
-  const IntlWrapper = customItnl ? IntlProvider : React.Fragment;
-  const RouterWrapper = customRouter ? Router : React.Fragment;
-  const store = init().getStore();
-
-  return (
-    <RouterWrapper>
-      <IntlWrapper {...(customItnl && intlProps)}>
-        <ApolloProvider client={client}>
-          <Provider store={store}>
-            <SystemDetails {...props} />
-          </Provider>
-        </ApolloProvider>
-      </IntlWrapper>
-    </RouterWrapper>
-  );
-};
-
-WrappedSystemDetails.propTypes = {
-  customItnl: propTypes.bool,
-  intlProps: propTypes.any,
-  customRouter: propTypes.bool,
-  client: propTypes.object,
-};
-
-WrappedSystemDetails.defaultProps = {
-  client: new ApolloClient({
-    link: new HttpLink({
-      uri: COMPLIANCE_API_ROOT + '/graphql',
-      credentials: 'include',
-    }),
-    cache: new InMemoryCache(),
-  }),
-};
-
-export default WrappedSystemDetails;
+export default Details;

--- a/src/SmartComponents/SystemDetails/NoPoliciesState.js
+++ b/src/SmartComponents/SystemDetails/NoPoliciesState.js
@@ -4,13 +4,13 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import {
   Title,
   Bullseye,
-  Button,
   EmptyState,
   EmptyStateBody,
   EmptyStatePrimary,
   EmptyStateSecondaryActions,
   EmptyStateIcon,
 } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 
 const NoPoliciesState = () => (
   <Bullseye>
@@ -34,9 +34,9 @@ const NoPoliciesState = () => (
         </BackgroundLink>
       </EmptyStatePrimary>
       <EmptyStateSecondaryActions>
-        <Button variant="link" component="a" href="/scappolicies">
+        <Link variant="plain" to="/scappolicies">
           View compliance policies
-        </Button>
+        </Link>
       </EmptyStateSecondaryActions>
     </EmptyState>
   </Bullseye>

--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -9,7 +9,7 @@ import Skeleton, {
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
-import { SystemDetails as ComplianceSystemDetails } from './ComplianceDetail';
+import Details from './ComplianceDetail';
 import {
   BreadcrumbLinkItem,
   StateViewWithError,
@@ -48,7 +48,7 @@ export const SystemDetails = ({ route }) => {
           <InventoryDetails />
         </PageHeader>
         <Main>
-          <ComplianceSystemDetails hidePassed inventoryId={inventoryId} />
+          <Details hidePassed inventoryId={inventoryId} />
         </Main>
       </StateViewPart>
       <StateViewPart stateKey="loading">

--- a/src/SmartComponents/SystemDetails/__snapshots__/NoPoliciesState.test.js.snap
+++ b/src/SmartComponents/SystemDetails/__snapshots__/NoPoliciesState.test.js.snap
@@ -26,13 +26,12 @@ exports[`NoPoliciesState with a system having policies 1`] = `
       </BackgroundLink>
     </EmptyStatePrimary>
     <EmptyStateSecondaryActions>
-      <Button
-        component="a"
-        href="/scappolicies"
-        variant="link"
+      <Link
+        to="/scappolicies"
+        variant="plain"
       >
         View compliance policies
-      </Button>
+      </Link>
     </EmptyStateSecondaryActions>
   </EmptyState>
 </Bullseye>

--- a/src/SmartComponents/SystemDetails/__snapshots__/SystemDetails.test.js.snap
+++ b/src/SmartComponents/SystemDetails/__snapshots__/SystemDetails.test.js.snap
@@ -45,7 +45,7 @@ exports[`SystemDetails expect to render a 500 error 1`] = `
       <InventoryDetails />
     </PageHeader>
     <Connect(InternalMain)>
-      <SystemDetails
+      <Details
         hidePassed={true}
         inventoryId={1}
       />
@@ -103,7 +103,7 @@ exports[`SystemDetails expect to render and pass hidePassed correctly 1`] = `
       <InventoryDetails />
     </PageHeader>
     <Connect(InternalMain)>
-      <SystemDetails
+      <Details
         hidePassed={true}
         inventoryId={1}
       />
@@ -161,7 +161,7 @@ exports[`SystemDetails expect to render loading 1`] = `
       <InventoryDetails />
     </PageHeader>
     <Connect(InternalMain)>
-      <SystemDetails
+      <Details
         hidePassed={true}
         inventoryId={1}
       />
@@ -219,7 +219,7 @@ exports[`SystemDetails expect to render without error 1`] = `
       <InventoryDetails />
     </PageHeader>
     <Connect(InternalMain)>
-      <SystemDetails
+      <Details
         hidePassed={true}
         inventoryId={1}
       />


### PR DESCRIPTION
This fixes the issue when viewing the Compliance tab in the Inventory application of a host without any compliance data.

To test:

1) Go to the Inventory applications
2) Choose a host without any compliance 
3) Open the "Compliance" tab

Without this change the page will fail with an error that the react router context can not be found.

This introduces a memory router to address the issue and allow `Link` components and other hooks dependent on react-router work in the federated module and can link back to the appropriate page within Compliance. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
