### PR TITLE
fix(EmptyStateView): RHICOMPL-3539 - Show no system enabled again

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -134,7 +134,8 @@ export const SystemsTable = ({
       emptyStateComponent &&
       result.meta.totalCount === 0 &&
       activeFilterValues.length === 0 &&
-      result?.meta?.tags?.length === 0
+      (typeof result?.meta?.tags === 'undefined' ||
+        result?.meta?.tags?.length === 0)
     ) {
       setIsEmpty(true);
     }


### PR DESCRIPTION
We depend on first request made for systems table and the first one is about OS versions. Request response doesn't have tags so view can't have proper empty state.  

If we have both checks for undefined and 0 value, we cover both cases - 
1) systems step view is loaded for the first time (first request is getSystems where we request os_versions and tags have undefined value) 
2) We use filter on this page and our request retrieves systems so we have tags value

**BEFORE:**
![image (65)](https://user-images.githubusercontent.com/33912805/214887101-1b670299-6a80-4629-a798-5026e2c544cd.png)

**AFTER:**
![image (66)](https://user-images.githubusercontent.com/33912805/214887119-6155a437-8fc1-433e-b44a-480bf79b4839.png)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
