### PR TITLE
fix: Update pdf package to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@patternfly/react-tokens": "^4.94.3",
         "@redhat-cloud-services/frontend-components": "^3.9.28",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.12",
-        "@redhat-cloud-services/frontend-components-pdf-generator": "^2.6.16",
+        "@redhat-cloud-services/frontend-components-pdf-generator": "2.6.17",
         "@redhat-cloud-services/frontend-components-remediations": "^3.2.8",
         "@redhat-cloud-services/frontend-components-utilities": "^3.3.11",
         "@redhat-cloud-services/host-inventory-client": "^1.0.114",
@@ -5173,11 +5173,11 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-pdf-generator": {
-      "version": "2.6.16",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-pdf-generator/-/frontend-components-pdf-generator-2.6.16.tgz",
-      "integrity": "sha512-I74rSn8ImCCKjGVecsP1Mu5q2FVv41HW7KSElCUAqGT2WgzowlT6IGPibKdGdb94u7LHV/sDlDlHzAl6d9ChEQ==",
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-pdf-generator/-/frontend-components-pdf-generator-2.6.17.tgz",
+      "integrity": "sha512-WCdGgwkYf90uPRbL0y2vI46Xil2A33Otn6cNPxhE30pGmJf6Gw7lzGEDAaSxagkVbs7/JOeLIteFNGqtFTLNxw==",
       "dependencies": {
-        "@patternfly/react-charts": "^6.3.9",
+        "@patternfly/react-charts": "6.3.9",
         "@patternfly/react-core": "^4.18.5",
         "@patternfly/react-icons": "^3.15.3",
         "@patternfly/react-styles": "^4.3.4",
@@ -5188,6 +5188,48 @@
         "react": "16.12.0",
         "react-dom": "16.12.0",
         "rgb-hex": "^3.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/patternfly": {
+      "version": "4.10.31",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.10.31.tgz",
+      "integrity": "sha512-UxdZ/apWRowXYZ5qPz5LPfXwyB4YGpomrCJPX7c36+Zg8jFpYyVqgVYainL8Yf/GrChtC2LKyoHg7UUTtMtp4A==",
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-charts": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.3.9.tgz",
+      "integrity": "sha512-eo1++UvE0vGsHcBkfVDB0XPxqm2s6QGjxmumRRcqTCXl3OgiBHxIH1j1nd/ycDWiIg07neu29ty+rfJfmj+FEw==",
+      "dependencies": {
+        "@patternfly/patternfly": "4.10.31",
+        "@patternfly/react-styles": "^4.3.4",
+        "@patternfly/react-tokens": "^4.4.4",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.15",
+        "tslib": "^1.11.1",
+        "victory": "^34.3.9",
+        "victory-area": "^34.3.8",
+        "victory-axis": "^34.3.8",
+        "victory-bar": "^34.3.8",
+        "victory-chart": "^34.3.9",
+        "victory-core": "^34.3.8",
+        "victory-create-container": "^34.3.8",
+        "victory-group": "^34.3.9",
+        "victory-legend": "^34.3.8",
+        "victory-line": "^34.3.8",
+        "victory-pie": "^34.3.8",
+        "victory-scatter": "^34.3.8",
+        "victory-stack": "^34.3.9",
+        "victory-tooltip": "^34.3.8",
+        "victory-voronoi-container": "^34.3.8",
+        "victory-zoom-container": "^34.3.8"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/@patternfly/react-icons": {
@@ -5221,6 +5263,87 @@
         "react-dom": ">=16.8.0 || >=17.0.0"
       }
     },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/delaunay-find": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+      "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+      "dependencies": {
+        "delaunator": "^4.0.0"
+      }
+    },
     "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/react": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
