### PR TITLE
fix(RHICOMPL-3474): Adds additional param for reloading original rule…

### DIFF
--- a/src/PresentationalComponents/ResetRules/ResetRules.js
+++ b/src/PresentationalComponents/ResetRules/ResetRules.js
@@ -15,7 +15,7 @@ const ResetRules = ({
     if (!loading) {
       updateRules(selectedRuleRefIds);
     }
-  }, [loading]);
+  }, [loading, originalRules]);
 
   const resetDefaultRules = () => {
     handleSelect && handleSelect(profile, newOsMinorVersion, originalRules);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHICOMPL-3474
The original rules list just wasnt being updated properly, so when opening the modal again or changing the profile, the original rules weren't getting updated. 

To test open the create policy wizard and make your way to the forth step(Rules)
Play around with the selected rules count and press the 'reset rules' button, it should always reset the the original number.
Then close it and repeat the steps, the behavior should be the same 


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
