### PR TITLE
fix(Shared dependencies): Align versions of redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,10 @@
         "react-content-loader": "^6.2.0",
         "react-dom": "^17.0.2",
         "react-intl": "^5.25.1",
-        "react-redux": "^7.2.9",
+        "react-redux": "7.2.6",
         "react-router-dom": "^5.3.4",
         "react-show-more-text": "^1.6.2",
-        "redux": "^4.2.0",
+        "redux": "4.1.2",
         "redux-form": "^8.3.8",
         "redux-logger": "^3.0.6",
         "redux-promise-middleware": "^6.1.2"
@@ -18908,9 +18908,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-redux": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
-      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -18920,7 +18920,7 @@
         "react-is": "^17.0.2"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
+        "react": "^16.8.3 || ^17"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -19278,9 +19278,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -37700,9 +37700,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-redux": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
-      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -37997,9 +37997,9 @@
       }
     },
     "redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "react-content-loader": "^6.2.0",
     "react-dom": "^17.0.2",
     "react-intl": "^5.25.1",
-    "react-redux": "^7.2.9",
+    "react-redux": "7.2.6",
     "react-router-dom": "^5.3.4",
     "react-show-more-text": "^1.6.2",
-    "redux": "^4.2.0",
+    "redux": "4.1.2",
     "redux-form": "^8.3.8",
     "redux-logger": "^3.0.6",
     "redux-promise-middleware": "^6.1.2"


### PR DESCRIPTION
Associated Jira ticket: https://issues.redhat.com/browse/RHIF-111

This aligns the version of redux and react-redux libraries to the ones in insights-chrome