@@ -5246,6 +5369,242 @@
       },
       "peerDependencies": {
         "react": "^16.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-area": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+      "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-axis": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+      "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-bar": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+      "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-brush-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+      "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-chart": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+      "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-core": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-create-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+      "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "victory-brush-container": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-cursor-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+      "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-group": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+      "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-legend": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+      "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-line": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+      "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-pie": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+      "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+      "dependencies": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-polar-axis": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+      "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-scatter": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+      "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-selection-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+      "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-shared-events": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+      "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-stack": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+      "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-tooltip": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+      "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-voronoi-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+      "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+      "dependencies": {
+        "delaunay-find": "0.0.5",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-tooltip": "^34.3.12"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-pdf-generator/node_modules/victory-zoom-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+      "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-remediations": {
@@ -9731,6 +10090,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -9829,6 +10193,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -23633,6 +24002,39 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/victory": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-34.3.12.tgz",
+      "integrity": "sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==",
+      "dependencies": {
+        "victory-area": "^34.3.12",
+        "victory-axis": "^34.3.12",
+        "victory-bar": "^34.3.12",
+        "victory-box-plot": "^34.3.12",
+        "victory-brush-container": "^34.3.12",
+        "victory-brush-line": "^34.3.12",
+        "victory-candlestick": "^34.3.12",
+        "victory-chart": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-create-container": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-errorbar": "^34.3.12",
+        "victory-group": "^34.3.12",
+        "victory-histogram": "^34.3.12",
+        "victory-legend": "^34.3.12",
+        "victory-line": "^34.3.12",
+        "victory-pie": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-scatter": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-shared-events": "^34.3.12",
+        "victory-stack": "^34.3.12",
+        "victory-tooltip": "^34.3.12",
+        "victory-voronoi": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
+      }
+    },
     "node_modules/victory-area": {
       "version": "36.6.8",
       "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.8.tgz",
@@ -23674,6 +24076,110 @@
         "react": ">=16.6.0"
       }
     },
+    "node_modules/victory-box-plot": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-34.3.12.tgz",
+      "integrity": "sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-box-plot/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/victory-box-plot/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/victory-box-plot/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/victory-box-plot/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/victory-box-plot/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/victory-box-plot/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/victory-box-plot/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/victory-box-plot/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/victory-box-plot/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/victory-box-plot/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/victory-box-plot/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/victory-box-plot/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/victory-box-plot/node_modules/victory-core": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
     "node_modules/victory-brush-container": {
       "version": "36.6.8",
       "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.8.tgz",
@@ -23686,6 +24192,213 @@
       },
       "peerDependencies": {
         "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-34.3.12.tgz",
+      "integrity": "sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-brush-line/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/victory-brush-line/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/victory-brush-line/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/victory-brush-line/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/victory-brush-line/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/victory-brush-line/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/victory-brush-line/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/victory-brush-line/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/victory-brush-line/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/victory-brush-line/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/victory-brush-line/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/victory-brush-line/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/victory-brush-line/node_modules/victory-core": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-34.3.12.tgz",
+      "integrity": "sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-candlestick/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/victory-candlestick/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/victory-candlestick/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/victory-candlestick/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/victory-candlestick/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/victory-candlestick/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/victory-candlestick/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/victory-candlestick/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/victory-candlestick/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/victory-candlestick/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/victory-candlestick/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/victory-candlestick/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/victory-candlestick/node_modules/victory-core": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
       }
     },
     "node_modules/victory-chart": {
@@ -23749,6 +24462,109 @@
         "react": ">=16.6.0"
       }
     },
