### PR TITLE
feat(Policies): RHICOMPL-3768 - Request additional rule data separately

### DIFF
--- a/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
+++ b/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
@@ -75,11 +75,10 @@ SSGPopoverBody.propTypes = {
 };
 
 const BENCHMARK_QUERY = gql`
-  query benchmarkQuery($id: String!, $enableRuleTree: Boolean = false) {
+  query benchmarkQuery($id: String!) {
     benchmark(id: $id) {
       id
       osMajorVersion
-      ruleTree @include(if: $enableRuleTree)
       rules {
         id
         title
@@ -90,14 +89,6 @@ const BENCHMARK_QUERY = gql`
         remediationAvailable
         identifier
         values
-      }
-      valueDefinitions {
-        defaultValue
-        description
-        id
-        refId
-        title
-        valueType
       }
     }
   }

--- a/src/SmartComponents/CreatePolicy/constants.js
+++ b/src/SmartComponents/CreatePolicy/constants.js
@@ -1,0 +1,85 @@
+import gql from 'graphql-tag';
+
+export const BENCHMARKS_QUERY = gql`
+  query Benchmarks($filter: String!) {
+    benchmarks(search: $filter) {
+      nodes {
+        id
+        latestSupportedOsMinorVersions
+        ruleTree
+        valueDefinitions {
+          defaultValue
+          description
+          id
+          refId
+          title
+          valueType
+        }
+        profiles {
+          id
+          refId
+          osMajorVersion
+        }
+        version
+      }
+    }
+  }
+`;
+
+export const BENCHMARKS_RULES_TREES_QUERY = gql`
+  query Benchmarks($filter: String!) {
+    benchmarks(search: $filter) {
+      nodes {
+        id
+        ruleTree
+      }
+    }
+  }
+`;
+
+export const BENCHMARKS_VALUE_DEFINITIONS_QUERY = gql`
+  query Benchmarks($filter: String!) {
+    benchmarks(search: $filter) {
+      nodes {
+        id
+        latestSupportedOsMinorVersions
+        ruleTree
+        valueDefinitions {
+          defaultValue
+          description
+          id
+          refId
+          title
+          valueType
+        }
+        profiles {
+          id
+          refId
+          osMajorVersion
+        }
+        version
+      }
+    }
+  }
+`;
+
+export const PROFILES_QUERY = gql`
+  query Profiles($filter: String!) {
+    profiles(search: $filter) {
+      edges {
+        node {
+          id
+          refId
+          osMinorVersion
+          benchmark {
+            id
+            latestSupportedOsMinorVersions
+          }
+          rules {
+            refId
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/SmartComponents/CreatePolicy/hooks/useBenchmarksQuery.js
+++ b/src/SmartComponents/CreatePolicy/hooks/useBenchmarksQuery.js
@@ -1,0 +1,101 @@
+import { useMemo, useCallback } from 'react';
+import { useQuery } from '@apollo/client';
+import { logMultipleErrors } from 'Utilities/helpers';
+import useFeature from 'Utilities/hooks/useFeature';
+import {
+  BENCHMARKS_QUERY,
+  BENCHMARKS_RULES_TREES_QUERY,
+  BENCHMARKS_VALUE_DEFINITIONS_QUERY,
+} from '../constants';
+
+const compileData = (benchmarksData, ruleTreesData, valueDefinitionsData) => ({
+  benchmarks: {
+    nodes: benchmarksData?.benchmarks.nodes.map((node) => {
+      const ruleTree = ruleTreesData?.benchmarks.nodes.find(
+        ({ id }) => id === node.id
+      )?.ruleTree;
+      const valueDefinitions = valueDefinitionsData?.benchmarks.nodes.find(
+        ({ id }) => id === node.id
+      )?.valueDefinitions;
+
+      return {
+        ...node,
+        ruleTree,
+        valueDefinitions,
+      };
+    }),
+  },
+});
+
+const useBenchmarksQuery = ({ osMajorVersion, osMinorVersions }) => {
+  const filter =
+    `os_major_version = ${osMajorVersion} ` +
+    `and latest_supported_os_minor_version ^ "${osMinorVersions.join(',')}"`;
+
+  const ruleGroupsEnabled = useFeature('ruleGroups');
+  const valueEditingEnabled = useFeature('valueEditing');
+
+  const {
+    data: benchmarksData,
+    error: benchmarksError,
+    loading: benchmarksLoading,
+    refetch: refetchProfiles,
+  } = useQuery(BENCHMARKS_QUERY, {
+    variables: {
+      filter,
+    },
+    skip: osMinorVersions.length === 0,
+    fetchPolicy: 'no-cache',
+  });
+
+  const {
+    data: ruleTreesData,
+    error: ruleTreesError,
+    loading: ruleTreesLoading,
+    refetch: refecthRuleTrees,
+  } = useQuery(BENCHMARKS_RULES_TREES_QUERY, {
+    variables: { filter },
+    skip: osMinorVersions.length === 0 || !ruleGroupsEnabled,
+    fetchPolicy: 'no-cache',
+  });
+
+  const {
+    data: valueDefinitionsData,
+    error: valueDefinitionsError,
+    loading: valueDefinitionsLoading,
+    refetch: refecthValueDefinitions,
+  } = useQuery(BENCHMARKS_VALUE_DEFINITIONS_QUERY, {
+    variables: { filter },
+    skip: osMinorVersions.length === 0 || !valueEditingEnabled,
+    fetchPolicy: 'no-cache',
+  });
+
+  const data = useMemo(
+    () => compileData(benchmarksData, ruleTreesData, valueDefinitionsData),
+    [benchmarksData, ruleTreesData, valueDefinitionsData]
+  );
+
+  const error = useMemo(
+    () =>
+      logMultipleErrors(benchmarksError, ruleTreesError, valueDefinitionsError),
+    [benchmarksError, ruleTreesError, valueDefinitionsError]
+  );
+
+  const loading =
+    benchmarksLoading || ruleTreesLoading || valueDefinitionsLoading;
+
+  const refetch = useCallback(() => {
+    refetchProfiles();
+    refecthRuleTrees();
+    refecthValueDefinitions();
+  }, [refetchProfiles, refecthRuleTrees, refecthValueDefinitions]);
+
+  return {
+    data,
+    error,
+    loading,
+    refetch,
+  };
+};
+
+export default useBenchmarksQuery;

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import { Button, Spinner } from '@patternfly/react-core';
+import { useParams } from 'react-router-dom';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
 import {
   ComplianceModal,
@@ -9,10 +10,12 @@ import {
 } from 'PresentationalComponents';
 import EditPolicyForm from './EditPolicyForm';
 import { useOnSave, useLinkToPolicy } from './hooks';
-import usePolicyQueries from './hooks/usePolicyQueries.js';
+import usePolicyQuery from 'Utilities/hooks/usePolicyQuery';
 
 export const EditPolicy = ({ route }) => {
-  const { policy, loading, error } = usePolicyQueries();
+  const { policy_id: policyId } = useParams();
+  const { data, error, loading } = usePolicyQuery({ policyId });
+  const policy = data?.profile;
 
   const linkToPolicy = useLinkToPolicy();
   const [updatedPolicy, setUpdatedPolicy] = useState(null);

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -177,20 +177,22 @@ export const EditPolicyRulesTab = ({
             must be customized independently.
           </Text>
         </TextContent>
-        <TabbedRules
-          resetLink
-          rulesPageLink
-          selectedFilter
-          remediationsEnabled={false}
-          columns={[Columns.Name, Columns.Severity, Columns.Remediation]}
-          tabsData={tabsData}
-          ruleValues={ruleValues(policy)}
-          selectedRuleRefIds={selectedRuleRefIds}
-          setSelectedRuleRefIds={setSelectedRuleRefIds}
-          setRuleValues={setRuleValues}
-          level={1}
-          ouiaId="RHELVersions"
-        />
+        {tabsData.length > 0 && (
+          <TabbedRules
+            resetLink
+            rulesPageLink
+            selectedFilter
+            remediationsEnabled={false}
+            columns={[Columns.Name, Columns.Severity, Columns.Remediation]}
+            tabsData={tabsData}
+            ruleValues={ruleValues(policy)}
+            selectedRuleRefIds={selectedRuleRefIds}
+            setSelectedRuleRefIds={setSelectedRuleRefIds}
+            setRuleValues={setRuleValues}
+            level={1}
+            ouiaId="RHELVersions"
+          />
+        )}
       </StateViewPart>
       <StateViewPart stateKey="empty">
         <EditPolicyRulesTabEmptyState />

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -56,7 +56,7 @@ exports[`EditPolicy expect to render without error 1`] = `
           "name": "profile1",
           "policy": Object {
             "name": "parentpolicy",
-            "profiles": undefined,
+            "profiles": Array [],
           },
           "refId": "121212",
           "totalHostCount": 1,
