### PR TITLE
fix(Rules): RHICOMPL-3434 consume identifier/references as objects

### DIFF
--- a/src/Utilities/ruleHelpers.js
+++ b/src/Utilities/ruleHelpers.js
@@ -34,15 +34,12 @@ export const systemsWithRuleObjectsFailed = (systems) =>
 
 export const toRulesArrayWithProfile = (profilesWithRules) =>
   profilesWithRules.flatMap((profileWithRules) =>
-    profileWithRules.rules.map((rule) => {
-      const identifier = rule.identifier && JSON.parse(rule.identifier);
-      return {
-        ...rule,
-        references: rule.references ? JSON.parse(rule.references) : [],
-        identifier: identifier && identifier.label ? identifier : null,
-        profile: profileWithRules.profile,
-      };
-    })
+    profileWithRules.rules.map(({ identifier, references, ...rule }) => ({
+      ...rule,
+      references: references ? references : [],
+      identifier: identifier && identifier.label ? identifier : null,
+      profile: profileWithRules.profile,
+    }))
   );
 
 export const complianceScoreData = (profiles) => {


### PR DESCRIPTION
The ruleIdentifier and ruleReferences fields are no longer double-JSON-encoded since https://github.com/RedHatInsights/compliance-backend/pull/1523, so we can drop the `JSON.parse` from the frontend part.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