+    "node_modules/victory-errorbar": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-34.3.12.tgz",
+      "integrity": "sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-errorbar/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/victory-errorbar/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/victory-errorbar/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/victory-errorbar/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/victory-errorbar/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/victory-errorbar/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/victory-errorbar/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/victory-errorbar/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/victory-errorbar/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/victory-errorbar/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/victory-errorbar/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/victory-errorbar/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/victory-errorbar/node_modules/victory-core": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
     "node_modules/victory-group": {
       "version": "36.6.8",
       "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.8.tgz",
@@ -23762,6 +24578,137 @@
       },
       "peerDependencies": {
         "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-34.3.12.tgz",
+      "integrity": "sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==",
+      "dependencies": {
+        "d3-array": "^2.4.0",
+        "d3-scale": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-bar": "^34.3.12",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/victory-histogram/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/victory-histogram/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/victory-histogram/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/victory-histogram/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/d3-scale/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/victory-histogram/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/victory-histogram/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/victory-histogram/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/victory-histogram/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/victory-histogram/node_modules/victory-bar": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+      "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/victory-core": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
       }
     },
     "node_modules/victory-legend": {
@@ -23908,6 +24855,17 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/victory-voronoi": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-34.3.12.tgz",
+      "integrity": "sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==",
+      "dependencies": {
+        "d3-voronoi": "^1.1.2",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
     "node_modules/victory-voronoi-container": {
       "version": "36.6.8",
       "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.8.tgz",
@@ -23924,6 +24882,99 @@
         "react": ">=16.6.0"
       }
     },
+    "node_modules/victory-voronoi/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/victory-voronoi/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/victory-voronoi/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/victory-voronoi/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/victory-voronoi/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/victory-voronoi/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/victory-voronoi/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/victory-voronoi/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/victory-voronoi/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/victory-voronoi/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/victory-voronoi/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/victory-voronoi/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/victory-voronoi/node_modules/victory-core": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
     "node_modules/victory-zoom-container": {
       "version": "36.6.8",
       "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.8.tgz",
@@ -23935,6 +24986,318 @@
       },
       "peerDependencies": {
         "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/victory/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/victory/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/victory/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/victory/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/victory/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/victory/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/victory/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/victory/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/victory/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/victory/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/victory/node_modules/delaunay-find": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+      "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+      "dependencies": {
+        "delaunator": "^4.0.0"
+      }
+    },
+    "node_modules/victory/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/victory/node_modules/victory-area": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+      "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-axis": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+      "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-bar": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+      "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-brush-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+      "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-chart": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+      "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-core": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+      "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
+    "node_modules/victory/node_modules/victory-create-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+      "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "victory-brush-container": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-cursor-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+      "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-group": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+      "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-legend": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+      "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-line": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+      "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-pie": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+      "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+      "dependencies": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-polar-axis": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+      "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-scatter": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+      "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-selection-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+      "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-shared-events": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+      "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-stack": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+      "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-tooltip": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+      "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-voronoi-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+      "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+      "dependencies": {
+        "delaunay-find": "0.0.5",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-tooltip": "^34.3.12"
+      }
+    },
+    "node_modules/victory/node_modules/victory-zoom-container": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+      "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -28590,11 +29953,11 @@
       }
     },
     "@redhat-cloud-services/frontend-components-pdf-generator": {
-      "version": "2.6.16",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-pdf-generator/-/frontend-components-pdf-generator-2.6.16.tgz",
-      "integrity": "sha512-I74rSn8ImCCKjGVecsP1Mu5q2FVv41HW7KSElCUAqGT2WgzowlT6IGPibKdGdb94u7LHV/sDlDlHzAl6d9ChEQ==",
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-pdf-generator/-/frontend-components-pdf-generator-2.6.17.tgz",
+      "integrity": "sha512-WCdGgwkYf90uPRbL0y2vI46Xil2A33Otn6cNPxhE30pGmJf6Gw7lzGEDAaSxagkVbs7/JOeLIteFNGqtFTLNxw==",
       "requires": {
-        "@patternfly/react-charts": "^6.3.9",
+        "@patternfly/react-charts": "6.3.9",
         "@patternfly/react-core": "^4.18.5",
         "@patternfly/react-icons": "^3.15.3",
         "@patternfly/react-styles": "^4.3.4",
@@ -28607,6 +29970,40 @@
         "rgb-hex": "^3.0.0"
       },
       "dependencies": {
+        "@patternfly/patternfly": {
+          "version": "4.10.31",
+          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.10.31.tgz",
+          "integrity": "sha512-UxdZ/apWRowXYZ5qPz5LPfXwyB4YGpomrCJPX7c36+Zg8jFpYyVqgVYainL8Yf/GrChtC2LKyoHg7UUTtMtp4A=="
+        },
+        "@patternfly/react-charts": {
+          "version": "6.3.9",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.3.9.tgz",
+          "integrity": "sha512-eo1++UvE0vGsHcBkfVDB0XPxqm2s6QGjxmumRRcqTCXl3OgiBHxIH1j1nd/ycDWiIg07neu29ty+rfJfmj+FEw==",
+          "requires": {
+            "@patternfly/patternfly": "4.10.31",
+            "@patternfly/react-styles": "^4.3.4",
+            "@patternfly/react-tokens": "^4.4.4",
+            "hoist-non-react-statics": "^3.3.0",
+            "lodash": "^4.17.15",
+            "tslib": "^1.11.1",
+            "victory": "^34.3.9",
+            "victory-area": "^34.3.8",
+            "victory-axis": "^34.3.8",
+            "victory-bar": "^34.3.8",
+            "victory-chart": "^34.3.9",
+            "victory-core": "^34.3.8",
+            "victory-create-container": "^34.3.8",
+            "victory-group": "^34.3.9",
+            "victory-legend": "^34.3.8",
+            "victory-line": "^34.3.8",
+            "victory-pie": "^34.3.8",
+            "victory-scatter": "^34.3.8",
+            "victory-stack": "^34.3.9",
+            "victory-tooltip": "^34.3.8",
+            "victory-voronoi-container": "^34.3.8",
+            "victory-zoom-container": "^34.3.8"
+          }
+        },
         "@patternfly/react-icons": {
           "version": "3.15.17",
           "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-3.15.17.tgz",
@@ -28629,6 +30026,87 @@
             "lodash": "^4.17.0"
           }
         },
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "delaunay-find": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+          "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+          "requires": {
+            "delaunator": "^4.0.0"
+          }
+        },
         "react": {
           "version": "16.12.0",
           "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
@@ -28648,6 +30126,242 @@
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
             "scheduler": "^0.18.0"
+          }
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "victory-area": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+          "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+          "requires": {
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-axis": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+          "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-bar": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+          "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+          "requires": {
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-brush-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+          "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-chart": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+          "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-axis": "^34.3.12",
+            "victory-core": "^34.3.12",
+            "victory-polar-axis": "^34.3.12",
+            "victory-shared-events": "^34.3.12"
+          }
+        },
+        "victory-core": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+          "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+          "requires": {
+            "d3-ease": "^1.0.0",
+            "d3-interpolate": "^1.1.1",
+            "d3-scale": "^1.0.0",
+            "d3-shape": "^1.2.0",
+            "d3-timer": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0"
+          }
+        },
+        "victory-create-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+          "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "victory-brush-container": "^34.3.12",
+            "victory-core": "^34.3.12",
+            "victory-cursor-container": "^34.3.12",
+            "victory-selection-container": "^34.3.12",
+            "victory-voronoi-container": "^34.3.12",
+            "victory-zoom-container": "^34.3.12"
+          }
+        },
+        "victory-cursor-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+          "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-group": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+          "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12",
+            "victory-shared-events": "^34.3.12"
+          }
+        },
+        "victory-legend": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+          "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-line": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+          "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+          "requires": {
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-pie": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+          "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+          "requires": {
+            "d3-shape": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-polar-axis": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+          "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-scatter": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+          "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-selection-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+          "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-shared-events": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+          "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-stack": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+          "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12",
+            "victory-shared-events": "^34.3.12"
+          }
+        },
+        "victory-tooltip": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+          "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-voronoi-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+          "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+          "requires": {
+            "delaunay-find": "0.0.5",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12",
+            "victory-tooltip": "^34.3.12"
+          }
+        },
+        "victory-zoom-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+          "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
           }
         }
       }
