### PR TITLE
fix(RBAC): RHICOMPL-3518 - Fix RBAC when opening from Inventory

### DIFF
--- a/src/PresentationalComponents/LinkWithPermission/LinkWithPermission.test.js
+++ b/src/PresentationalComponents/LinkWithPermission/LinkWithPermission.test.js
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import LinkWithPermission, { LinkWithRBAC } from './LinkWithPermission';
-import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import useFeature from 'Utilities/hooks/useFeature';
 jest.mock('Utilities/hooks/useFeature');
 
@@ -31,7 +31,7 @@ jest.mock(
     ...jest.requireActual(
       '@redhat-cloud-services/frontend-components-utilities/RBACHook'
     ),
-    usePermissionsWithContext: jest.fn(() => ({
+    usePermissions: jest.fn(() => ({
       hasAccess: true,
       isLoading: false,
     })),
@@ -42,7 +42,7 @@ const linkText = 'Test Link';
 
 describe('LinkWithPermission', () => {
   beforeEach(() => {
-    usePermissionsWithContext.mockImplementation(() => ({
+    usePermissions.mockImplementation(() => ({
       hasAccess: false,
       isLoading: false,
     }));
@@ -69,7 +69,7 @@ describe('LinkWithRBAC', () => {
   });
 
   it('expect to render without error', () => {
-    usePermissionsWithContext.mockImplementation(() => ({
+    usePermissions.mockImplementation(() => ({
       hasAccess: true,
       isLoading: false,
     }));
@@ -79,7 +79,7 @@ describe('LinkWithRBAC', () => {
   });
 
   it('expect to render without error and disabled', () => {
-    usePermissionsWithContext.mockImplementation(() => ({
+    usePermissions.mockImplementation(() => ({
       hasAccess: false,
       isLoading: false,
     }));

--- a/src/Utilities/hooks/useRoutePermissions.js
+++ b/src/Utilities/hooks/useRoutePermissions.js
@@ -1,9 +1,10 @@
-import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { findRouteByPath } from '@/Routes';
 
 const useRoutePermissions = (to) => {
   const route = findRouteByPath(to);
-  return usePermissionsWithContext(
+  return usePermissions(
+    'compliance',
     route?.requiredPermissions || [],
     false,
     false


### PR DESCRIPTION
Ticket: [RHICOMPL-3518](https://issues.redhat.com/browse/RHICOMPL-3518)

When opening a Compliance Tab from Inventory and system is not in a policy then incorrect permissions are applied, because no request to Compliance RBAC was made.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