@@ -90,7 +90,7 @@ exports[`EditPolicy expect to render without error 1`] = `
             "name": "profile1",
             "policy": Object {
               "name": "parentpolicy",
-              "profiles": undefined,
+              "profiles": Array [],
             },
             "refId": "121212",
             "totalHostCount": 1,

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyRulesTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyRulesTab.test.js.snap
@@ -221,49 +221,6 @@ exports[`EditPolicyRulesTab expect to render without error 1`] = `
         Different release versions of RHEL are associated with different versions of the SCAP Security Guide (SSG), therefore each release must be customized independently.
       </Text>
     </TextContent>
-    <TabbedRules
-      columns={
-        Array [
-          Object {
-            "renderExport": [Function],
-            "renderFunc": [Function],
-            "sortByProp": "title",
-            "title": "Name",
-          },
-          Object {
-            "exportKey": "severity",
-            "renderFunc": [Function],
-            "sortByArray": Array [
-              "high",
-              "medium",
-              "low",
-              "unknown",
-            ],
-            "sortByProp": "severity",
-            "title": "Severity",
-          },
-          Object {
-            "renderExport": [Function],
-            "renderFunc": [Function],
-            "sortByFunction": [Function],
-            "title": "Remediation",
-            "transforms": Array [
-              [Function],
-            ],
-          },
-        ]
-      }
-      level={1}
-      ouiaId="RHELVersions"
-      remediationsEnabled={false}
-      resetLink={true}
-      ruleValues={Object {}}
-      rulesPageLink={true}
-      selectedFilter={true}
-      selectedRuleRefIds={Array []}
-      setSelectedRuleRefIds={[Function]}
-      tabsData={Array []}
-    />
   </StateViewPart>
   <StateViewPart
     stateKey="empty"