@@ -32303,6 +34017,11 @@
         "internmap": "1 - 2"
       }
     },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
     "d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -32371,6 +34090,11 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "dargs": {
       "version": "7.0.0",
@@ -42801,6 +44525,353 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "victory": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-34.3.12.tgz",
+      "integrity": "sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==",
+      "requires": {
+        "victory-area": "^34.3.12",
+        "victory-axis": "^34.3.12",
+        "victory-bar": "^34.3.12",
+        "victory-box-plot": "^34.3.12",
+        "victory-brush-container": "^34.3.12",
+        "victory-brush-line": "^34.3.12",
+        "victory-candlestick": "^34.3.12",
+        "victory-chart": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-create-container": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-errorbar": "^34.3.12",
+        "victory-group": "^34.3.12",
+        "victory-histogram": "^34.3.12",
+        "victory-legend": "^34.3.12",
+        "victory-line": "^34.3.12",
+        "victory-pie": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-scatter": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-shared-events": "^34.3.12",
+        "victory-stack": "^34.3.12",
+        "victory-tooltip": "^34.3.12",
+        "victory-voronoi": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "delaunay-find": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+          "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+          "requires": {
+            "delaunator": "^4.0.0"
+          }
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "victory-area": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+          "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+          "requires": {
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-axis": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+          "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-bar": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+          "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+          "requires": {
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-brush-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+          "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-chart": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+          "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-axis": "^34.3.12",
+            "victory-core": "^34.3.12",
+            "victory-polar-axis": "^34.3.12",
+            "victory-shared-events": "^34.3.12"
+          }
+        },
+        "victory-core": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+          "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+          "requires": {
+            "d3-ease": "^1.0.0",
+            "d3-interpolate": "^1.1.1",
+            "d3-scale": "^1.0.0",
+            "d3-shape": "^1.2.0",
+            "d3-timer": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0"
+          }
+        },
+        "victory-create-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+          "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "victory-brush-container": "^34.3.12",
+            "victory-core": "^34.3.12",
+            "victory-cursor-container": "^34.3.12",
+            "victory-selection-container": "^34.3.12",
+            "victory-voronoi-container": "^34.3.12",
+            "victory-zoom-container": "^34.3.12"
+          }
+        },
+        "victory-cursor-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+          "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-group": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+          "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12",
+            "victory-shared-events": "^34.3.12"
+          }
+        },
+        "victory-legend": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+          "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-line": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+          "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+          "requires": {
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-pie": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+          "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+          "requires": {
+            "d3-shape": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-polar-axis": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+          "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-scatter": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+          "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-selection-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+          "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-shared-events": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+          "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-stack": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+          "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12",
+            "victory-shared-events": "^34.3.12"
+          }
+        },
+        "victory-tooltip": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+          "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-voronoi-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+          "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+          "requires": {
+            "delaunay-find": "0.0.5",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0",
+            "victory-core": "^34.3.12",
+            "victory-tooltip": "^34.3.12"
+          }
+        },
+        "victory-zoom-container": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+          "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        }
+      }
+    },
     "victory-area": {
       "version": "36.6.8",
       "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.8.tgz",
@@ -42833,6 +44904,112 @@
         "victory-vendor": "^36.6.8"
       }
     },
