### PR TITLE
fix(RulesTable): RHICOMPL-3530 - Show Identifiers and Refs for rules

### DIFF
--- a/src/PresentationalComponents/RulesTable/RuleDetailsRow.js
+++ b/src/PresentationalComponents/RulesTable/RuleDetailsRow.js
@@ -16,8 +16,11 @@ const RuleDetailsRow = ({ item: rule }) => {
 
   return (
     <div key={key} style={{ marginTop: 'var(--pf-global--spacer--lg)' }}>
-      <Stack id={`rule-description-${key}`} className="margin-bottom-lg">
-        <StackItem style={{ marginBottom: 'var(--pf-global--spacer--sm)' }}>
+      <Stack
+        id={`rule-description-${key}`}
+        style={{ marginBottom: 'var(--pf-global--spacer--md)' }}
+      >
+        <StackItem style={{ marginBottom: 'var(--pf-global--spacer--xs)' }}>
           <Text className="pf-c-form__label" component={TextVariants.h5}>
             <b>Description</b>
           </Text>
@@ -26,33 +29,33 @@ const RuleDetailsRow = ({ item: rule }) => {
       </Stack>
       <Stack
         id={`rule-identifiers-references-${key}`}
-        className="margin-bottom-lg"
+        style={{ marginBottom: 'var(--pf-global--spacer--md)' }}
       >
         <Grid>
-          {identifier && identifier.length > 0 && (
+          {identifier && (
             <GridItem span={2}>
-              <Text className="pf-c-form__label" component={TextVariants.h5}>
+              <Text
+                className="pf-c-form__label"
+                component={TextVariants.h5}
+                style={{ marginBottom: 'var(--pf-global--spacer--xs)' }}
+              >
                 <b>Identifier</b>
               </Text>
               <Text>
-                {identifier
-                  .map((ident, idx) => (
-                    <ConditionalLink
-                      href={ident.system}
-                      target="_blank"
-                      key={`${refId}-identifier-${idx}`}
-                    >
-                      {ident.label}
-                    </ConditionalLink>
-                  ))
-                  .reduce((prev, next) => [prev, ', ', next])}
+                <ConditionalLink href={identifier.system} target="_blank">
+                  {identifier.label}
+                </ConditionalLink>
               </Text>
             </GridItem>
           )}
 
           {references && references.length > 0 && (
             <GridItem span={10}>
-              <Text className="pf-c-form__label" component={TextVariants.h5}>
+              <Text
+                className="pf-c-form__label"
+                component={TextVariants.h5}
+                style={{ marginBottom: 'var(--pf-global--spacer--xs)' }}
+              >
                 <b>References</b>
               </Text>
               <Text>
@@ -78,7 +81,7 @@ const RuleDetailsRow = ({ item: rule }) => {
           id={`rule-rationale-${key}`}
           style={{ marginBottom: 'var(--pf-global--spacer--lg)' }}
         >
-          <StackItem style={{ marginBottom: 'var(--pf-global--spacer--sm)' }}>
+          <StackItem style={{ marginBottom: 'var(--pf-global--spacer--xs)' }}>
             <Text className="pf-c-form__label" component={TextVariants.h5}>
               <b>Rationale</b>
             </Text>

--- a/src/PresentationalComponents/RulesTable/__snapshots__/RuleDetailsRow.test.js.snap
+++ b/src/PresentationalComponents/RulesTable/__snapshots__/RuleDetailsRow.test.js.snap
@@ -10,13 +10,17 @@ exports[`RuleDetailsRow expect to render without error 1`] = `
   }
 >
   <Stack
-    className="margin-bottom-lg"
     id="rule-description-rule-child-row-xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime"
+    style={
+      Object {
+        "marginBottom": "var(--pf-global--spacer--md)",
+      }
+    }
   >
     <StackItem
       style={
         Object {
-          "marginBottom": "var(--pf-global--spacer--sm)",
+          "marginBottom": "var(--pf-global--spacer--xs)",
         }
       }
     >
@@ -36,8 +40,12 @@ exports[`RuleDetailsRow expect to render without error 1`] = `
     </StackItem>
   </Stack>
   <Stack
-    className="margin-bottom-lg"
     id="rule-identifiers-references-rule-child-row-xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime"
+    style={
+      Object {
+        "marginBottom": "var(--pf-global--spacer--md)",
+      }
+    }
   >
     <Grid />
   </Stack>
@@ -52,7 +60,7 @@ exports[`RuleDetailsRow expect to render without error 1`] = `
     <StackItem
       style={
         Object {
-          "marginBottom": "var(--pf-global--spacer--sm)",
+          "marginBottom": "var(--pf-global--spacer--xs)",
         }
       }
     >

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -70,6 +70,7 @@ export const QUERY = gql`
             refId
             description
             remediationAvailable
+            references
             identifier
             precedence
           }


### PR DESCRIPTION
1) References and identifiers are shown now on both pages (System details and Policy details->Rules).
2) Fixed spacing between elements

**Before:**
![image](https://user-images.githubusercontent.com/33912805/214124729-887868e8-7185-4816-a705-2ffc1cf0668f.png)

**After:**
![image](https://user-images.githubusercontent.com/33912805/214125236-da411230-09fd-48cd-a2c9-089a5f25abad.png)

Also closing https://issues.redhat.com/browse/RHICOMPL-3165 here

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
