### PR TITLE
fix(RHICOMPL-3535): Default rules table crash on filter

### DIFF
--- a/src/Utilities/hooks/useTableTools/useBulkSelect.js
+++ b/src/Utilities/hooks/useTableTools/useBulkSelect.js
@@ -181,7 +181,7 @@ export const useBulkSelectWithItems = ({
   const setPageMemo = useMemo(() => setPage, []);
 
   useEffect(() => {
-    if (paginatedTotal === 0) {
+    if (paginatedTotal === 0 && setPage) {
       setPageMemo(-1);
     }
   }, [paginatedTotal, setPageMemo]);


### PR DESCRIPTION
See Jira card comments for steps on navigating to default rules table. `/insights/compliance/scappolicies/{POLICY_ID}/default_ruleset`

Description of problem
Default rules table crashes if you type non existing rule name

How reproducible
Always

Steps to Reproduce:
Navigate to Default rules table page
Search for 'foo'

Expected results
No crashes

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