+    "victory-box-plot": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-34.3.12.tgz",
+      "integrity": "sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "victory-core": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+          "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+          "requires": {
+            "d3-ease": "^1.0.0",
+            "d3-interpolate": "^1.1.1",
+            "d3-scale": "^1.0.0",
+            "d3-shape": "^1.2.0",
+            "d3-timer": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0"
+          }
+        }
+      }
+    },
     "victory-brush-container": {
       "version": "36.6.8",
       "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.8.tgz",
@@ -42842,6 +45019,217 @@
         "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
         "victory-core": "^36.6.8"
+      }
+    },
+    "victory-brush-line": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-34.3.12.tgz",
+      "integrity": "sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "victory-core": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+          "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+          "requires": {
+            "d3-ease": "^1.0.0",
+            "d3-interpolate": "^1.1.1",
+            "d3-scale": "^1.0.0",
+            "d3-shape": "^1.2.0",
+            "d3-timer": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0"
+          }
+        }
+      }
+    },
+    "victory-candlestick": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-34.3.12.tgz",
+      "integrity": "sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "victory-core": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+          "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+          "requires": {
+            "d3-ease": "^1.0.0",
+            "d3-interpolate": "^1.1.1",
+            "d3-scale": "^1.0.0",
+            "d3-shape": "^1.2.0",
+            "d3-timer": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0"
+          }
+        }
       }
     },
     "victory-chart": {
@@ -42893,6 +45281,111 @@
         "victory-core": "^36.6.8"
       }
     },
