### PR TITLE
Fix several empty state layout bugs and inconsistencies

### DIFF
--- a/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.js
+++ b/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.js
@@ -5,7 +5,6 @@ import {
   Title,
   TextContent,
   Button,
-  Bullseye,
   EmptyState,
   EmptyStateBody,
   EmptyStatePrimary,
@@ -28,7 +27,7 @@ const QUERY = gql`
 `;
 
 const ComplianceEmptyState = ({ title, mainButton, client }) => {
-  let { data, error, loading } = useQuery(QUERY, {
+  const { data, error, loading } = useQuery(QUERY, {
     fetchPolicy: 'network-only',
     client,
   });
@@ -48,56 +47,54 @@ const ComplianceEmptyState = ({ title, mainButton, client }) => {
   const haveWord = policiesCount > 1 ? 'have' : 'has';
 
   return (
-    <Bullseye>
-      <EmptyState>
-        <EmptyStateIcon
-          style={{
-            fontWeight: '500',
-            color: 'var(--pf-global--primary-color--100)',
-          }}
-          size="xl"
-          title="Compliance"
-          icon={CloudSecurityIcon}
-        />
-        <Title headingLevel="h1" size="lg">
-          {title}
-        </Title>
-        <br />
-        <EmptyStateBody>
-          {policiesCount > 0 && (
-            <TextContent>
-              <a href="insights/compliance/scappolicies">
-                {policiesCount} {policyWord}
-              </a>{' '}
-              {haveWord} been created but {haveWord} no reports.
-            </TextContent>
-          )}
+    <EmptyState>
+      <EmptyStateIcon
+        style={{
+          fontWeight: '500',
+          color: 'var(--pf-global--primary-color--100)',
+        }}
+        size="xl"
+        title="Compliance"
+        icon={CloudSecurityIcon}
+      />
+      <Title headingLevel="h1" size="lg">
+        {title}
+      </Title>
+      <br />
+      <EmptyStateBody>
+        {policiesCount > 0 && (
           <TextContent>
-            The Compliance service uses SCAP policies to track your
-            organization&#39;s adherence to compliance requirements.
+            <a href="insights/compliance/scappolicies">
+              {policiesCount} {policyWord}
+            </a>{' '}
+            {haveWord} been created but {haveWord} no reports.
           </TextContent>
-          <TextContent>
-            Get started by adding a policy, or read documentation about how to
-            connect OpenSCAP to the Compliance service.
-          </TextContent>
-        </EmptyStateBody>
-        <EmptyStatePrimary>{mainButton}</EmptyStatePrimary>
-        <EmptyStateSecondaryActions>
-          <Button
-            variant="link"
-            component="a"
-            target="_blank"
-            rel="noopener noreferrer"
-            href={
-              `https://access.redhat.com/documentation/en-us/red_hat_insights/` +
-              `2022/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index`
-            }
-          >
-            Learn about OpenSCAP and Compliance
-          </Button>
-        </EmptyStateSecondaryActions>
-      </EmptyState>
-    </Bullseye>
+        )}
+        <TextContent>
+          The Compliance service uses SCAP policies to track your
+          organization&#39;s adherence to compliance requirements.
+        </TextContent>
+        <TextContent>
+          Get started by adding a policy, or read documentation about how to
+          connect OpenSCAP to the Compliance service.
+        </TextContent>
+      </EmptyStateBody>
+      <EmptyStatePrimary>{mainButton}</EmptyStatePrimary>
+      <EmptyStateSecondaryActions>
+        <Button
+          variant="link"
+          component="a"
+          target="_blank"
+          rel="noopener noreferrer"
+          href={
+            `https://access.redhat.com/documentation/en-us/red_hat_insights/` +
+            `2022/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index`
+          }
+        >
+          Learn about OpenSCAP and Compliance
+        </Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>
   );
 };
 

--- a/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.js
+++ b/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.js
@@ -57,18 +57,19 @@ const ComplianceEmptyState = ({ title, mainButton, client }) => {
         title="Compliance"
         icon={CloudSecurityIcon}
       />
-      <Title headingLevel="h1" size="lg">
+      <Title headingLevel="h2" size="lg">
         {title}
       </Title>
-      <br />
       <EmptyStateBody>
-        {policiesCount > 0 && (
+        {policiesCount > 0 ? (
           <TextContent>
             <a href="insights/compliance/scappolicies">
               {policiesCount} {policyWord}
             </a>{' '}
             {haveWord} been created but {haveWord} no reports.
           </TextContent>
+        ) : (
+          <></>
         )}
         <TextContent>
           The Compliance service uses SCAP policies to track your

--- a/src/PresentationalComponents/ComplianceEmptyState/__snapshots__/ComplianceEmptyState.test.js.snap
+++ b/src/PresentationalComponents/ComplianceEmptyState/__snapshots__/ComplianceEmptyState.test.js.snap
@@ -14,12 +14,11 @@ exports[`ComplianceEmptyState expect to render different message if many policie
     title="Compliance"
   />
   <Title
-    headingLevel="h1"
+    headingLevel="h2"
     size="lg"
   >
     No policies
   </Title>
-  <br />
   <EmptyStateBody>
     <TextContent>
       <a
@@ -79,12 +78,11 @@ exports[`ComplianceEmptyState expect to render different message if one policy e
     title="Compliance"
   />
   <Title
-    headingLevel="h1"
+    headingLevel="h2"
     size="lg"
   >
     No policies
   </Title>
-  <br />
   <EmptyStateBody>
     <TextContent>
       <a
@@ -144,12 +142,11 @@ exports[`ComplianceEmptyState expect to render without error if no policies exis
     title="Compliance"
   />
   <Title
-    headingLevel="h1"
+    headingLevel="h2"
     size="lg"
   >
     No policies
   </Title>
-  <br />
   <EmptyStateBody>
     <TextContent>
       The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.

--- a/src/PresentationalComponents/ComplianceEmptyState/__snapshots__/ComplianceEmptyState.test.js.snap
+++ b/src/PresentationalComponents/ComplianceEmptyState/__snapshots__/ComplianceEmptyState.test.js.snap
@@ -1,188 +1,182 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ComplianceEmptyState expect to render different message if many policies exist 1`] = `
-<Bullseye>
-  <EmptyState>
-    <EmptyStateIcon
-      icon={[Function]}
-      size="xl"
-      style={
-        Object {
-          "color": "var(--pf-global--primary-color--100)",
-          "fontWeight": "500",
-        }
+<EmptyState>
+  <EmptyStateIcon
+    icon={[Function]}
+    size="xl"
+    style={
+      Object {
+        "color": "var(--pf-global--primary-color--100)",
+        "fontWeight": "500",
       }
-      title="Compliance"
-    />
-    <Title
-      headingLevel="h1"
-      size="lg"
-    >
-      No policies
-    </Title>
-    <br />
-    <EmptyStateBody>
-      <TextContent>
-        <a
-          href="insights/compliance/scappolicies"
-        >
-          2
-           
-          policies
-        </a>
+    }
+    title="Compliance"
+  />
+  <Title
+    headingLevel="h1"
+    size="lg"
+  >
+    No policies
+  </Title>
+  <br />
+  <EmptyStateBody>
+    <TextContent>
+      <a
+        href="insights/compliance/scappolicies"
+      >
+        2
          
-        have
-         been created but 
-        have
-         no reports.
-      </TextContent>
-      <TextContent>
-        The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.
-      </TextContent>
-      <TextContent>
-        Get started by adding a policy, or read documentation about how to connect OpenSCAP to the Compliance service.
-      </TextContent>
-    </EmptyStateBody>
-    <EmptyStatePrimary>
-      <Button
-        component="a"
-        href="/insights/compliance/scappolicies"
-        variant="primary"
-      >
-        Create new policy
-      </Button>
-    </EmptyStatePrimary>
-    <EmptyStateSecondaryActions>
-      <Button
-        component="a"
-        href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
-        rel="noopener noreferrer"
-        target="_blank"
-        variant="link"
-      >
-        Learn about OpenSCAP and Compliance
-      </Button>
-    </EmptyStateSecondaryActions>
-  </EmptyState>
-</Bullseye>
+        policies
+      </a>
+       
+      have
+       been created but 
+      have
+       no reports.
+    </TextContent>
+    <TextContent>
+      The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.
+    </TextContent>
+    <TextContent>
+      Get started by adding a policy, or read documentation about how to connect OpenSCAP to the Compliance service.
+    </TextContent>
+  </EmptyStateBody>
+  <EmptyStatePrimary>
+    <Button
+      component="a"
+      href="/insights/compliance/scappolicies"
+      variant="primary"
+    >
+      Create new policy
+    </Button>
+  </EmptyStatePrimary>
+  <EmptyStateSecondaryActions>
+    <Button
+      component="a"
+      href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
+      rel="noopener noreferrer"
+      target="_blank"
+      variant="link"
+    >
+      Learn about OpenSCAP and Compliance
+    </Button>
+  </EmptyStateSecondaryActions>
+</EmptyState>
 `;
 
 exports[`ComplianceEmptyState expect to render different message if one policy exists 1`] = `
-<Bullseye>
-  <EmptyState>
-    <EmptyStateIcon
-      icon={[Function]}
-      size="xl"
-      style={
-        Object {
-          "color": "var(--pf-global--primary-color--100)",
-          "fontWeight": "500",
-        }
+<EmptyState>
+  <EmptyStateIcon
+    icon={[Function]}
+    size="xl"
+    style={
+      Object {
+        "color": "var(--pf-global--primary-color--100)",
+        "fontWeight": "500",
       }
-      title="Compliance"
-    />
-    <Title
-      headingLevel="h1"
-      size="lg"
-    >
-      No policies
-    </Title>
-    <br />
-    <EmptyStateBody>
-      <TextContent>
-        <a
-          href="insights/compliance/scappolicies"
-        >
-          1
-           
-          policy
-        </a>
+    }
+    title="Compliance"
+  />
+  <Title
+    headingLevel="h1"
+    size="lg"
+  >
+    No policies
+  </Title>
+  <br />
+  <EmptyStateBody>
+    <TextContent>
+      <a
+        href="insights/compliance/scappolicies"
+      >
+        1
          
-        has
-         been created but 
-        has
-         no reports.
-      </TextContent>
-      <TextContent>
-        The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.
-      </TextContent>
-      <TextContent>
-        Get started by adding a policy, or read documentation about how to connect OpenSCAP to the Compliance service.
-      </TextContent>
-    </EmptyStateBody>
-    <EmptyStatePrimary>
-      <Button
-        component="a"
-        href="/insights/compliance/scappolicies"
-        variant="primary"
-      >
-        Create new policy
-      </Button>
-    </EmptyStatePrimary>
-    <EmptyStateSecondaryActions>
-      <Button
-        component="a"
-        href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
-        rel="noopener noreferrer"
-        target="_blank"
-        variant="link"
-      >
-        Learn about OpenSCAP and Compliance
-      </Button>
-    </EmptyStateSecondaryActions>
-  </EmptyState>
-</Bullseye>
+        policy
+      </a>
+       
+      has
+       been created but 
+      has
+       no reports.
+    </TextContent>
+    <TextContent>
+      The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.
+    </TextContent>
+    <TextContent>
+      Get started by adding a policy, or read documentation about how to connect OpenSCAP to the Compliance service.
+    </TextContent>
+  </EmptyStateBody>
+  <EmptyStatePrimary>
+    <Button
+      component="a"
+      href="/insights/compliance/scappolicies"
+      variant="primary"
+    >
+      Create new policy
+    </Button>
+  </EmptyStatePrimary>
+  <EmptyStateSecondaryActions>
+    <Button
+      component="a"
+      href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
+      rel="noopener noreferrer"
+      target="_blank"
+      variant="link"
+    >
+      Learn about OpenSCAP and Compliance
+    </Button>
+  </EmptyStateSecondaryActions>
+</EmptyState>
 `;
 
 exports[`ComplianceEmptyState expect to render without error if no policies exist 1`] = `
-<Bullseye>
-  <EmptyState>
-    <EmptyStateIcon
-      icon={[Function]}
-      size="xl"
-      style={
-        Object {
-          "color": "var(--pf-global--primary-color--100)",
-          "fontWeight": "500",
-        }
+<EmptyState>
+  <EmptyStateIcon
+    icon={[Function]}
+    size="xl"
+    style={
+      Object {
+        "color": "var(--pf-global--primary-color--100)",
+        "fontWeight": "500",
       }
-      title="Compliance"
-    />
-    <Title
-      headingLevel="h1"
-      size="lg"
+    }
+    title="Compliance"
+  />
+  <Title
+    headingLevel="h1"
+    size="lg"
+  >
+    No policies
+  </Title>
+  <br />
+  <EmptyStateBody>
+    <TextContent>
+      The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.
+    </TextContent>
+    <TextContent>
+      Get started by adding a policy, or read documentation about how to connect OpenSCAP to the Compliance service.
+    </TextContent>
+  </EmptyStateBody>
+  <EmptyStatePrimary>
+    <Button
+      component="a"
+      href="/insights/compliance/scappolicies"
+      variant="primary"
     >
-      No policies
-    </Title>
-    <br />
-    <EmptyStateBody>
-      <TextContent>
-        The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.
-      </TextContent>
-      <TextContent>
-        Get started by adding a policy, or read documentation about how to connect OpenSCAP to the Compliance service.
-      </TextContent>
-    </EmptyStateBody>
-    <EmptyStatePrimary>
-      <Button
-        component="a"
-        href="/insights/compliance/scappolicies"
-        variant="primary"
-      >
-        Create new policy
-      </Button>
-    </EmptyStatePrimary>
-    <EmptyStateSecondaryActions>
-      <Button
-        component="a"
-        href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
-        rel="noopener noreferrer"
-        target="_blank"
-        variant="link"
-      >
-        Learn about OpenSCAP and Compliance
-      </Button>
-    </EmptyStateSecondaryActions>
-  </EmptyState>
-</Bullseye>
+      Create new policy
+    </Button>
+  </EmptyStatePrimary>
+  <EmptyStateSecondaryActions>
+    <Button
+      component="a"
+      href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
+      rel="noopener noreferrer"
+      target="_blank"
+      variant="link"
+    >
+      Learn about OpenSCAP and Compliance
+    </Button>
+  </EmptyStateSecondaryActions>
+</EmptyState>
 `;

--- a/src/PresentationalComponents/ErrorPage/ErrorPage.js
+++ b/src/PresentationalComponents/ErrorPage/ErrorPage.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { Title, Button, Text } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import InvalidObject from '@redhat-cloud-services/frontend-components/InvalidObject';
 import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
+import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
 
-const ErrorPage = ({ error, ...props }) => {
+const ErrorPage = ({ error }) => {
   if (error.networkError && error.networkError.statusCode === 401) {
     window.insights.chrome.auth.logout(true);
     return false;
@@ -19,30 +18,7 @@ const ErrorPage = ({ error, ...props }) => {
     return <InvalidObject />;
   }
 
-  return (
-    <section
-      {...props}
-      className="pf-l-page__main-section pf-c-page__main-section ins-c-component_invalid-componet"
-    >
-      <ExclamationCircleIcon
-        size="xl"
-        style={{ color: 'var(--pf-global--danger-color--100)' }}
-      />
-      <Title headingLevel="h1">There was an error</Title>
-      <Text>
-        If you need to contact Red Hat Support about this, this is the exact
-        error:
-        <Text>{error.message}</Text>
-      </Text>
-      <Button
-        variant="link"
-        ouiaId="ErrorPageGoBackButton"
-        onClick={history.goBack}
-      >
-        Go back
-      </Button>
-    </section>
-  );
+  return <ErrorState />;
 };
 
 ErrorPage.propTypes = {

--- a/src/PresentationalComponents/ErrorPage/__snapshots__/ErrorPage.test.js.snap
+++ b/src/PresentationalComponents/ErrorPage/__snapshots__/ErrorPage.test.js.snap
@@ -10,36 +10,4 @@ exports[`ErrorPage expect to render a 403 error 1`] = `
 
 exports[`ErrorPage expect to render an invalid object 1`] = `<InvalidObject />`;
 
-exports[`ErrorPage expect to render without error 1`] = `
-<section
-  className="pf-l-page__main-section pf-c-page__main-section ins-c-component_invalid-componet"
->
-  <ExclamationCircleIcon
-    color="currentColor"
-    noVerticalAlign={false}
-    size="xl"
-    style={
-      Object {
-        "color": "var(--pf-global--danger-color--100)",
-      }
-    }
-  />
-  <Title
-    headingLevel="h1"
-  >
-    There was an error
-  </Title>
-  <Text>
-    If you need to contact Red Hat Support about this, this is the exact error:
-    <Text>
-      An error message
-    </Text>
-  </Text>
-  <Button
-    ouiaId="ErrorPageGoBackButton"
-    variant="link"
-  >
-    Go back
-  </Button>
-</section>
-`;
+exports[`ErrorPage expect to render without error 1`] = `<ErrorState />`;

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -79,24 +79,25 @@ export const Reports = () => {
   }
 
   return (
-    <StateViewWithError stateValues={{ error, data, loading }}>
-      <StateViewPart stateKey="loading">
-        <ReportsHeader />
-        <Main>
-          <SkeletonTable colSize={3} rowSize={10} />
-        </Main>
-      </StateViewPart>
-      <StateViewPart stateKey="data">
-        <ReportsHeader />
-        <Main>
-          {showView ? (
-            <ReportsTable {...{ profiles }} />
-          ) : (
-            <ReportsEmptyState />
-          )}
-        </Main>
-      </StateViewPart>
-    </StateViewWithError>
+    <>
+      <ReportsHeader />
+      <StateViewWithError stateValues={{ error, data, loading }}>
+        <StateViewPart stateKey="loading">
+          <Main>
+            <SkeletonTable colSize={3} rowSize={10} />
+          </Main>
+        </StateViewPart>
+        <StateViewPart stateKey="data">
+          <Main>
+            {showView ? (
+              <ReportsTable {...{ profiles }} />
+            ) : (
+              <ReportsEmptyState />
+            )}
+          </Main>
+        </StateViewPart>
+      </StateViewWithError>
+    </>
   );
 };
 

--- a/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
+++ b/src/SmartComponents/Reports/__snapshots__/Reports.test.js.snap
@@ -1,82 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Reports expect to render emptystate 1`] = `
-<StateViewWithError
-  stateValues={
-    Object {
-      "data": Object {
-        "profiles": Object {
-          "edges": Array [],
+<Fragment>
+  <ReportsHeader />
+  <StateViewWithError
+    stateValues={
+      Object {
+        "data": Object {
+          "profiles": Object {
+            "edges": Array [],
+          },
         },
-      },
-      "error": undefined,
-      "loading": undefined,
+        "error": undefined,
+        "loading": undefined,
+      }
     }
-  }
->
-  <StateViewPart
-    stateKey="loading"
   >
-    <ReportsHeader />
-    <Connect(InternalMain)>
-      <SkeletonTable
-        colSize={3}
-        rowSize={10}
-      />
-    </Connect(InternalMain)>
-  </StateViewPart>
-  <StateViewPart
-    stateKey="data"
-  >
-    <ReportsHeader />
-    <Connect(InternalMain)>
-      <ReportsEmptyState />
-    </Connect(InternalMain)>
-  </StateViewPart>
-</StateViewWithError>
+    <StateViewPart
+      stateKey="loading"
+    >
+      <Connect(InternalMain)>
+        <SkeletonTable
+          colSize={3}
+          rowSize={10}
+        />
+      </Connect(InternalMain)>
+    </StateViewPart>
+    <StateViewPart
+      stateKey="data"
+    >
+      <Connect(InternalMain)>
+        <ReportsEmptyState />
+      </Connect(InternalMain)>
+    </StateViewPart>
+  </StateViewWithError>
+</Fragment>
 `;
 
 exports[`Reports expect to render loading 1`] = `
-<StateViewWithError
-  stateValues={
-    Object {
-      "data": undefined,
-      "error": false,
-      "loading": true,
+<Fragment>
+  <ReportsHeader />
+  <StateViewWithError
+    stateValues={
+      Object {
+        "data": undefined,
+        "error": false,
+        "loading": true,
+      }
     }
-  }
->
-  <StateViewPart
-    stateKey="loading"
   >
-    <ReportsHeader />
-    <Connect(InternalMain)>
-      <SkeletonTable
-        colSize={3}
-        rowSize={10}
-      />
-    </Connect(InternalMain)>
-  </StateViewPart>
-  <StateViewPart
-    stateKey="data"
-  >
-    <ReportsHeader />
-    <Connect(InternalMain)>
-      <ReportsEmptyState />
-    </Connect(InternalMain)>
-  </StateViewPart>
-</StateViewWithError>
+    <StateViewPart
+      stateKey="loading"
+    >
+      <Connect(InternalMain)>
+        <SkeletonTable
+          colSize={3}
+          rowSize={10}
+        />
+      </Connect(InternalMain)>
+    </StateViewPart>
+    <StateViewPart
+      stateKey="data"
+    >
+      <Connect(InternalMain)>
+        <ReportsEmptyState />
+      </Connect(InternalMain)>
+    </StateViewPart>
+  </StateViewWithError>
+</Fragment>
 `;
 
 exports[`Reports expect to render without error 1`] = `
-<StateViewWithError
-  stateValues={
-    Object {
-      "data": Object {
-        "profiles": Object {
-          "edges": Array [
-            Object {
-              "node": Object {
+<Fragment>
+  <ReportsHeader />
+  <StateViewWithError
+    stateValues={
+      Object {
+        "data": Object {
+          "profiles": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "businessObjective": Object {
+                    "id": "1",
+                    "title": "BO 1",
+                  },
+                  "complianceThreshold": 1,
+                  "compliantHostCount": 1,
+                  "description": "profile description",
+                  "id": "1",
+                  "name": "profile1",
+                  "refId": "121212",
+                  "testResultHostCount": 1,
+                },
+              },
+            ],
+          },
+        },
+        "error": undefined,
+        "loading": undefined,
+      }
+    }
+  >
+    <StateViewPart
+      stateKey="loading"
+    >
+      <Connect(InternalMain)>
+        <SkeletonTable
+          colSize={3}
+          rowSize={10}
+        />
+      </Connect(InternalMain)>
+    </StateViewPart>
+    <StateViewPart
+      stateKey="data"
+    >
+      <Connect(InternalMain)>
+        <ReportsTable
+          profiles={
+            Array [
+              Object {
                 "businessObjective": Object {
                   "id": "1",
                   "title": "BO 1",
@@ -89,51 +132,11 @@ exports[`Reports expect to render without error 1`] = `
                 "refId": "121212",
                 "testResultHostCount": 1,
               },
-            },
-          ],
-        },
-      },
-      "error": undefined,
-      "loading": undefined,
-    }
-  }
->
-  <StateViewPart
-    stateKey="loading"
-  >
-    <ReportsHeader />
-    <Connect(InternalMain)>
-      <SkeletonTable
-        colSize={3}
-        rowSize={10}
-      />
-    </Connect(InternalMain)>
-  </StateViewPart>
-  <StateViewPart
-    stateKey="data"
-  >
-    <ReportsHeader />
-    <Connect(InternalMain)>
-      <ReportsTable
-        profiles={
-          Array [
-            Object {
-              "businessObjective": Object {
-                "id": "1",
-                "title": "BO 1",
-              },
-              "complianceThreshold": 1,
-              "compliantHostCount": 1,
-              "description": "profile description",
-              "id": "1",
-              "name": "profile1",
-              "refId": "121212",
-              "testResultHostCount": 1,
-            },
-          ]
-        }
-      />
-    </Connect(InternalMain)>
-  </StateViewPart>
-</StateViewWithError>
+            ]
+          }
+        />
+      </Connect(InternalMain)>
+    </StateViewPart>
+  </StateViewWithError>
+</Fragment>
 `;


### PR DESCRIPTION
I found and fixed a couple of places in compliance where error/empty states had bad or inconsistent layout.

## Before the change

1. On all pages, broken error state layout, and on the reports page, the header is not rendered: ![image](https://user-images.githubusercontent.com/31385370/210824060-6357c00d-8569-4931-b882-4de7bf02142a.png)
3. On the reports page, the empty state is centered with Bullseye which is not consistent with all other platform empty states (centered on top, but no vertically), the header has `h1` which is not correct (from the accessibility perspective), and also there is unnecessary extra `<br />` between the header and content: ![image](https://user-images.githubusercontent.com/31385370/210824277-782b533f-e097-41fb-bf9c-edad6ed701f2.png)

## After the change

1. ![image](https://user-images.githubusercontent.com/31385370/210824711-35b65bc0-9d02-4c80-b04a-ec5715d6cfbe.png)
2. ![image](https://user-images.githubusercontent.com/31385370/210826566-091cf426-f031-4969-bb8a-446935657857.png)


