### PR TITLE
feat(TableTools): RHICOMPL-3769 - Allow switching between tree and list view

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -75,7 +75,6 @@ const RulesTable = ({
       items={rules}
       columns={columns}
       isStickyHeader
-      variant={ruleGroups ? 'compact' : 'default'}
       filters={{
         filterConfig: buildFilterConfig({
           showRuleStateFilter,

--- a/src/PresentationalComponents/RulesTable/__snapshots__/RulesTable.test.js.snap
+++ b/src/PresentationalComponents/RulesTable/__snapshots__/RulesTable.test.js.snap
@@ -456,7 +456,6 @@ exports[`RulesTable expect to pass on options 1`] = `
       "selectedFilter": false,
     }
   }
-  variant="default"
 />
 `;
 
@@ -915,6 +914,5 @@ exports[`RulesTable expect to render without error 1`] = `
       "selectedFilter": false,
     }
   }
-  variant="default"
 />
 `;

--- a/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
+++ b/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
@@ -75,11 +75,10 @@ SSGPopoverBody.propTypes = {
 };
 
 const BENCHMARK_QUERY = gql`
-  query benchmarkQuery($id: String!, $enableRuleTree: Boolean = false) {
+  query benchmarkQuery($id: String!) {
     benchmark(id: $id) {
       id
       osMajorVersion
-      ruleTree @include(if: $enableRuleTree)
       rules {
         id
         title
@@ -90,14 +89,6 @@ const BENCHMARK_QUERY = gql`
         remediationAvailable
         identifier
         values
-      }
-      valueDefinitions {
-        defaultValue
-        description
-        id
-        refId
-        title
-        valueType
       }
     }
   }

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.cy.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.cy.js
@@ -421,7 +421,7 @@ describe('Policies table tests', () => {
 
     it('Row actions has correct items', () => {
       cy.ouiaType('PF4/TableRow', 'tr')
-        .get('td[data-key="5"] >> button')
+        .get('td[data-key="6"] >> button')
         .first()
         .click();
       cy.ouiaType('PF4/TableRow', 'tr')

--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -97,7 +97,7 @@ export const CreatePolicyForm = ({
   return (
     <React.Fragment>
       <Wizard
-        width={1220}
+        width={1300}
         className="compliance"
         isOpen
         onNext={onNext}

--- a/src/SmartComponents/CreatePolicy/__snapshots__/CreatePolicy.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/CreatePolicy.test.js.snap
@@ -76,7 +76,7 @@ exports[`CreatePolicyForm expect to render the wizard 1`] = `
     ]
   }
   title="Create SCAP policy"
-  width={1220}
+  width={1300}
 />
 `;
 

--- a/src/SmartComponents/CreatePolicy/constants.js
+++ b/src/SmartComponents/CreatePolicy/constants.js
@@ -1,0 +1,85 @@
+import gql from 'graphql-tag';
+
+export const BENCHMARKS_QUERY = gql`
+  query Benchmarks($filter: String!) {
+    benchmarks(search: $filter) {
+      nodes {
+        id
+        latestSupportedOsMinorVersions
+        ruleTree
+        valueDefinitions {
+          defaultValue
+          description
+          id
+          refId
+          title
+          valueType
+        }
+        profiles {
+          id
+          refId
+          osMajorVersion
+        }
+        version
+      }
+    }
+  }
+`;
+
+export const BENCHMARKS_RULES_TREES_QUERY = gql`
+  query Benchmarks($filter: String!) {
+    benchmarks(search: $filter) {
+      nodes {
+        id
+        ruleTree
+      }
+    }
+  }
+`;
+
+export const BENCHMARKS_VALUE_DEFINITIONS_QUERY = gql`
+  query Benchmarks($filter: String!) {
+    benchmarks(search: $filter) {
+      nodes {
+        id
+        latestSupportedOsMinorVersions
+        ruleTree
+        valueDefinitions {
+          defaultValue
+          description
+          id
+          refId
+          title
+          valueType
+        }
+        profiles {
+          id
+          refId
+          osMajorVersion
+        }
+        version
+      }
+    }
+  }
+`;
+
+export const PROFILES_QUERY = gql`
+  query Profiles($filter: String!) {
+    profiles(search: $filter) {
+      edges {
+        node {
+          id
+          refId
+          osMinorVersion
+          benchmark {
+            id
+            latestSupportedOsMinorVersions
+          }
+          rules {
+            refId
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/SmartComponents/CreatePolicy/hooks/useBenchmarksQuery.js
+++ b/src/SmartComponents/CreatePolicy/hooks/useBenchmarksQuery.js
@@ -1,0 +1,101 @@
+import { useMemo, useCallback } from 'react';
+import { useQuery } from '@apollo/client';
+import { logMultipleErrors } from 'Utilities/helpers';
+import useFeature from 'Utilities/hooks/useFeature';
+import {
+  BENCHMARKS_QUERY,
+  BENCHMARKS_RULES_TREES_QUERY,
+  BENCHMARKS_VALUE_DEFINITIONS_QUERY,
+} from '../constants';
+
+const compileData = (benchmarksData, ruleTreesData, valueDefinitionsData) => ({
+  benchmarks: {
+    nodes: benchmarksData?.benchmarks.nodes.map((node) => {
+      const ruleTree = ruleTreesData?.benchmarks.nodes.find(
+        ({ id }) => id === node.id
+      )?.ruleTree;
+      const valueDefinitions = valueDefinitionsData?.benchmarks.nodes.find(
+        ({ id }) => id === node.id
+      )?.valueDefinitions;
+
+      return {
+        ...node,
+        ruleTree,
+        valueDefinitions,
+      };
+    }),
+  },
+});
+
+const useBenchmarksQuery = ({ osMajorVersion, osMinorVersions }) => {
+  const filter =
+    `os_major_version = ${osMajorVersion} ` +
+    `and latest_supported_os_minor_version ^ "${osMinorVersions.join(',')}"`;
+
+  const ruleGroupsEnabled = useFeature('ruleGroups');
+  const valueEditingEnabled = useFeature('valueEditing');
+
+  const {
+    data: benchmarksData,
+    error: benchmarksError,
+    loading: benchmarksLoading,
+    refetch: refetchProfiles,
+  } = useQuery(BENCHMARKS_QUERY, {
+    variables: {
+      filter,
+    },
+    skip: osMinorVersions.length === 0,
+    fetchPolicy: 'no-cache',
+  });
+
+  const {
+    data: ruleTreesData,
+    error: ruleTreesError,
+    loading: ruleTreesLoading,
+    refetch: refecthRuleTrees,
+  } = useQuery(BENCHMARKS_RULES_TREES_QUERY, {
+    variables: { filter },
+    skip: osMinorVersions.length === 0 || !ruleGroupsEnabled,
+    fetchPolicy: 'no-cache',
+  });
+
+  const {
+    data: valueDefinitionsData,
+    error: valueDefinitionsError,
+    loading: valueDefinitionsLoading,
+    refetch: refecthValueDefinitions,
+  } = useQuery(BENCHMARKS_VALUE_DEFINITIONS_QUERY, {
+    variables: { filter },
+    skip: osMinorVersions.length === 0 || !valueEditingEnabled,
+    fetchPolicy: 'no-cache',
+  });
+
+  const data = useMemo(
+    () => compileData(benchmarksData, ruleTreesData, valueDefinitionsData),
+    [benchmarksData, ruleTreesData, valueDefinitionsData]
+  );
+
+  const error = useMemo(
+    () =>
+      logMultipleErrors(benchmarksError, ruleTreesError, valueDefinitionsError),
+    [benchmarksError, ruleTreesError, valueDefinitionsError]
+  );
+
+  const loading =
+    benchmarksLoading || ruleTreesLoading || valueDefinitionsLoading;
+
+  const refetch = useCallback(() => {
+    refetchProfiles();
+    refecthRuleTrees();
+    refecthValueDefinitions();
+  }, [refetchProfiles, refecthRuleTrees, refecthValueDefinitions]);
+
+  return {
+    data,
+    error,
+    loading,
+    refetch,
+  };
+};
+
+export default useBenchmarksQuery;

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -79,6 +79,7 @@ export const EditPolicy = ({ route }) => {
       isOpen
       position={'top'}
       style={{ minHeight: '350px' }}
+      width={1220}
       variant={'large'}
       ouiaId="EditPolicyModal"
       title={`Edit ${policy ? policy.name : ''}`}

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import { Button, Spinner } from '@patternfly/react-core';
+import { useParams } from 'react-router-dom';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
 import {
   ComplianceModal,
@@ -9,10 +10,12 @@ import {
 } from 'PresentationalComponents';
 import EditPolicyForm from './EditPolicyForm';
 import { useOnSave, useLinkToPolicy } from './hooks';
-import usePolicyQueries from './hooks/usePolicyQueries.js';
+import usePolicyQuery from 'Utilities/hooks/usePolicyQuery';
 
 export const EditPolicy = ({ route }) => {
-  const { policy, loading, error } = usePolicyQueries();
+  const { policy_id: policyId } = useParams();
+  const { data, error, loading } = usePolicyQuery({ policyId });
+  const policy = data?.profile;
 
   const linkToPolicy = useLinkToPolicy();
   const [updatedPolicy, setUpdatedPolicy] = useState(null);

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -177,20 +177,22 @@ export const EditPolicyRulesTab = ({
             must be customized independently.
           </Text>
         </TextContent>
-        <TabbedRules
-          resetLink
-          rulesPageLink
-          selectedFilter
-          remediationsEnabled={false}
-          columns={[Columns.Name, Columns.Severity, Columns.Remediation]}
-          tabsData={tabsData}
-          ruleValues={ruleValues(policy)}
-          selectedRuleRefIds={selectedRuleRefIds}
-          setSelectedRuleRefIds={setSelectedRuleRefIds}
-          setRuleValues={setRuleValues}
-          level={1}
-          ouiaId="RHELVersions"
-        />
+        {tabsData.length > 0 && (
+          <TabbedRules
+            resetLink
+            rulesPageLink
+            selectedFilter
+            remediationsEnabled={false}
+            columns={[Columns.Name, Columns.Severity, Columns.Remediation]}
+            tabsData={tabsData}
+            ruleValues={ruleValues(policy)}
+            selectedRuleRefIds={selectedRuleRefIds}
+            setSelectedRuleRefIds={setSelectedRuleRefIds}
+            setRuleValues={setRuleValues}
+            level={1}
+            ouiaId="RHELVersions"
+          />
+        )}
       </StateViewPart>
       <StateViewPart stateKey="empty">
         <EditPolicyRulesTabEmptyState />

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -34,6 +34,7 @@ exports[`EditPolicy expect to render without error 1`] = `
   }
   title="Edit profile1"
   variant="large"
+  width={1220}
 >
   <StateViewWithError
     stateValues={

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicy.test.js.snap
@@ -56,7 +56,7 @@ exports[`EditPolicy expect to render without error 1`] = `
           "name": "profile1",
           "policy": Object {
             "name": "parentpolicy",
-            "profiles": undefined,
+            "profiles": Array [],
           },
           "refId": "121212",
           "totalHostCount": 1,
@@ -90,7 +90,7 @@ exports[`EditPolicy expect to render without error 1`] = `
             "name": "profile1",
             "policy": Object {
               "name": "parentpolicy",
-              "profiles": undefined,
+              "profiles": Array [],
             },
             "refId": "121212",
             "totalHostCount": 1,

--- a/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyRulesTab.test.js.snap
+++ b/src/SmartComponents/EditPolicy/__snapshots__/EditPolicyRulesTab.test.js.snap
@@ -221,49 +221,6 @@ exports[`EditPolicyRulesTab expect to render without error 1`] = `
         Different release versions of RHEL are associated with different versions of the SCAP Security Guide (SSG), therefore each release must be customized independently.
       </Text>
     </TextContent>
-    <TabbedRules
-      columns={
-        Array [
-          Object {
-            "renderExport": [Function],
-            "renderFunc": [Function],
-            "sortByProp": "title",
-            "title": "Name",
-          },
-          Object {
-            "exportKey": "severity",
-            "renderFunc": [Function],
-            "sortByArray": Array [
-              "high",
-              "medium",
-              "low",
-              "unknown",
-            ],
-            "sortByProp": "severity",
-            "title": "Severity",
-          },
-          Object {
-            "renderExport": [Function],
-            "renderFunc": [Function],
-            "sortByFunction": [Function],
-            "title": "Remediation",
-            "transforms": Array [
-              [Function],
-            ],
-          },
-        ]
-      }
-      level={1}
-      ouiaId="RHELVersions"
-      remediationsEnabled={false}
-      resetLink={true}
-      ruleValues={Object {}}
-      rulesPageLink={true}
-      selectedFilter={true}
-      selectedRuleRefIds={Array []}
-      setSelectedRuleRefIds={[Function]}
-      tabsData={Array []}
-    />
   </StateViewPart>
   <StateViewPart
     stateKey="empty"

--- a/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
+++ b/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
@@ -169,14 +169,14 @@ const EditPolicyDetailsInline = ({
 EditPolicyDetailsInline.propTypes = {
   text: propTypes.string,
   variant: propTypes.string,
-  policy: propTypes.obj,
+  policy: propTypes.object,
   propertyName: propTypes.string,
   inlineClosedText: propTypes.string,
   label: propTypes.string,
   showTextUnderInline: propTypes.string,
   textUnderInline: propTypes.string,
   typeOfInput: propTypes.string,
-  Component: propTypes.component,
+  Component: propTypes.node,
 };
 
 export default EditPolicyDetailsInline;

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -1,8 +1,6 @@
 import React, { Fragment, useEffect } from 'react';
 import propTypes from 'prop-types';
-import gql from 'graphql-tag';
 import { useParams, useLocation } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -31,90 +29,20 @@ import PolicySystemsTab from './PolicySystemsTab';
 import PolicyMultiversionRules from './PolicyMultiversionRules';
 import './PolicyDetails.scss';
 import useSaveValueToPolicy from './hooks/useSaveValueToPolicy';
-import useFeature from 'Utilities/hooks/useFeature';
-
-export const QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
-    profile(id: $policyId) {
-      id
-      name
-      refId
-      external
-      description
-      totalHostCount
-      compliantHostCount
-      complianceThreshold
-      osMajorVersion
-      lastScanned
-      policyType
-      policy {
-        id
-        name
-        refId
-        profiles {
-          id
-          name
-          refId
-          osMinorVersion
-          osMajorVersion
-          values
-          benchmark {
-            id
-            title
-            latestSupportedOsMinorVersions
-            osMajorVersion
-            version
-            ruleTree @include(if: $enableRuleTree)
-            valueDefinitions {
-              defaultValue
-              description
-              id
-              refId
-              title
-              valueType
-            }
-          }
-          rules {
-            id
-            title
-            severity
-            rationale
-            refId
-            description
-            remediationAvailable
-            references
-            identifier
-            precedence
-            values
-          }
-        }
-      }
-      businessObjective {
-        id
-        title
-      }
-      hosts {
-        id
-        osMinorVersion
-      }
-    }
-  }
-`;
+import usePolicyQuery from 'Utilities/hooks/usePolicyQuery';
 
 export const PolicyDetails = ({ route }) => {
-  const ruleGroups = useFeature('ruleGroups');
-
   const defaultTab = 'details';
   const { policy_id: policyId } = useParams();
-  const location = useLocation();
-  let { data, error, loading, refetch } = useQuery(QUERY, {
-    variables: { policyId, enableRuleTree: ruleGroups },
-    fetchPolicy: 'no-cache',
+  const { data, error, loading, refetch } = usePolicyQuery({
+    policyId,
   });
+  const location = useLocation();
   const policy = data?.profile;
   const hasOsMinorProfiles = !!policy?.policy.profiles.find(
     (profile) => !!profile.osMinorVersion
   );
+
   const saveToPolicy = useSaveValueToPolicy(policy, () => {
     refetch();
   });
@@ -136,7 +64,7 @@ export const PolicyDetails = ({ route }) => {
         </section>
       </StateViewPart>
       <StateViewPart stateKey="data">
-        {policy && (
+        {policy ? (
           <Fragment>
             <PageHeader className="page-header-tabs">
               <Breadcrumb ouiaId="PolicyDetailsPathBreadcrumb">
@@ -183,6 +111,8 @@ export const PolicyDetails = ({ route }) => {
               </TabSwitcher>
             </section>
           </Fragment>
+        ) : (
+          ''
         )}
       </StateViewPart>
     </StateViewWithError>

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -26,7 +26,9 @@ exports[`PolicyDetails expect to render without error 1`] = `
             "profiles": Array [
               Object {
                 "benchmark": Object {
+                  "ruleTree": Object {},
                   "title": "benchmark",
+                  "valueDefinitions": Object {},
                   "version": "0.1.5",
                 },
                 "businessObjective": Object {
@@ -38,6 +40,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                 "name": "profile1",
                 "osMinorVersion": "9",
                 "refId": "121212",
+                "values": undefined,
               },
             ],
           },
@@ -158,7 +161,9 @@ exports[`PolicyDetails expect to render without error 1`] = `
                   "profiles": Array [
                     Object {
                       "benchmark": Object {
+                        "ruleTree": Object {},
                         "title": "benchmark",
+                        "valueDefinitions": Object {},
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {
@@ -170,6 +175,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "name": "profile1",
                       "osMinorVersion": "9",
                       "refId": "121212",
+                      "values": undefined,
                     },
                   ],
                 },
@@ -206,7 +212,9 @@ exports[`PolicyDetails expect to render without error 1`] = `
                   "profiles": Array [
                     Object {
                       "benchmark": Object {
+                        "ruleTree": Object {},
                         "title": "benchmark",
+                        "valueDefinitions": Object {},
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {
@@ -218,6 +226,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "name": "profile1",
                       "osMinorVersion": "9",
                       "refId": "121212",
+                      "values": undefined,
                     },
                   ],
                 },
@@ -254,7 +263,9 @@ exports[`PolicyDetails expect to render without error 1`] = `
                   "profiles": Array [
                     Object {
                       "benchmark": Object {
+                        "ruleTree": Object {},
                         "title": "benchmark",
+                        "valueDefinitions": Object {},
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {
@@ -266,6 +277,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "name": "profile1",
                       "osMinorVersion": "9",
                       "refId": "121212",
+                      "values": undefined,
                     },
                   ],
                 },

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicyDetails.test.js.snap
@@ -28,7 +28,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                 "benchmark": Object {
                   "ruleTree": Object {},
                   "title": "benchmark",
-                  "valueDefinitions": Object {},
+                  "valueDefinitions": Array [],
                   "version": "0.1.5",
                 },
                 "businessObjective": Object {
@@ -163,7 +163,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "benchmark": Object {
                         "ruleTree": Object {},
                         "title": "benchmark",
-                        "valueDefinitions": Object {},
+                        "valueDefinitions": Array [],
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {
@@ -214,7 +214,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "benchmark": Object {
                         "ruleTree": Object {},
                         "title": "benchmark",
-                        "valueDefinitions": Object {},
+                        "valueDefinitions": Array [],
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {
@@ -265,7 +265,7 @@ exports[`PolicyDetails expect to render without error 1`] = `
                       "benchmark": Object {
                         "ruleTree": Object {},
                         "title": "benchmark",
-                        "valueDefinitions": Object {},
+                        "valueDefinitions": Array [],
                         "version": "0.1.5",
                       },
                       "businessObjective": Object {

--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -186,3 +186,13 @@ export const constructQuery = (columns) => {
     fragments,
   };
 };
+
+export const logMultipleErrors = (...errors) => {
+  for (const error of errors) {
+    if (error) {
+      console.error(error);
+    }
+  }
+
+  return errors?.filter((v) => !!v).length > 0 || undefined;
+};

--- a/src/Utilities/hooks/usePolicyQuery/constants.js
+++ b/src/Utilities/hooks/usePolicyQuery/constants.js
@@ -1,32 +1,7 @@
 import gql from 'graphql-tag';
 
-export const BENCHMARKS_QUERY = gql`
-  query Benchmarks($filter: String!, $enableRuleTree: Boolean = false) {
-    benchmarks(search: $filter) {
-      nodes {
-        id
-        latestSupportedOsMinorVersions
-        ruleTree @include(if: $enableRuleTree)
-        valueDefinitions {
-          defaultValue
-          description
-          id
-          refId
-          title
-          valueType
-        }
-        profiles {
-          id
-          refId
-          ssgVersion
-        }
-      }
-    }
-  }
-`;
-
-export const MULTIVERSION_QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
+export const POLICY_QUERY = gql`
+  query Profile($policyId: String!) {
     profile(id: $policyId) {
       id
       name
@@ -46,28 +21,34 @@ export const MULTIVERSION_QUERY = gql`
         refId
         profiles {
           id
-          parentProfileId
           name
           refId
           osMinorVersion
           osMajorVersion
-          values
+          parentProfileId
           benchmark {
             id
             title
             latestSupportedOsMinorVersions
             osMajorVersion
             version
-            ruleTree @include(if: $enableRuleTree)
+            profiles {
+              id
+              refId
+              ssgVersion
+            }
           }
           rules {
+            id
             title
             severity
             rationale
             refId
             description
             remediationAvailable
+            references
             identifier
+            precedence
             values
           }
         }
@@ -85,27 +66,36 @@ export const MULTIVERSION_QUERY = gql`
   }
 `;
 
-export const RULE_VALUE_DEFINITIONS_QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
+export const POLICY_RULE_TREES_QUERY = gql`
+  query Profile($policyId: String!) {
     profile(id: $policyId) {
-      id
       policy {
-        id
-        refId
         profiles {
           id
-          parentProfileId
-          refId
           benchmark {
-            id
-            ruleTree @include(if: $enableRuleTree)
+            ruleTree
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const POLICY_VALUE_DEFINITONS_QUERY = gql`
+  query Profile($policyId: String!) {
+    profile(id: $policyId) {
+      policy {
+        profiles {
+          id
+          values
+          benchmark {
             valueDefinitions {
-              defaultValue
-              description
               id
               refId
               title
               valueType
+              defaultValue
+              description
             }
           }
         }

--- a/src/Utilities/hooks/usePolicyQuery/helpers.js
+++ b/src/Utilities/hooks/usePolicyQuery/helpers.js
@@ -1,0 +1,35 @@
+export const compileData = (policyData, ruleTreesData, valueDefinitionsData) =>
+  policyData && {
+    profile: {
+      ...policyData.profile,
+      policy: {
+        ...(policyData?.profile.policy || {}),
+        profiles:
+          policyData?.profile.policy.profiles?.map((profile) => {
+            const ruleTree =
+              ruleTreesData?.profile.policy.profiles.find(
+                ({ id }) => id === profile.id
+              )?.benchmark.ruleTree || {};
+
+            const valueDefinitions =
+              valueDefinitionsData?.profile.policy.profiles.find(
+                ({ id }) => id === profile.id
+              )?.benchmark.valueDefinitions || {};
+
+            const values = valueDefinitionsData?.profile.policy.profiles.find(
+              ({ id }) => id === profile.id
+            )?.values;
+
+            return {
+              ...profile,
+              values,
+              benchmark: {
+                ...profile.benchmark,
+                ruleTree,
+                valueDefinitions,
+              },
+            };
+          }) || [],
+      },
+    },
+  };

--- a/src/Utilities/hooks/usePolicyQuery/helpers.js
+++ b/src/Utilities/hooks/usePolicyQuery/helpers.js
@@ -14,7 +14,7 @@ export const compileData = (policyData, ruleTreesData, valueDefinitionsData) =>
             const valueDefinitions =
               valueDefinitionsData?.profile.policy.profiles.find(
                 ({ id }) => id === profile.id
-              )?.benchmark.valueDefinitions || {};
+              )?.benchmark.valueDefinitions || [];
 
             const values = valueDefinitionsData?.profile.policy.profiles.find(
               ({ id }) => id === profile.id

--- a/src/Utilities/hooks/usePolicyQuery/index.js
+++ b/src/Utilities/hooks/usePolicyQuery/index.js
@@ -1,0 +1,1 @@
+export { default } from './usePolicyQuery';

--- a/src/Utilities/hooks/usePolicyQuery/usePolicyQuery.js
+++ b/src/Utilities/hooks/usePolicyQuery/usePolicyQuery.js
@@ -1,0 +1,80 @@
+import { useMemo, useCallback } from 'react';
+import { useQuery } from '@apollo/client';
+import { logMultipleErrors } from 'Utilities/helpers';
+import useFeature from 'Utilities/hooks/useFeature';
+import {
+  POLICY_QUERY,
+  POLICY_RULE_TREES_QUERY,
+  POLICY_VALUE_DEFINITONS_QUERY,
+} from './constants';
+import { compileData } from './helpers';
+
+const usePolicyQuery = ({ policyId, skip: skipCondition }) => {
+  const ruleGroupsEnabled = useFeature('ruleGroups');
+  const valueEditingEnabled = useFeature('valueEditing');
+  const skip = policyId === 'new' || skipCondition;
+
+  const {
+    data: policyData,
+    error: policyError,
+    loading: policyLoading,
+    refetch: refecthPolicy,
+  } = useQuery(POLICY_QUERY, {
+    variables: { policyId },
+    skip,
+    fetchPolicy: 'no-cache',
+  });
+
+  const {
+    data: ruleTreesData,
+    error: ruleTreesError,
+    loading: ruleTreesLoading,
+    refetch: refecthRuleTrees,
+  } = useQuery(POLICY_RULE_TREES_QUERY, {
+    variables: { policyId },
+    skip: !ruleGroupsEnabled || skip,
+    fetchPolicy: 'no-cache',
+  });
+
+  const {
+    data: valueDefinitionsData,
+    error: valueDefinitionsError,
+    loading: valueDefinitionsLoading,
+    refetch: refecthValueDefinitions,
+  } = useQuery(POLICY_VALUE_DEFINITONS_QUERY, {
+    variables: { policyId },
+    skip: !valueEditingEnabled || skip,
+    fetchPolicy: 'no-cache',
+  });
+
+  const data = useMemo(
+    () => compileData(policyData, ruleTreesData, valueDefinitionsData),
+    [policyData, ruleTreesData, valueDefinitionsData]
+  );
+
+  const error = useMemo(
+    () => logMultipleErrors(policyError, ruleTreesError, valueDefinitionsError),
+    [policyError, ruleTreesError, valueDefinitionsError]
+  );
+
+  const loading = policyLoading || ruleTreesLoading || valueDefinitionsLoading;
+
+  const refetch = useCallback(() => {
+    if (!skip) {
+      refecthPolicy();
+      refecthRuleTrees();
+      refecthValueDefinitions();
+    }
+  }, [refecthPolicy, refecthRuleTrees, refecthValueDefinitions]);
+
+  return policyId === 'new'
+    ? { data: true, refetch: () => {} }
+    : {
+        data,
+        error,
+        loading,
+        refetch,
+      };
+};
+
+export default usePolicyQuery;

--- a/src/Utilities/hooks/useTableTools/Components/Bars.js
+++ b/src/Utilities/hooks/useTableTools/Components/Bars.js
@@ -1,0 +1,29 @@
+import React from 'react';
+const Bars = () => (
+  <svg
+    width="14px"
+    height="14px"
+    viewBox="0 0 14 14"
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlSpace="preserve"
+    style={{
+      fillRule: 'evenodd',
+      clipRule: 'evenodd',
+      strokeLinejoin: 'round',
+      strokeMiterlimit: 2,
+    }}
+  >
+    <g transform="matrix(1,0,0,1,-60.5538,-10.4896)">
+      <rect x="59.391" y="12.428" width="14.103" height="2.066" />
+    </g>
+    <g transform="matrix(1,0,0,1,-56.566,-5.40626)">
+      <rect x="59.391" y="12.428" width="14.103" height="2.066" />
+    </g>
+    <g transform="matrix(1,0,0,1,-56.4533,-0.438152)">
+      <rect x="59.391" y="12.428" width="14.103" height="2.066" />
+    </g>
+  </svg>
+);
+
+export default Bars;

--- a/src/Utilities/hooks/useTableTools/Components/TableToolsTable.js
+++ b/src/Utilities/hooks/useTableTools/Components/TableToolsTable.js
@@ -14,20 +14,19 @@ const TableToolsTable = ({
   toolbarProps: toolbarPropsProp,
   ...tablePropsRest
 }) => {
-  const { toolbarProps, tableProps, ColumnManager } = useTableTools(
-    items,
-    columns,
-    {
+  const { toolbarProps, tableProps, ColumnManager, TreeTableToggle } =
+    useTableTools(items, columns, {
       filters,
       toolbarProps: toolbarPropsProp,
       tableProps: tablePropsRest,
       ...options,
-    }
-  );
+    });
 
   return (
     <React.Fragment>
-      <PrimaryToolbar {...toolbarProps} />
+      <PrimaryToolbar {...toolbarProps}>
+        {TreeTableToggle && <TreeTableToggle />}
+      </PrimaryToolbar>
 
       <Table {...tableProps}>
         <TableHeader />

--- a/src/Utilities/hooks/useTableTools/Components/TreeTableToggle.js
+++ b/src/Utilities/hooks/useTableTools/Components/TreeTableToggle.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import propTypes from 'prop-types';
+
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import { ListIcon } from '@patternfly/react-icons';
+import Bars from './Bars';
+
+const TreeTableToggle = ({ onToggle, tableType }) => (
+  <ToggleGroup>
+    <ToggleGroupItem
+      icon={<ListIcon />}
+      aria-label="list"
+      isSelected={tableType === 'list'}
+      onChange={onToggle}
+    />
+    <ToggleGroupItem
+      icon={<Bars />}
+      aria-label="tree"
+      isSelected={tableType === 'tree'}
+      onChange={onToggle}
+    />
+  </ToggleGroup>
+);
+
+TreeTableToggle.propTypes = {
+  onToggle: propTypes.function,
+  tableType: propTypes.string,
+};
+
+export default TreeTableToggle;

--- a/src/Utilities/hooks/useTableTools/Components/__snapshots__/TableToolsTable.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/Components/__snapshots__/TableToolsTable.test.js.snap
@@ -241,6 +241,7 @@ exports[`TableToolsTable expect to render without error 1`] = `
     isNested={false}
     isStickyHeader={false}
     isTreeTable={false}
+    onCollapse={[Function]}
     onSort={[Function]}
     ouiaSafe={true}
     role="grid"
@@ -483,7 +484,7 @@ exports[`TableToolsTable expect to render without error 1`] = `
     sortBy={
       Object {
         "direction": "asc",
-        "index": 0,
+        "index": 1,
       }
     }
     variant={null}

--- a/src/Utilities/hooks/useTableTools/__fixtures__/tableTree.js
+++ b/src/Utilities/hooks/useTableTools/__fixtures__/tableTree.js
@@ -51,4 +51,9 @@ export default [
     itemId: '3rd-branch',
     leaf: item(7),
   },
+  {
+    title: '4th Branch',
+    itemId: '4th-branch',
+    leaves: [item(8)],
+  },
 ];

--- a/src/Utilities/hooks/useTableTools/__snapshots__/rowBuilderHelpers.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__snapshots__/rowBuilderHelpers.test.js.snap
@@ -49,6 +49,25 @@ Array [
     "itemId": "item-7",
     "props": Object {},
   },
+  Object {
+    "cells": Array [
+      Object {
+        "props": Object {
+          "colSpan": 1,
+        },
+        "title": <strong>
+          4th Branch
+        </strong>,
+      },
+    ],
+    "isTreeBranch": true,
+    "itemId": "4th-branch",
+    "props": Object {
+      "aria-level": 1,
+      "aria-setsize": 1,
+      "isExpanded": false,
+    },
+  },
 ]
 `;
 
@@ -101,6 +120,25 @@ Array [
     "itemId": "item-7",
     "props": Object {},
   },
+  Object {
+    "cells": Array [
+      Object {
+        "props": Object {
+          "colSpan": 1,
+        },
+        "title": <strong>
+          4th Branch
+        </strong>,
+      },
+    ],
+    "isTreeBranch": true,
+    "itemId": "4th-branch",
+    "props": Object {
+      "aria-level": 1,
+      "aria-setsize": 1,
+      "isExpanded": false,
+    },
+  },
 ]
 `;
 
@@ -142,5 +180,6 @@ Array [
   "item-4",
   "item-5",
   "item-6",
+  "item-8",
 ]
 `;

--- a/src/Utilities/hooks/useTableTools/__snapshots__/useExpandable.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__snapshots__/useExpandable.test.js.snap
@@ -38,6 +38,7 @@ exports[`useExpandable returns an expandable configuration 1`] = `
 Object {
   "all": Array [
     Object {
+      "openItems": Array [],
       "tableProps": Object {
         "onCollapse": [Function],
       },
@@ -45,6 +46,7 @@ Object {
     },
   ],
   "current": Object {
+    "openItems": Array [],
     "tableProps": Object {
       "onCollapse": [Function],
     },

--- a/src/Utilities/hooks/useTableTools/__snapshots__/useTableSort.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__snapshots__/useTableSort.test.js.snap
@@ -54,7 +54,7 @@ Object {
         "onSort": [Function],
         "sortBy": Object {
           "direction": "asc",
-          "index": 0,
+          "index": 1,
         },
       },
     },
@@ -110,7 +110,7 @@ Object {
       "onSort": [Function],
       "sortBy": Object {
         "direction": "asc",
-        "index": 0,
+        "index": 1,
       },
     },
   },

--- a/src/Utilities/hooks/useTableTools/rowBuilderHelpers.js
+++ b/src/Utilities/hooks/useTableTools/rowBuilderHelpers.js
@@ -23,7 +23,10 @@ const childRowForItem = (item, idx, DetailsComponent, colSpan) => ({
   cells: [
     {
       title: <DetailsComponent item={item} key={'item-' + item.rowId} />,
-      props: { colSpan, className: 'compliance-rule-details' },
+      props: {
+        ...(colSpan ? { colSpan } : {}),
+        className: 'compliance-rule-details',
+      },
     },
   ],
 });
@@ -250,4 +253,29 @@ export const collectLeaves = (tableTree, itemId) => {
   };
 
   return tableTree.reduce(pickBranch, []);
+};
+
+export const findParentsForItemInTree = (tableTree) => (itemId) => {
+  let parents;
+  const findParents = (branches = [], itemId, parentBranches = []) => {
+    for (let branch of branches) {
+      const hasItem =
+        branch.leaves?.some((currentItemId) => currentItemId === itemId) ||
+        branch.leaf === itemId;
+
+      if (hasItem) {
+        parents = [branch.itemId, ...parentBranches];
+        break;
+      } else {
+        findParents(branch.twigs || [], itemId, [
+          branch.itemId,
+          ...parentBranches,
+        ]);
+      }
+    }
+  };
+
+  findParents(tableTree, itemId);
+
+  return parents || [];
 };

--- a/src/Utilities/hooks/useTableTools/rowBuilderHelpers.test.js
+++ b/src/Utilities/hooks/useTableTools/rowBuilderHelpers.test.js
@@ -1,5 +1,9 @@
 import tableTree, { exampleItems } from './__fixtures__/tableTree';
-import { chopTreeIntoTable, collectLeaves } from './rowBuilderHelpers';
+import {
+  chopTreeIntoTable,
+  collectLeaves,
+  findParentsForItemInTree,
+} from './rowBuilderHelpers';
 
 const exampleColumns = [{ title: 'Name', key: 'name' }];
 
@@ -30,5 +34,30 @@ describe('collectLeaves', () => {
       collectLeaves(tableTree, '2nd-branch-2nd-twig-1st-twig')
     ).toMatchSnapshot();
     expect(collectLeaves(tableTree, '3rd-branch')).toMatchSnapshot();
+  });
+});
+
+describe('findParentsForItemInTree', () => {
+  console.log(tableTree);
+  it('returns the parents for a first level a given itemId', () => {
+    expect(findParentsForItemInTree(tableTree)('item-8')).toEqual([
+      '4th-branch',
+    ]);
+  });
+
+  it('returns the parents for a leaf item with the given itemId', () => {
+    expect(findParentsForItemInTree(tableTree)('item-7')).toEqual([
+      '3rd-branch',
+    ]);
+  });
+
+  it('returns the parents for a given itemId', () => {
+    expect(findParentsForItemInTree(tableTree)('item-6').sort()).toEqual(
+      [
+        '2nd-branch',
+        '2nd-branch-2nd-twig',
+        '2nd-branch-2nd-twig-1st-twig',
+      ].sort()
+    );
   });
 });

--- a/src/Utilities/hooks/useTableTools/useBulkSelect.js
+++ b/src/Utilities/hooks/useTableTools/useBulkSelect.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { filterSelected } from './helper';
 
 const compileTitle = (itemsTotal, titleOption) => {
@@ -45,7 +45,7 @@ export const useBulkSelect = ({
   itemIdsInTable,
   itemIdsOnPage,
   identifier = 'id',
-  tableTree,
+  showTreeTable,
 }) => {
   const enableBulkSelect = !!onSelect;
   const [selectedIds, setSelectedItemIds] = useState(preselected);
@@ -111,7 +111,7 @@ export const useBulkSelect = ({
         selectItems: (ids) => onSelectCallback(() => selectItems(ids)),
         unselectItems: (ids) => onSelectCallback(() => unselectItems(ids)),
         tableProps: {
-          ...(!tableTree
+          ...(!showTreeTable
             ? { onSelect: total > 0 ? selectOne : undefined }
             : {}),
           canSelectAll: false,
@@ -178,13 +178,11 @@ export const useBulkSelectWithItems = ({
 
   const allCount = filtered ? filteredTotal : total;
 
-  const setPageMemo = useMemo(() => setPage, []);
-
   useEffect(() => {
     if (paginatedTotal === 0 && setPage) {
-      setPageMemo(-1);
+      setPage?.(-1);
     }
-  }, [paginatedTotal, setPageMemo]);
+  }, [paginatedTotal]);
 
   const { selectNone, selectedIds, ...bulkSelect } = useBulkSelect({
     ...options,

--- a/src/Utilities/hooks/useTableTools/useExpandable.test.js
+++ b/src/Utilities/hooks/useTableTools/useExpandable.test.js
@@ -55,15 +55,4 @@ describe('useExpandable', () => {
 
     expect(openedItem).toMatchSnapshot();
   });
-
-  it('should not return an expandable configuration with treetable active', () => {
-    const { result } = renderHook(() =>
-      useExpandable({
-        ...defaultOptions,
-        tableTree: ['item'],
-      })
-    );
-
-    expect(Object.keys(result.current).length).toEqual(0);
-  });
 });

--- a/src/Utilities/hooks/useTableTools/useFilterConfig.js
+++ b/src/Utilities/hooks/useTableTools/useFilterConfig.js
@@ -29,7 +29,8 @@ const perpareInitialActiveFilters = (
 };
 
 const useFilterConfig = (options = {}) => {
-  const { filters, setPage, selectedFilter, onDeleteFilter } = options;
+  const { filters, setPage, selectedFilter, onDeleteFilter, onFilter } =
+    options;
   const enableFilters = !!filters;
   const { filterConfig = [], activeFilters: initialActiveFiltersRaw } =
     filters || {};
@@ -44,7 +45,9 @@ const useFilterConfig = (options = {}) => {
       ...prevFilters,
       [filter]: value,
     }));
-
+    if (filter === 'name') {
+      onFilter?.();
+    }
     setPage && setPage(1);
   };
 

--- a/src/Utilities/hooks/useTableTools/usePaginate.js
+++ b/src/Utilities/hooks/useTableTools/usePaginate.js
@@ -2,7 +2,8 @@ import { useState } from 'react';
 
 const usePaginate = (options = {}) => {
   const { perPage = 10 } = options;
-  const enablePagination = options.pagination !== false && !options.tableTree;
+  const enablePagination =
+    options.pagination !== false && !options.showTreeTable;
   const [paginationState, setPaginationState] = useState({
     perPage,
     page: 1,

--- a/src/Utilities/hooks/useTableTools/useTableSort.js
+++ b/src/Utilities/hooks/useTableTools/useTableSort.js
@@ -16,16 +16,18 @@ const addSortableTransform = (columns) =>
 
 const columnOffset = (options = {}) =>
   (typeof options.onSelect === 'function' || options.hasRadioSelect ? 1 : 0) +
-  (typeof options.detailsComponent !== 'undefined') +
-  (typeof options.tableTree !== 'undefined' ? -2 : 0);
+  (typeof options.detailsComponent !== 'undefined');
+
+const sortByFromOptions = (options = {}) => ({
+  index:
+    options.tableType === 'tree'
+      ? options.sortBy?.index - 1
+      : options.sortBy?.index || 1,
+  direction: options.sortBy?.direction || 'asc',
+});
 
 const useTableSort = (columns, options = {}) => {
-  const [sortBy, setSortBy] = useState(
-    options.sortBy || {
-      index: 0,
-      direction: 'asc',
-    }
-  );
+  const [sortBy, setSortBy] = useState(sortByFromOptions(options));
   const onSort = (_, index, direction) => {
     setSortBy({
       index,
@@ -36,8 +38,11 @@ const useTableSort = (columns, options = {}) => {
   const sorter = useCallback(
     (items) => {
       const currentSortableColumn =
-        columns[sortBy.index - columnOffset(options)];
-
+        columns[
+          sortBy.index -
+            (options.tableType === 'tree' ? 0 : columnOffset(options)) -
+            1
+        ];
       return currentSortableColumn?.sortByArray
         ? orderByArray(
             items,
@@ -52,7 +57,7 @@ const useTableSort = (columns, options = {}) => {
             sortBy.direction
           );
     },
-    [sortBy, columns]
+    [sortBy, columns, options.tableType]
   );
 
   return {

--- a/src/Utilities/hooks/useTableTools/useTableTools.js
+++ b/src/Utilities/hooks/useTableTools/useTableTools.js
@@ -11,6 +11,7 @@ import useColumnManager from './useColumnManager';
 import { useRadioSelectWithItems } from './useRadioSelect';
 import { useActionResolverWithItems } from './useActionResolver';
 import { useExportWithItems } from './useExport';
+import useTreeTable from './useTreeTable';
 
 const filteredAndSortedItems = (items, filter, sorter) => {
   const filtered = filter ? filter(items) : items;
@@ -27,6 +28,14 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     columns: managedColumns,
   } = useColumnManager(columns, options);
 
+  const {
+    toolbarProps: treeTableToolbarProps,
+    showTreeTable,
+    TreeTableToggle,
+    setTableType,
+    tableType,
+  } = useTreeTable(options);
+
   const { toolbarProps: toolbarActionsProps } = useToolbarActions({
     ...options,
     actions: [
@@ -39,7 +48,10 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     toolbarProps: pagintionToolbarProps,
     setPage,
     paginator,
-  } = usePaginate(options);
+  } = usePaginate({
+    ...options,
+    showTreeTable,
+  });
 
   const {
     toolbarProps: conditionalFilterProps,
@@ -49,15 +61,22 @@ const useTableTools = (items = [], columns = [], options = {}) => {
   } = useFilterConfig({
     ...options,
     setPage,
+    onFilter: () => setTableType?.('list'),
   });
 
-  const { transformer: openItem, tableProps: expandableProps } =
-    useExpandable(options);
+  const {
+    transformer: openItem,
+    tableProps: expandableProps,
+    openItems,
+  } = useExpandable({
+    ...options,
+    showTreeTable,
+  });
 
   const { tableProps: sortableTableProps, sorter } = useTableSortWithItems(
     items,
     managedColumns,
-    options
+    { ...options, tableType }
   );
 
   const {
@@ -73,6 +92,7 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     filter,
     paginator,
     setPage,
+    showTreeTable,
   });
 
   const { tableProps: radioSelectTableProps } = useRadioSelectWithItems({
@@ -120,6 +140,9 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     unselectItems,
     expandOnFilter: options.expandOnFilter,
     activeFilters,
+    showTreeTable,
+    onCollapse: expandableProps?.onCollapse,
+    openItems,
   });
 
   const toolbarProps = {
@@ -132,6 +155,7 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     ...toolbarPropsOption,
     ...exportToolbarProps,
     ...toolbarActionsProps,
+    ...treeTableToolbarProps,
   };
 
   const tableProps = {
@@ -149,6 +173,7 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     toolbarProps,
     tableProps,
     ColumnManager,
+    TreeTableToggle,
   };
 };
 

--- a/src/Utilities/hooks/useTableTools/useTreeTable.js
+++ b/src/Utilities/hooks/useTableTools/useTreeTable.js
@@ -1,0 +1,36 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import TreeTableToggle from './Components/TreeTableToggle';
+
+const useTreeTable = (options) => {
+  const enableTreeTable = !!options.tableTree;
+  const [tableType, setTableType] = useState('tree');
+
+  const onToggle = useCallback(() => {
+    if (tableType === 'list') {
+      setTableType('tree');
+    } else {
+      setTableType('list');
+    }
+  }, [tableType]);
+
+  const Toggle = useMemo(() => {
+    const T = () => (
+      <TreeTableToggle onToggle={onToggle} tableType={tableType} />
+    );
+    return T;
+  }, [tableType]);
+
+  return enableTreeTable
+    ? {
+        toolbarProps: {
+          variant: 'compact',
+        },
+        showTreeTable: tableType === 'tree',
+        tableType,
+        setTableType,
+        TreeTableToggle: Toggle,
+      }
+    : {};
+};
+
+export default useTreeTable;


### PR DESCRIPTION
This adds the ability for users to switch between tree and list view of a rules table.


**How to test:**

(see also https://github.com/RedHatInsights/compliance-frontend/pull/1945 to enable the features)

1) Open any page that contains a Rules Table (for example the policy details rules tab)
2) Try switching between list and tree view.
3) Switch to the tree view and filter. This will switch automatically to the list view
4) Expand an item and switch between list and tree view verifying the expansion is maintained.
5) Select an item and switch views to verify the selection is maintained.
6) Try to break it. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
