### PR TITLE
fix: Unsupported systems not in system count

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -129,3 +129,9 @@ button.pf-c-menu-toggle {
     color: #000;
   }
 }
+
+.reports-table {
+  td {
+      vertical-align: middle;
+    }
+}

--- a/src/Charts.scss
+++ b/src/Charts.scss
@@ -4,8 +4,12 @@
     display: inline-flex;
 }
 
-.chart-container{
+.report-details-chart-container{
     width: 462px;
+}
+
+.report-table-chart-container{
+    width: 200px;
 }
 
 .card-chart-container{

--- a/src/PresentationalComponents/ReportsTable/Cells.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.js
@@ -8,9 +8,9 @@ import {
   GreySmallText,
   UnsupportedSSGVersion,
   LinkWithPermission as Link,
-  ReportStatusBar,
   LinkButton,
 } from 'PresentationalComponents';
+import ReportChart from '../../SmartComponents/ReportDetails/Components/ReportChart';
 
 export const Name = (profile) => (
   <TextContent>
@@ -63,40 +63,14 @@ OperatingSystem.propTypes = {
   policy: propTypes.object,
 };
 
-export const CompliantSystems = ({
-  testResultHostCount = 0,
-  compliantHostCount = 0,
-  unsupportedHostCount = 0,
-  totalHostCount = 0,
-}) => {
-  const tooltipText =
-    'Insights cannot provide a compliance score for systems running an unsupported ' +
-    'version of the SSG at the time this report was created, as the SSG version was not supported by RHEL.';
+export const CompliantSystems = (profile) => {
   return (
     <React.Fragment>
-      <ReportStatusBar
-        hostCounts={{
-          totalResults: testResultHostCount,
-          compliant: compliantHostCount,
-          unsupported: unsupportedHostCount,
-          total: totalHostCount,
-        }}
+      <ReportChart
+        profile={profile}
+        hasLegend={false}
+        chartClass="report-table-chart-container"
       />
-
-      <GreySmallText>
-        {`${compliantHostCount} of ${testResultHostCount} systems `}
-
-        {unsupportedHostCount > 0 && (
-          <UnsupportedSSGVersion
-            {...{ tooltipText }}
-            style={{ marginLeft: '.5em' }}
-          >
-            <strong className="ins-c-warning-text">
-              {unsupportedHostCount} unsupported
-            </strong>
-          </UnsupportedSSGVersion>
-        )}
-      </GreySmallText>
     </React.Fragment>
   );
 };

--- a/src/PresentationalComponents/ReportsTable/ReportsTable.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.js
@@ -12,6 +12,7 @@ import {
   operatingSystemFilter,
   policyComplianceFilter,
 } from './Filters';
+import '../../App.scss';
 
 const ReportsTable = ({ profiles }) => {
   const manageColumnsEnabled = useFeature('manageColumns');
@@ -52,6 +53,7 @@ const ReportsTable = ({ profiles }) => {
         manageColumns: manageColumnsEnabled,
         emptyRows: emptyRows('reports', columns.length),
       }}
+      className={'reports-table'}
     />
   );
 };

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Cells.test.js.snap
@@ -2,52 +2,32 @@
 
 exports[`CompliantSystems expect to render with unsupported hosts 1`] = `
 <Fragment>
-  <ReportStatusBar
-    hostCounts={
+  <ReportChart
+    chartClass="report-table-chart-container"
+    hasLegend={false}
+    profile={
       Object {
-        "compliant": 9,
-        "total": 0,
-        "totalResults": 10,
-        "unsupported": 42,
+        "compliantHostCount": 9,
+        "testResultHostCount": 10,
+        "unsupportedHostCount": 42,
       }
     }
   />
-  <GreySmallText>
-    9 of 10 systems 
-    <UnsupportedSSGVersion
-      style={
-        Object {
-          "marginLeft": ".5em",
-        }
-      }
-      tooltipText="Insights cannot provide a compliance score for systems running an unsupported version of the SSG at the time this report was created, as the SSG version was not supported by RHEL."
-    >
-      <strong
-        className="ins-c-warning-text"
-      >
-        42
-         unsupported
-      </strong>
-    </UnsupportedSSGVersion>
-  </GreySmallText>
 </Fragment>
 `;
 
 exports[`CompliantSystems expect to render without error 1`] = `
 <Fragment>
-  <ReportStatusBar
-    hostCounts={
+  <ReportChart
+    chartClass="report-table-chart-container"
+    hasLegend={false}
+    profile={
       Object {
-        "compliant": 9,
-        "total": 0,
-        "totalResults": 10,
-        "unsupported": 0,
+        "compliantHostCount": 9,
+        "testResultHostCount": 10,
       }
     }
   />
-  <GreySmallText>
-    9 of 10 systems 
-  </GreySmallText>
 </Fragment>
 `;
 

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ReportsTable expect to render without error 1`] = `
 <TableToolsTable
   aria-label="Reports"
+  className="reports-table"
   columns={
     Array [
       Object {

--- a/src/SmartComponents/ReportDetails/Components/ReportChart.js
+++ b/src/SmartComponents/ReportDetails/Components/ReportChart.js
@@ -6,30 +6,34 @@ import '@/Charts.scss';
 import ChartLegend from './ChartLegend';
 import useDonutChart from './hooks/useDonutChart';
 
-const ReportChart = ({ profile = {} }) => {
+const ReportChart = ({ profile = {}, hasLegend = true, chartClass }) => {
   const { chartProps, legendData } = useDonutChart(profile);
 
   return (
-    <Grid className="chart-container">
-      <GridItem span={6}>
+    <Grid className={chartClass}>
+      <GridItem span={hasLegend ? 6 : 12}>
         <ChartDonut {...chartProps} />
       </GridItem>
-      <GridItem
-        span={6}
-        className="pf-u-display-flex pf-u-align-items-center"
-        style={{
-          fontSize: '.85em',
-          height: '100%',
-        }}
-      >
-        <ChartLegend legendData={legendData} />
-      </GridItem>
+      {hasLegend ? (
+        <GridItem
+          span={6}
+          className="pf-u-display-flex pf-u-align-items-center"
+          style={{
+            fontSize: '.85em',
+            height: '100%',
+          }}
+        >
+          <ChartLegend legendData={legendData} />
+        </GridItem>
+      ) : null}
     </Grid>
   );
 };
 
 ReportChart.propTypes = {
   profile: propTypes.object,
+  hasLegend: propTypes.bool,
+  chartClass: propTypes.string,
 };
 
 export default ReportChart;

--- a/src/SmartComponents/ReportDetails/Components/__snapshots__/ReportChart.test.js.snap
+++ b/src/SmartComponents/ReportDetails/Components/__snapshots__/ReportChart.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ReportChart expect to render with not reporting hosts 1`] = `
 <div>
   <div
-    class="pf-l-grid chart-container"
+    class="pf-l-grid"
   >
     <div
       class="pf-l-grid__item pf-m-6-col"
@@ -165,7 +165,7 @@ exports[`ReportChart expect to render with not reporting hosts 1`] = `
 exports[`ReportChart expect to render with unsupported hosts 1`] = `
 <div>
   <div
-    class="pf-l-grid chart-container"
+    class="pf-l-grid"
   >
     <div
       class="pf-l-grid__item pf-m-6-col"
@@ -327,7 +327,7 @@ exports[`ReportChart expect to render with unsupported hosts 1`] = `
 exports[`ReportChart expect to render with zero unsupported hosts 1`] = `
 <div>
   <div
-    class="pf-l-grid chart-container"
+    class="pf-l-grid"
   >
     <div
       class="pf-l-grid__item pf-m-6-col"
@@ -457,7 +457,7 @@ exports[`ReportChart expect to render with zero unsupported hosts 1`] = `
 exports[`ReportChart expect to render without error with no profile 1`] = `
 <div>
   <div
-    class="pf-l-grid chart-container"
+    class="pf-l-grid"
   >
     <div
       class="pf-l-grid__item pf-m-6-col"
@@ -587,7 +587,7 @@ exports[`ReportChart expect to render without error with no profile 1`] = `
 exports[`ReportChart expect to render without error with zero counts 1`] = `
 <div>
   <div
-    class="pf-l-grid chart-container"
+    class="pf-l-grid"
   >
     <div
       class="pf-l-grid__item pf-m-6-col"

--- a/src/SmartComponents/ReportDetails/Components/hooks/useDonutChart.js
+++ b/src/SmartComponents/ReportDetails/Components/hooks/useDonutChart.js
@@ -1,4 +1,11 @@
-import { ChartThemeVariant } from '@patternfly/react-charts';
+import React from 'react';
+import propTypes from 'prop-types';
+import {
+  ChartThemeVariant,
+  ChartTooltip,
+  ChartLabel,
+} from '@patternfly/react-charts';
+import { Icon } from '@patternfly/react-core';
 import black300 from '@patternfly/react-tokens/dist/esm/global_palette_black_300';
 import blue200 from '@patternfly/react-tokens/dist/esm/chart_color_blue_200';
 import blue300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
@@ -6,6 +13,38 @@ import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color
 import chart_color_gold_300 from '@patternfly/react-tokens/dist/esm/chart_color_gold_300';
 import { fixedPercentage } from 'Utilities/TextHelper';
 import useLegendData from './useLegendData';
+import { SquareFullIcon } from '@patternfly/react-icons';
+
+const DonutLabel = ({
+  x,
+  y,
+  datum,
+  chartColorScale,
+  flyoutValues,
+  ...rest
+}) => {
+  const iconLeftEdge = x - flyoutValues[datum._x - 1] / 2 + 5;
+  const percentOfDonut = (datum.endAngle - datum.startAngle) / 360;
+  rest.text = `${rest.text}: ${(percentOfDonut * 100).toFixed(2)}%`;
+  return (
+    <g>
+      <foreignObject height="100%" width="100%" x={iconLeftEdge} y={y - 11}>
+        <Icon>
+          <SquareFullIcon color={chartColorScale[datum._x - 1]} />
+        </Icon>
+      </foreignObject>
+      <ChartLabel x={x + 10} y={y} {...rest} />
+    </g>
+  );
+};
+
+DonutLabel.propTypes = {
+  x: propTypes.number,
+  y: propTypes.number,
+  datum: propTypes.object,
+  chartColorScale: propTypes.array,
+  flyoutValues: propTypes.array,
+};
 
 const useDonutChart = (profile) => {
   const {
@@ -30,6 +69,7 @@ const useDonutChart = (profile) => {
     chart_color_gold_300.value,
     chart_color_black_200.value,
   ];
+  const flyoutValues = [150, 180, 170, 170];
   const legendData = useLegendData(donutValues, profile);
 
   const compliancePercentage = testResultHostCount
@@ -39,6 +79,18 @@ const useDonutChart = (profile) => {
   return {
     chartProps: {
       data: donutValues,
+      labelComponent: (
+        <ChartTooltip
+          flyoutWidth={({ index }) => flyoutValues[index]}
+          labelComponent={
+            <DonutLabel
+              chartColorScale={chartColorScale}
+              flyoutValues={flyoutValues}
+            />
+          }
+          constrainToVisibleArea={true}
+        />
+      ),
       identifier: donutId,
       title: compliancePercentage,
       subTitle: 'Compliant',

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -1,19 +1,14 @@
 /* eslint-disable react/display-name */
 import React from 'react';
-import black300 from '@patternfly/react-tokens/dist/esm/global_palette_black_300';
-import blue200 from '@patternfly/react-tokens/dist/esm/chart_color_blue_200';
-import blue300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import propTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import gql from 'graphql-tag';
-import { ChartDonut, ChartThemeVariant } from '@patternfly/react-charts';
 import {
   Breadcrumb,
   BreadcrumbItem,
   Grid,
   GridItem,
-  Text,
 } from '@patternfly/react-core';
 import PageHeader, {
   PageHeaderTitle,
@@ -21,7 +16,6 @@ import PageHeader, {
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import EmptyTable from '@redhat-cloud-services/frontend-components/EmptyTable';
 import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
-import { fixedPercentage, pluralize } from 'Utilities/TextHelper';
 import {
   BackgroundLink,
   BreadcrumbLinkItem,
@@ -29,7 +23,6 @@ import {
   ReportDetailsDescription,
   StateViewWithError,
   StateViewPart,
-  UnsupportedSSGVersion,
   SubPageTitle,
   LinkButton,
 } from 'PresentationalComponents';
@@ -40,6 +33,7 @@ import '@/Charts.scss';
 import './ReportDetails.scss';
 import * as Columns from '../SystemsTable/Columns';
 import { default as ReportDetailsWithNotReportedSystems } from './ReportDetailsWithNotReportedSystems';
+import ReportChart from './Components/ReportChart';
 
 export const QUERY = gql`
   query Profile($policyId: String!) {
@@ -73,53 +67,14 @@ export const ReportDetails = ({ route }) => {
     variables: { policyId },
     fetchPolicy: 'no-cache',
   });
-  let donutValues = [];
-  let donutId = 'loading-donut';
-  let chartColorScale;
   let profile = {};
   let policyName;
-  let legendData;
-  let compliancePercentage;
   let pageTitle;
 
   if (!loading && data) {
     profile = data.profile;
     policyName = profile.policy.name;
     pageTitle = `Report: ${policyName}`;
-    const compliantHostCount = profile.compliantHostCount;
-    const testResultHostCount = profile.testResultHostCount;
-    donutId = profile.name.replace(/ /g, '');
-    donutValues = [
-      { x: 'Compliant', y: testResultHostCount ? compliantHostCount : '0' },
-      { x: 'Non-compliant', y: testResultHostCount - compliantHostCount },
-    ];
-    chartColorScale = (testResultHostCount === 0 && [black300.value]) || [
-      blue300.value,
-      blue200.value,
-    ];
-    legendData = [
-      {
-        name:
-          donutValues[0].y +
-          ' ' +
-          pluralize(donutValues[0].y, 'system') +
-          ' compliant',
-      },
-      {
-        name:
-          donutValues[1].y +
-          ' ' +
-          pluralize(donutValues[1].y, 'system') +
-          ' non-compliant',
-      },
-    ];
-    compliancePercentage = testResultHostCount
-      ? fixedPercentage(
-          Math.floor(
-            100 * (donutValues[0].y / (donutValues[0].y + donutValues[1].y))
-          )
-        )
-      : 0;
   }
 
   useTitleEntity(route, policyName);
@@ -183,38 +138,13 @@ export const ReportDetails = ({ route }) => {
             <GridItem sm={12} md={12} lg={12} xl={6}>
               <div className="chart-inline">
                 <div className="chart-container">
-                  <ChartDonut
-                    data={donutValues}
-                    identifier={donutId}
-                    title={compliancePercentage}
-                    subTitle="Compliant"
-                    themeVariant={ChartThemeVariant.light}
-                    colorScale={chartColorScale}
-                    style={{ fontSize: 20 }}
-                    constrainToVisibleArea={true}
-                    innerRadius={88}
-                    width={462}
-                    legendPosition="right"
-                    legendData={legendData}
-                    legendOrientation="vertical"
-                    padding={{
-                      bottom: 20,
-                      left: 0,
-                      right: 250,
-                      top: 20,
-                    }}
+                  <ReportChart
+                    profile={profile}
+                    hasLegend={true}
+                    chartClass="report-details-chart-container"
                   />
                 </div>
               </div>
-              {profile.unsupportedHostCount > 0 && (
-                <Text>
-                  <UnsupportedSSGVersion showHelpIcon>
-                    <strong className="ins-c-warning-text">
-                      {profile.unsupportedHostCount} systems not supported
-                    </strong>
-                  </UnsupportedSSGVersion>
-                </Text>
-              )}
             </GridItem>
             <GridItem sm={12} md={12} lg={12} xl={6}>
               <ReportDetailsDescription profile={profile} />

--- a/src/SmartComponents/ReportDetails/ReportDetailsWithNotReportedSystems.js
+++ b/src/SmartComponents/ReportDetails/ReportDetailsWithNotReportedSystems.js
@@ -9,7 +9,6 @@ import {
   BreadcrumbItem,
   Grid,
   GridItem,
-  Text,
 } from '@patternfly/react-core';
 import PageHeader, {
   PageHeaderTitle,
@@ -24,7 +23,6 @@ import {
   ReportDetailsDescription,
   StateViewWithError,
   StateViewPart,
-  UnsupportedSSGVersion,
   SubPageTitle,
   LinkButton,
 } from 'PresentationalComponents';
@@ -150,16 +148,11 @@ export const ReportDetails = ({ route }) => {
           </Grid>
           <Grid hasGutter>
             <GridItem sm={12} md={12} lg={12} xl={6}>
-              <ReportChart profile={profile} />
-              {profile.unsupportedHostCount > 0 && (
-                <Text ouiaId="UnsupportedSSGCountNotification">
-                  <UnsupportedSSGVersion showHelpIcon>
-                    <strong className="ins-c-warning-text">
-                      {profile.unsupportedHostCount} systems not supported
-                    </strong>
-                  </UnsupportedSSGVersion>
-                </Text>
-              )}
+              <ReportChart
+                profile={profile}
+                hasLegend={true}
+                chartClass="report-details-chart-container"
+              />
             </GridItem>
             <GridItem sm={12} md={12} lg={12} xl={6}>
               <ReportDetailsDescription profile={profile} />

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -184,72 +184,38 @@ exports[`ReportDetails expect to render without error 1`] = `
             <div
               className="chart-container"
             >
-              <ChartDonut
-                colorScale={
-                  Array [
-                    "#06c",
-                    "#519de9",
-                  ]
-                }
-                constrainToVisibleArea={true}
-                data={
-                  Array [
-                    Object {
-                      "x": "Compliant",
-                      "y": 5,
-                    },
-                    Object {
-                      "x": "Non-compliant",
-                      "y": 5,
-                    },
-                  ]
-                }
-                identifier="profile1"
-                innerRadius={88}
-                legendData={
-                  Array [
-                    Object {
-                      "name": "5 systems compliant",
-                    },
-                    Object {
-                      "name": "5 systems non-compliant",
-                    },
-                  ]
-                }
-                legendOrientation="vertical"
-                legendPosition="right"
-                padding={
+              <ReportChart
+                chartClass="report-details-chart-container"
+                hasLegend={true}
+                profile={
                   Object {
-                    "bottom": 20,
-                    "left": 0,
-                    "right": 250,
-                    "top": 20,
+                    "benchmark": Object {
+                      "version": "0.1.4",
+                    },
+                    "businessObjective": Object {
+                      "id": "1",
+                      "title": "BO 1",
+                    },
+                    "complianceThreshold": 1,
+                    "compliantHostCount": 5,
+                    "description": "profile description",
+                    "external": false,
+                    "id": "1",
+                    "name": "profile1",
+                    "osMajorVersion": "7",
+                    "policy": Object {
+                      "id": "thepolicyid",
+                      "name": "the policy name",
+                    },
+                    "policyType": "policy type",
+                    "refId": "121212",
+                    "testResultHostCount": 10,
+                    "unsupportedHostCount": 5,
                   }
                 }
-                style={
-                  Object {
-                    "fontSize": 20,
-                  }
-                }
-                subTitle="Compliant"
-                themeVariant="light"
-                title="50%"
-                width={462}
               />
             </div>
           </div>
-          <Text>
-            <UnsupportedSSGVersion
-              showHelpIcon={true}
-            >
-              <strong
-                className="ins-c-warning-text"
-              >
-                5
-                 systems not supported
-              </strong>
-            </UnsupportedSSGVersion>
-          </Text>
         </GridItem>
         <GridItem
           lg={12}
@@ -578,72 +544,38 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
             <div
               className="chart-container"
             >
-              <ChartDonut
-                colorScale={
-                  Array [
-                    "#06c",
-                    "#519de9",
-                  ]
-                }
-                constrainToVisibleArea={true}
-                data={
-                  Array [
-                    Object {
-                      "x": "Compliant",
-                      "y": 5,
-                    },
-                    Object {
-                      "x": "Non-compliant",
-                      "y": 5,
-                    },
-                  ]
-                }
-                identifier="profile1"
-                innerRadius={88}
-                legendData={
-                  Array [
-                    Object {
-                      "name": "5 systems compliant",
-                    },
-                    Object {
-                      "name": "5 systems non-compliant",
-                    },
-                  ]
-                }
-                legendOrientation="vertical"
-                legendPosition="right"
-                padding={
+              <ReportChart
+                chartClass="report-details-chart-container"
+                hasLegend={true}
+                profile={
                   Object {
-                    "bottom": 20,
-                    "left": 0,
-                    "right": 250,
-                    "top": 20,
+                    "benchmark": Object {
+                      "version": "0.1.4",
+                    },
+                    "businessObjective": Object {
+                      "id": "1",
+                      "title": "BO 1",
+                    },
+                    "complianceThreshold": 1,
+                    "compliantHostCount": 5,
+                    "description": "profile description",
+                    "external": false,
+                    "id": "1",
+                    "name": "profile1",
+                    "osMajorVersion": "7",
+                    "policy": Object {
+                      "id": "thepolicyid",
+                      "name": "the policy name",
+                    },
+                    "policyType": "policy type",
+                    "refId": "121212",
+                    "testResultHostCount": 10,
+                    "unsupportedHostCount": 5,
                   }
                 }
-                style={
-                  Object {
-                    "fontSize": 20,
-                  }
-                }
-                subTitle="Compliant"
-                themeVariant="light"
-                title="50%"
-                width={462}
               />
             </div>
           </div>
-          <Text>
-            <UnsupportedSSGVersion
-              showHelpIcon={true}
-            >
-              <strong
-                className="ins-c-warning-text"
-              >
-                5
-                 systems not supported
-              </strong>
-            </UnsupportedSSGVersion>
-          </Text>
         </GridItem>
         <GridItem
           lg={12}


### PR DESCRIPTION
This PR replaces the bar chart on the reports table with the donut chart. It also fixes the counts which were previously incorrect.

The "total number of systems" considered in the main reports view do not take into account neither the reported or unsupported systems in the X of Y systems.

Though, the bar chart displayed on each of the report entries does take them into account (displaying the unsupported systems in yellow, and the never-reported systems in gray)

Steps to Reproduce:

have one unsupported system reporting
have 2 more additional systems associated to the reported policy Check reports page

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
