### PR TITLE
fix(useRoutePermissions): RHICOMPL-3465 - Default to an empty array if no route is found

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,8 @@ import React, { useEffect } from 'react';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/RouterParams';
 import { Routes } from './Routes';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
+import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
+
 import './App.scss';
 import { useSetFlagsFromUrl } from 'Utilities/hooks/useFeature';
 
@@ -36,10 +38,10 @@ const App = (props) => {
   }, []);
 
   return (
-    <React.Fragment>
+    <RBACProvider appName="compliance">
       <NotificationsPortal />
       <Routes childProps={props} />
-    </React.Fragment>
+    </RBACProvider>
   );
 };
 

--- a/src/PresentationalComponents/LinkWithPermission/LinkWithPermission.test.js
+++ b/src/PresentationalComponents/LinkWithPermission/LinkWithPermission.test.js
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import LinkWithPermission, { LinkWithRBAC } from './LinkWithPermission';
-import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import useFeature from 'Utilities/hooks/useFeature';
 jest.mock('Utilities/hooks/useFeature');
 
@@ -31,7 +31,7 @@ jest.mock(
     ...jest.requireActual(
       '@redhat-cloud-services/frontend-components-utilities/RBACHook'
     ),
-    usePermissions: jest.fn(() => ({
+    usePermissionsWithContext: jest.fn(() => ({
       hasAccess: true,
       isLoading: false,
     })),
@@ -42,7 +42,7 @@ const linkText = 'Test Link';
 
 describe('LinkWithPermission', () => {
   beforeEach(() => {
-    usePermissions.mockImplementation(() => ({
+    usePermissionsWithContext.mockImplementation(() => ({
       hasAccess: false,
       isLoading: false,
     }));
@@ -69,7 +69,7 @@ describe('LinkWithRBAC', () => {
   });
 
   it('expect to render without error', () => {
-    usePermissions.mockImplementation(() => ({
+    usePermissionsWithContext.mockImplementation(() => ({
       hasAccess: true,
       isLoading: false,
     }));
@@ -79,7 +79,7 @@ describe('LinkWithRBAC', () => {
   });
 
   it('expect to render without error and disabled', () => {
-    usePermissions.mockImplementation(() => ({
+    usePermissionsWithContext.mockImplementation(() => ({
       hasAccess: false,
       isLoading: false,
     }));

--- a/src/PresentationalComponents/WithPermission/WithPermission.js
+++ b/src/PresentationalComponents/WithPermission/WithPermission.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import useFeature from 'Utilities/hooks/useFeature';
 
@@ -10,8 +10,7 @@ const WithPermission = ({
   hide = false,
 }) => {
   const rbacEnabled = useFeature('rbac');
-  const { hasAccess, isLoading } = usePermissions(
-    'compliance',
+  const { hasAccess, isLoading } = usePermissionsWithContext(
     requiredPermissions,
     false,
     false

--- a/src/PresentationalComponents/WithPermission/WithPermission.test.js
+++ b/src/PresentationalComponents/WithPermission/WithPermission.test.js
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import WithPermission from './WithPermission';
-import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 
 import useFeature from 'Utilities/hooks/useFeature';
 jest.mock('Utilities/hooks/useFeature');
@@ -9,7 +9,7 @@ jest.mock('@redhat-cloud-services/frontend-components-utilities/RBACHook');
 describe('WithPermission', () => {
   it('expect to render without error', () => {
     useFeature.mockImplementation(() => true);
-    usePermissions.mockImplementation(() => ({
+    usePermissionsWithContext.mockImplementation(() => ({
       hasAccess: true,
       isLoading: false,
     }));
@@ -22,7 +22,7 @@ describe('WithPermission', () => {
 
   it('expect to render with rbac disabled', () => {
     useFeature.mockImplementation(() => false);
-    usePermissions.mockImplementation(() => ({
+    usePermissionsWithContext.mockImplementation(() => ({
       hasAccess: true,
       isLoading: false,
     }));
@@ -35,7 +35,7 @@ describe('WithPermission', () => {
 
   it('expect to render "No permissions" with no access', () => {
     useFeature.mockImplementation(() => true);
-    usePermissions.mockImplementation(() => ({
+    usePermissionsWithContext.mockImplementation(() => ({
       hasAccess: false,
       isLoading: false,
     }));
@@ -48,7 +48,7 @@ describe('WithPermission', () => {
 
   it('expect to render nothing when hidden and no access', () => {
     useFeature.mockImplementation(() => true);
-    usePermissions.mockImplementation(() => ({
+    usePermissionsWithContext.mockImplementation(() => ({
       hasAccess: false,
       isLoading: false,
     }));

--- a/src/Utilities/hooks/useRoutePermissions.js
+++ b/src/Utilities/hooks/useRoutePermissions.js
@@ -1,10 +1,9 @@
-import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { findRouteByPath } from '@/Routes';
 
 const useRoutePermissions = (to) => {
   const route = findRouteByPath(to);
-  return usePermissions(
-    'compliance',
+  return usePermissionsWithContext(
     route?.requiredPermissions || [],
     false,
     false

--- a/src/Utilities/hooks/useRoutePermissions.js
+++ b/src/Utilities/hooks/useRoutePermissions.js
@@ -3,7 +3,12 @@ import { findRouteByPath } from '@/Routes';
 
 const useRoutePermissions = (to) => {
   const route = findRouteByPath(to);
-  return usePermissions('compliance', route?.requiredPermissions, false, false);
+  return usePermissions(
+    'compliance',
+    route?.requiredPermissions || [],
+    false,
+    false
+  );
 };
 
 export default useRoutePermissions;


### PR DESCRIPTION
Fixes this error raised in Sentry by defaulting to an empty array if no route or required permissions are found: 

![Screenshot 2022-11-30 at 13 51 05](https://user-images.githubusercontent.com/7757/204800926-1edbd218-27bc-4e87-b60c-2338e2e8339d.png)

It also switches to the RBAC hook with context to get rid of this error, that occurs, because the old RBAC hook is trying to update a state.
 
![Screenshot 2022-11-30 at 13 46 56](https://user-images.githubusercontent.com/7757/204800700-6172a05f-9a8f-49c0-8281-d4e79f17d361.png)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
