### PR TITLE
chore: Remove/reduce use of history state

### DIFF
--- a/src/PresentationalComponents/PoliciesTable/hooks/useActionResolvers.js
+++ b/src/PresentationalComponents/PoliciesTable/hooks/useActionResolvers.js
@@ -1,9 +1,8 @@
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import useRoutePermissions from 'Utilities/hooks/useRoutePermissions';
 
 const useActionResolver = (policies) => {
   const history = useHistory();
-  const location = useLocation();
 
   const { hasAccess: hasDeleteAccess, isLoading: isDeleteAccessLoading } =
     useRoutePermissions(`/scappolicies/XYZ/delete`);
@@ -11,11 +10,9 @@ const useActionResolver = (policies) => {
     useRoutePermissions(`/scappolicies/XYZ/edit`);
 
   const onClick = (to, { itemId: policyId }) => {
-    const policy = policies.find((policy) => policy.id === policyId);
+    const { id, name } = policies.find((policy) => policy.id === policyId);
     history.push(to, {
-      policy,
-      background: location,
-      state: { policy },
+      state: { policy: { id, name } },
     });
   };
 

--- a/src/SmartComponents/DeleteReport/DeleteReport.js
+++ b/src/SmartComponents/DeleteReport/DeleteReport.js
@@ -1,7 +1,7 @@
 import { Button, ModalVariant, TextContent } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import React from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 import { DELETE_REPORT } from 'Mutations';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -10,10 +10,10 @@ import { dispatchAction } from 'Utilities/Dispatcher';
 
 const DeleteReport = () => {
   const history = useHistory();
-  const location = useLocation();
-  const { id } = location.state?.profile;
+  const { hash } = useLocation();
+  const { report_id: id } = useParams();
   const onClose = () => {
-    history.push(location.state.background);
+    history.push('/reports' + hash);
   };
 
   const onDelete = () => {

--- a/src/SmartComponents/DeleteReport/DeleteReport.test.js
+++ b/src/SmartComponents/DeleteReport/DeleteReport.test.js
@@ -1,10 +1,11 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 import { dispatchAction } from 'Utilities/Dispatcher';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: jest.fn(),
+  useParams: jest.fn(),
 }));
 jest.mock('@apollo/client');
 jest.mock('Utilities/Dispatcher');
@@ -14,9 +15,10 @@ import DeleteReport from './DeleteReport.js';
 describe('DeleteReport', () => {
   beforeEach(() => {
     useLocation.mockImplementation(() => ({
-      state: {
-        profile: { id: 'ID1' },
-      },
+      hash: '#hastag',
+    }));
+    useParams.mockImplementation(() => ({
+      report_id: 'ID1',
     }));
     useMutation.mockImplementation((query, options) => {
       return [

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -112,7 +112,6 @@ export const ReportDetails = ({ route }) => {
             >
               {pdfReportEnabled && (
                 <BackgroundLink
-                  state={{ profile }}
                   to={`/reports/${profile.id}/pdf`}
                   component={LinkButton}
                   ouiaId="ReportDetailsDownloadReportPDFLink"
@@ -123,7 +122,6 @@ export const ReportDetails = ({ route }) => {
                 </BackgroundLink>
               )}
               <BackgroundLink
-                state={{ profile }}
                 to={`/reports/${profile.id}/delete`}
                 component={LinkButton}
                 variant="link"

--- a/src/SmartComponents/ReportDetails/ReportDetailsWithNotReportedSystems.js
+++ b/src/SmartComponents/ReportDetails/ReportDetailsWithNotReportedSystems.js
@@ -124,7 +124,6 @@ export const ReportDetails = ({ route }) => {
             >
               {pdfReportEnabled && (
                 <BackgroundLink
-                  state={{ profile }}
                   to={`/reports/${profile.id}/pdf`}
                   component={LinkButton}
                   ouiaId="ReportDetailsDownloadReportPDFLink"
@@ -135,7 +134,6 @@ export const ReportDetails = ({ route }) => {
                 </BackgroundLink>
               )}
               <BackgroundLink
-                state={{ profile }}
                 to={`/reports/${profile.id}/delete`}
                 component={LinkButton}
                 variant="link"

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -97,34 +97,6 @@ exports[`ReportDetails expect to render without error 1`] = `
             className="pf-u-mr-md"
             component={[Function]}
             ouiaId="ReportDetailsDownloadReportPDFLink"
-            state={
-              Object {
-                "profile": Object {
-                  "benchmark": Object {
-                    "version": "0.1.4",
-                  },
-                  "businessObjective": Object {
-                    "id": "1",
-                    "title": "BO 1",
-                  },
-                  "complianceThreshold": 1,
-                  "compliantHostCount": 5,
-                  "description": "profile description",
-                  "external": false,
-                  "id": "1",
-                  "name": "profile1",
-                  "osMajorVersion": "7",
-                  "policy": Object {
-                    "id": "thepolicyid",
-                    "name": "the policy name",
-                  },
-                  "policyType": "policy type",
-                  "refId": "121212",
-                  "testResultHostCount": 10,
-                  "unsupportedHostCount": 5,
-                },
-              }
-            }
             to="/reports/1/pdf"
             variant="plain"
           >
@@ -134,34 +106,6 @@ exports[`ReportDetails expect to render without error 1`] = `
             component={[Function]}
             isInline={true}
             ouiaId="ReportDetailsDeleteReportLink"
-            state={
-              Object {
-                "profile": Object {
-                  "benchmark": Object {
-                    "version": "0.1.4",
-                  },
-                  "businessObjective": Object {
-                    "id": "1",
-                    "title": "BO 1",
-                  },
-                  "complianceThreshold": 1,
-                  "compliantHostCount": 5,
-                  "description": "profile description",
-                  "external": false,
-                  "id": "1",
-                  "name": "profile1",
-                  "osMajorVersion": "7",
-                  "policy": Object {
-                    "id": "thepolicyid",
-                    "name": "the policy name",
-                  },
-                  "policyType": "policy type",
-                  "refId": "121212",
-                  "testResultHostCount": 10,
-                  "unsupportedHostCount": 5,
-                },
-              }
-            }
             to="/reports/1/delete"
             variant="link"
           >
@@ -458,34 +402,6 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
             className="pf-u-mr-md"
             component={[Function]}
             ouiaId="ReportDetailsDownloadReportPDFLink"
-            state={
-              Object {
-                "profile": Object {
-                  "benchmark": Object {
-                    "version": "0.1.4",
-                  },
-                  "businessObjective": Object {
-                    "id": "1",
-                    "title": "BO 1",
-                  },
-                  "complianceThreshold": 1,
-                  "compliantHostCount": 5,
-                  "description": "profile description",
-                  "external": false,
-                  "id": "1",
-                  "name": "profile1",
-                  "osMajorVersion": "7",
-                  "policy": Object {
-                    "id": "thepolicyid",
-                    "name": "the policy name",
-                  },
-                  "policyType": "policy type",
-                  "refId": "121212",
-                  "testResultHostCount": 10,
-                  "unsupportedHostCount": 5,
-                },
-              }
-            }
             to="/reports/1/pdf"
             variant="plain"
           >
@@ -495,34 +411,6 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
             component={[Function]}
             isInline={true}
             ouiaId="ReportDetailsDeleteReportLink"
-            state={
-              Object {
-                "profile": Object {
-                  "benchmark": Object {
-                    "version": "0.1.4",
-                  },
-                  "businessObjective": Object {
-                    "id": "1",
-                    "title": "BO 1",
-                  },
-                  "complianceThreshold": 1,
-                  "compliantHostCount": 5,
-                  "description": "profile description",
-                  "external": false,
-                  "id": "1",
-                  "name": "profile1",
-                  "osMajorVersion": "7",
-                  "policy": Object {
-                    "id": "thepolicyid",
-                    "name": "the policy name",
-                  },
-                  "policyType": "policy type",
-                  "refId": "121212",
-                  "testResultHostCount": 10,
-                  "unsupportedHostCount": 5,
-                },
-              }
-            }
             to="/reports/1/delete"
             variant="link"
           >


### PR DESCRIPTION
We should reduce the (ab)use of the history state for passing data especially large amounts. https://github.com/RedHatInsights/compliance-frontend/pull/1891/commits/1bcae6ac12e1424eb4627abf7cc37c7939c497f3 contains a fix for only the edit systems and rules button, where without it, it will crash and not open the modals properly.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
