### PR TITLE
fix(PolicyTypeTable): RHICOMPL-3413 - Move 'In Use' before policy type

### DIFF
--- a/src/PresentationalComponents/InUseProfileLabel/InUseProfileLabel.js
+++ b/src/PresentationalComponents/InUseProfileLabel/InUseProfileLabel.js
@@ -8,7 +8,11 @@ const InUseProfileLabel = ({ compact }) => (
     content="A policy of this type is already in use.
         Only one policy per policy type can be created for a major release of RHEL."
   >
-    <Label color="orange" style={{ lineHeight: '1.5em' }} compact={compact}>
+    <Label
+      color="orange"
+      style={{ lineHeight: '1.5em', marginRight: '16px' }}
+      compact={compact}
+    >
       In use
     </Label>
   </Tooltip>

--- a/src/SmartComponents/CreatePolicy/Components/PolicyTypeTable.js
+++ b/src/SmartComponents/CreatePolicy/Components/PolicyTypeTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { fitContent } from '@patternfly/react-table';
+import { fitContent, info } from '@patternfly/react-table';
 import { InUseProfileLabel } from 'PresentationalComponents';
 import { TableToolsTable } from 'Utilities/hooks/useTableTools';
 import { renderComponent } from 'Utilities/helpers';
@@ -10,7 +10,8 @@ import PolicyTypeDetailsRow from './PolicyTypeDetailsRow';
 const NameCell = ({ name, disabled }) => {
   return (
     <>
-      {name} {disabled && <InUseProfileLabel compact />}
+      {disabled && <InUseProfileLabel compact />}
+      {name}
     </>
   );
 };
@@ -45,6 +46,12 @@ const PolicyTypeTable = ({ profiles, onChange, selectedProfile }) => (
       {
         title: 'Policy name',
         key: 'name',
+        transforms: [
+          info({
+            tooltip:
+              'In use policies have already been used and therefore can not be applied to another SCAP Policy under the selected OS.',
+          }),
+        ],
         sortByProp: 'name',
         renderFunc: renderComponent(NameCell),
       },


### PR DESCRIPTION
2 things were changed here:
1) Moved 'In Use' label to the left side
2) Added a new tooltip explaining 'In Use' label

**Before:**
![image (56)](https://user-images.githubusercontent.com/33912805/213175335-ae683e31-5913-4458-bca9-4d133f0023e1.png)
**After:**
![image](https://user-images.githubusercontent.com/33912805/213198039-79ce494a-7a20-4916-b23f-1fd94dc6c100.png)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