+    "victory-errorbar": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-34.3.12.tgz",
+      "integrity": "sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "victory-core": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+          "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+          "requires": {
+            "d3-ease": "^1.0.0",
+            "d3-interpolate": "^1.1.1",
+            "d3-scale": "^1.0.0",
+            "d3-shape": "^1.2.0",
+            "d3-timer": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0"
+          }
+        }
+      }
+    },
     "victory-group": {
       "version": "36.6.8",
       "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.8.tgz",
@@ -42903,6 +45396,141 @@
         "react-fast-compare": "^3.2.0",
         "victory-core": "^36.6.8",
         "victory-shared-events": "^36.6.8"
+      }
+    },
+    "victory-histogram": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-34.3.12.tgz",
+      "integrity": "sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==",
+      "requires": {
+        "d3-array": "^2.4.0",
+        "d3-scale": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-bar": "^34.3.12",
+        "victory-core": "^34.3.12"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          },
+          "dependencies": {
+            "d3-array": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+              "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+            }
+          }
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "internmap": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+          "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "victory-bar": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+          "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+          "requires": {
+            "d3-shape": "^1.2.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "victory-core": "^34.3.12"
+          }
+        },
+        "victory-core": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+          "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+          "requires": {
+            "d3-ease": "^1.0.0",
+            "d3-interpolate": "^1.1.1",
+            "d3-scale": "^1.0.0",
+            "d3-shape": "^1.2.0",
+            "d3-timer": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0"
+          }
+        }
       }
     },
     "victory-legend": {
@@ -43020,6 +45648,112 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "victory-voronoi": {
+      "version": "34.3.12",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-34.3.12.tgz",
+      "integrity": "sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==",
+      "requires": {
+        "d3-voronoi": "^1.1.2",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "victory-core": {
+          "version": "34.3.12",
+          "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+          "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+          "requires": {
+            "d3-ease": "^1.0.0",
+            "d3-interpolate": "^1.1.1",
+            "d3-scale": "^1.0.0",
+            "d3-shape": "^1.2.0",
+            "d3-timer": "^1.0.0",
+            "lodash": "^4.17.15",
+            "prop-types": "^15.5.8",
+            "react-fast-compare": "^2.0.0"
+          }
+        }
       }
     },
     "victory-voronoi-container": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@patternfly/react-tokens": "^4.94.3",
     "@redhat-cloud-services/frontend-components": "^3.9.28",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.12",
-    "@redhat-cloud-services/frontend-components-pdf-generator": "^2.6.16",
+    "@redhat-cloud-services/frontend-components-pdf-generator": "2.6.17",
     "@redhat-cloud-services/frontend-components-remediations": "^3.2.8",
     "@redhat-cloud-services/frontend-components-utilities": "^3.3.11",
     "@redhat-cloud-services/host-inventory-client": "^1.0.114",


### PR DESCRIPTION
### Description

There's an error of invalid hook calls with new PDF version. This is caused by charts using hooks and we need to have two versions of React because of async rendering of charts. There's a warning about incorrect import of theme colors, @RedHatInsights/platform-experience will take the initiative and duplicate the code from PF in frontend components PDF package since PF no longer supports these functions.