--- a/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
+++ b/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
@@ -169,14 +169,14 @@ const EditPolicyDetailsInline = ({
 EditPolicyDetailsInline.propTypes = {
   text: propTypes.string,
   variant: propTypes.string,
-  policy: propTypes.obj,
+  policy: propTypes.object,
   propertyName: propTypes.string,
   inlineClosedText: propTypes.string,
   label: propTypes.string,
   showTextUnderInline: propTypes.string,
   textUnderInline: propTypes.string,
   typeOfInput: propTypes.string,
-  Component: propTypes.component,
+  Component: propTypes.node,
 };
 
 export default EditPolicyDetailsInline;

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -1,8 +1,6 @@
 import React, { Fragment, useEffect } from 'react';
 import propTypes from 'prop-types';
-import gql from 'graphql-tag';
 import { useParams, useLocation } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -31,90 +29,20 @@ import PolicySystemsTab from './PolicySystemsTab';
 import PolicyMultiversionRules from './PolicyMultiversionRules';
 import './PolicyDetails.scss';
 import useSaveValueToPolicy from './hooks/useSaveValueToPolicy';
-import useFeature from 'Utilities/hooks/useFeature';
-
-export const QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
-    profile(id: $policyId) {
-      id
-      name
-      refId
-      external
-      description
-      totalHostCount
-      compliantHostCount
-      complianceThreshold
-      osMajorVersion
-      lastScanned
-      policyType
-      policy {
-        id
-        name
-        refId
-        profiles {
-          id
-          name
-          refId
-          osMinorVersion
-          osMajorVersion
-          values
-          benchmark {
-            id
-            title
-            latestSupportedOsMinorVersions
-            osMajorVersion
-            version
-            ruleTree @include(if: $enableRuleTree)
-            valueDefinitions {
-              defaultValue
-              description
-              id
-              refId
-              title
-              valueType
-            }
-          }
-          rules {
-            id
-            title
-            severity
-            rationale
-            refId
-            description
-            remediationAvailable
-            references
-            identifier
-            precedence
-            values
-          }
-        }
-      }
-      businessObjective {
-        id
-        title
-      }
-      hosts {
-        id
-        osMinorVersion
-      }
-    }
-  }
-`;
+import usePolicyQuery from 'Utilities/hooks/usePolicyQuery';
 
 export const PolicyDetails = ({ route }) => {
-  const ruleGroups = useFeature('ruleGroups');
-
   const defaultTab = 'details';
   const { policy_id: policyId } = useParams();
-  const location = useLocation();
-  let { data, error, loading, refetch } = useQuery(QUERY, {
-    variables: { policyId, enableRuleTree: ruleGroups },
-    fetchPolicy: 'no-cache',
+  const { data, error, loading, refetch } = usePolicyQuery({
+    policyId,
   });
+  const location = useLocation();
   const policy = data?.profile;
   const hasOsMinorProfiles = !!policy?.policy.profiles.find(
     (profile) => !!profile.osMinorVersion
   );
+
   const saveToPolicy = useSaveValueToPolicy(policy, () => {
     refetch();
   });
@@ -136,7 +64,7 @@ export const PolicyDetails = ({ route }) => {
         </section>
       </StateViewPart>
       <StateViewPart stateKey="data">
-        {policy && (
+        {policy ? (
           <Fragment>
             <PageHeader className="page-header-tabs">
               <Breadcrumb ouiaId="PolicyDetailsPathBreadcrumb">
@@ -183,6 +111,8 @@ export const PolicyDetails = ({ route }) => {
               </TabSwitcher>
             </section>
           </Fragment>
+        ) : (
+          ''
         )}
       </StateViewPart>
     </StateViewWithError>

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -26,7 +26,9 @@ exports[`PolicyDetails expect to render without error 1`] = `
             "profiles": Array [
               Object {
                 "benchmark": Object {
+                  "ruleTree": Object {},
                   "title": "benchmark",
+                  "valueDefinitions": Object {},
                   "version": "0.1.5",
                 },
                 "businessObjective": Object {
@@ -38,6 +40,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                 "name": "profile1",
                 "osMinorVersion": "9",
                 "refId": "121212",
+                "values": undefined,
               },
             ],
           },
@@ -158,7 +161,9 @@ exports[`PolicyDetails expect to render without error 1`] = `
                   "profiles": Array [
                     Object {
                       "benchmark": Object {
+                        "ruleTree": Object {},
                         "title": "benchmark",
+                        "valueDefinitions": Object {},
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {
@@ -170,6 +175,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "name": "profile1",
                       "osMinorVersion": "9",
                       "refId": "121212",
+                      "values": undefined,
                     },
                   ],
                 },
@@ -206,7 +212,9 @@ exports[`PolicyDetails expect to render without error 1`] = `
                   "profiles": Array [
                     Object {
                       "benchmark": Object {
+                        "ruleTree": Object {},
                         "title": "benchmark",
+                        "valueDefinitions": Object {},
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {
@@ -218,6 +226,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "name": "profile1",
                       "osMinorVersion": "9",
                       "refId": "121212",
+                      "values": undefined,
                     },
                   ],
                 },
@@ -254,7 +263,9 @@ exports[`PolicyDetails expect to render without error 1`] = `
                   "profiles": Array [
                     Object {
                       "benchmark": Object {
+                        "ruleTree": Object {},
                         "title": "benchmark",
+                        "valueDefinitions": Object {},
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {
@@ -266,6 +277,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "name": "profile1",
                       "osMinorVersion": "9",
                       "refId": "121212",
+                      "values": undefined,
                     },
                   ],
                 },

--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -186,3 +186,13 @@ export const constructQuery = (columns) => {
     fragments,
   };
 };
+
+export const logMultipleErrors = (...errors) => {
+  for (const error of errors) {
+    if (error) {
+      console.error(error);
+    }
+  }
+
+  return errors?.filter((v) => !!v).length > 0 || undefined;
+};

--- a/src/Utilities/hooks/usePolicyQuery/constants.js
+++ b/src/Utilities/hooks/usePolicyQuery/constants.js
@@ -1,32 +1,7 @@
 import gql from 'graphql-tag';
 
-export const BENCHMARKS_QUERY = gql`
-  query Benchmarks($filter: String!, $enableRuleTree: Boolean = false) {
-    benchmarks(search: $filter) {
-      nodes {
-        id
-        latestSupportedOsMinorVersions
-        ruleTree @include(if: $enableRuleTree)
-        valueDefinitions {
-          defaultValue
-          description
-          id
-          refId
-          title
-          valueType
-        }
-        profiles {
-          id
-          refId
-          ssgVersion
-        }
-      }
-    }
-  }
-`;
-
-export const MULTIVERSION_QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
+export const POLICY_QUERY = gql`
+  query Profile($policyId: String!) {
     profile(id: $policyId) {
       id
       name
@@ -46,28 +21,34 @@ export const MULTIVERSION_QUERY = gql`
         refId
         profiles {
           id
-          parentProfileId
           name
           refId
           osMinorVersion
           osMajorVersion
-          values
+          parentProfileId
           benchmark {
             id
             title
             latestSupportedOsMinorVersions
             osMajorVersion
             version
-            ruleTree @include(if: $enableRuleTree)
+            profiles {
+              id
+              refId
+              ssgVersion
+            }
           }
           rules {
+            id
             title
             severity
             rationale
             refId
             description
             remediationAvailable
+            references
             identifier
+            precedence
             values
           }
         }
@@ -85,27 +66,36 @@ export const MULTIVERSION_QUERY = gql`
   }
 `;
 
-export const RULE_VALUE_DEFINITIONS_QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
+export const POLICY_RULE_TREES_QUERY = gql`
+  query Profile($policyId: String!) {
     profile(id: $policyId) {
-      id
       policy {
-        id
-        refId
         profiles {
           id
-          parentProfileId
-          refId
           benchmark {
-            id
-            ruleTree @include(if: $enableRuleTree)
+            ruleTree
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const POLICY_VALUE_DEFINITONS_QUERY = gql`
+  query Profile($policyId: String!) {
+    profile(id: $policyId) {
+      policy {
+        profiles {
+          id
+          values
+          benchmark {
             valueDefinitions {
-              defaultValue
-              description
               id
               refId
               title
               valueType
+              defaultValue
+              description
             }
           }
         }

--- a/src/Utilities/hooks/usePolicyQuery/helpers.js
+++ b/src/Utilities/hooks/usePolicyQuery/helpers.js
@@ -1,0 +1,35 @@
+export const compileData = (policyData, ruleTreesData, valueDefinitionsData) =>
+  policyData && {
+    profile: {
+      ...policyData.profile,
+      policy: {
+        ...(policyData?.profile.policy || {}),
+        profiles:
+          policyData?.profile.policy.profiles?.map((profile) => {
+            const ruleTree =
+              ruleTreesData?.profile.policy.profiles.find(
+                ({ id }) => id === profile.id
+              )?.benchmark.ruleTree || {};
+
+            const valueDefinitions =
+              valueDefinitionsData?.profile.policy.profiles.find(
+                ({ id }) => id === profile.id
+              )?.benchmark.valueDefinitions || {};
+
+            const values = valueDefinitionsData?.profile.policy.profiles.find(
+              ({ id }) => id === profile.id
+            )?.values;
+
+            return {
+              ...profile,
+              values,
+              benchmark: {
+                ...profile.benchmark,
+                ruleTree,
+                valueDefinitions,
+              },
+            };
+          }) || [],
+      },
+    },
+  };

--- a/src/Utilities/hooks/usePolicyQuery/index.js
+++ b/src/Utilities/hooks/usePolicyQuery/index.js
@@ -1,0 +1,1 @@
+export { default } from './usePolicyQuery';

--- a/src/Utilities/hooks/usePolicyQuery/usePolicyQuery.js
+++ b/src/Utilities/hooks/usePolicyQuery/usePolicyQuery.js
@@ -1,0 +1,80 @@
+import { useMemo, useCallback } from 'react';
+import { useQuery } from '@apollo/client';
+import { logMultipleErrors } from 'Utilities/helpers';
+import useFeature from 'Utilities/hooks/useFeature';
+import {
+  POLICY_QUERY,
+  POLICY_RULE_TREES_QUERY,
+  POLICY_VALUE_DEFINITONS_QUERY,
+} from './constants';
+import { compileData } from './helpers';
+
+const usePolicyQuery = ({ policyId, skip: skipCondition }) => {
+  const ruleGroupsEnabled = useFeature('ruleGroups');
+  const valueEditingEnabled = useFeature('valueEditing');
+  const skip = policyId === 'new' || skipCondition;
+
+  const {
+    data: policyData,
+    error: policyError,
+    loading: policyLoading,
+    refetch: refecthPolicy,
+  } = useQuery(POLICY_QUERY, {
+    variables: { policyId },
+    skip,
+    fetchPolicy: 'no-cache',
+  });
+
+  const {
+    data: ruleTreesData,
+    error: ruleTreesError,
+    loading: ruleTreesLoading,
+    refetch: refecthRuleTrees,
+  } = useQuery(POLICY_RULE_TREES_QUERY, {
+    variables: { policyId },
+    skip: !ruleGroupsEnabled || skip,
+    fetchPolicy: 'no-cache',
+  });
+
+  const {
+    data: valueDefinitionsData,
+    error: valueDefinitionsError,
+    loading: valueDefinitionsLoading,
+    refetch: refecthValueDefinitions,
+  } = useQuery(POLICY_VALUE_DEFINITONS_QUERY, {
+    variables: { policyId },
+    skip: !valueEditingEnabled || skip,
+    fetchPolicy: 'no-cache',
+  });
+
+  const data = useMemo(
+    () => compileData(policyData, ruleTreesData, valueDefinitionsData),
+    [policyData, ruleTreesData, valueDefinitionsData]
+  );
+
+  const error = useMemo(
+    () => logMultipleErrors(policyError, ruleTreesError, valueDefinitionsError),
+    [policyError, ruleTreesError, valueDefinitionsError]
+  );
+
+  const loading = policyLoading || ruleTreesLoading || valueDefinitionsLoading;
+
+  const refetch = useCallback(() => {
+    if (!skip) {
+      refecthPolicy();
+      refecthRuleTrees();
+      refecthValueDefinitions();
+    }
+  }, [refecthPolicy, refecthRuleTrees, refecthValueDefinitions]);
+
+  return policyId === 'new'
+    ? { data: true, refetch: () => {} }
+    : {
+        data,
+        error,
+        loading,
+        refetch,
+      };
+};
+
+export default usePolicyQuery;


### PR DESCRIPTION
This changes the requesting of additional data, like the rule tree and value definitions with values for rules of policies/profiles to be requested only when needed and separately.


**How to test:**

1) Verify that the rules table behaves correctly with both ruleGroups and valueEditing disabled (append `?ruleGroups=disable` and `?valueEditing=disable` to the URL of any page containing a rules table.
2) Enable (append `?ruleGroups=enable` and `?valueEditing=enable`) both or only one feature and verify rules tables in the Crate Policy wizard, on the Policy Details, in the Edit Policy/Rules modal and on the Systems Details page work properly and allow using the new features. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
