### PR TITLE
feat(metrics): RHICOMPL-3502 make query names unique

### DIFF
--- a/src/PresentationalComponents/ComplianceRemediationButton/constants.js
+++ b/src/PresentationalComponents/ComplianceRemediationButton/constants.js
@@ -4,7 +4,7 @@ export const DEFAULT_SYSTEMS_PER_BATCH = 3;
 export const DEFAULT_CONNCURRENT_REQUESTS_FOR_ISSUES = 3;
 
 export const GET_SYSTEMS_ISSUES = gql`
-  query getSystems(
+  query CRB_Systems(
     $filter: String!
     $policyId: ID
     $perPage: Int

--- a/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
+++ b/src/PresentationalComponents/TabbedRules/ProfileTabContent.js
@@ -75,7 +75,7 @@ SSGPopoverBody.propTypes = {
 };
 
 const BENCHMARK_QUERY = gql`
-  query benchmarkQuery($id: String!) {
+  query PTC_Benchmark($id: String!) {
     benchmark(id: $id) {
       id
       osMajorVersion

--- a/src/SmartComponents/CreatePolicy/constants.js
+++ b/src/SmartComponents/CreatePolicy/constants.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const BENCHMARKS_QUERY = gql`
-  query Benchmarks($filter: String!) {
+  query CP_Benchmarks($filter: String!) {
     benchmarks(search: $filter) {
       nodes {
         id
@@ -27,7 +27,7 @@ export const BENCHMARKS_QUERY = gql`
 `;
 
 export const BENCHMARKS_RULES_TREES_QUERY = gql`
-  query Benchmarks($filter: String!) {
+  query CP_BenchmarksRuleTree($filter: String!) {
     benchmarks(search: $filter) {
       nodes {
         id
@@ -38,7 +38,7 @@ export const BENCHMARKS_RULES_TREES_QUERY = gql`
 `;
 
 export const BENCHMARKS_VALUE_DEFINITIONS_QUERY = gql`
-  query Benchmarks($filter: String!) {
+  query CP_BenchmarksValueDefinitions($filter: String!) {
     benchmarks(search: $filter) {
       nodes {
         id
@@ -64,7 +64,7 @@ export const BENCHMARKS_VALUE_DEFINITIONS_QUERY = gql`
 `;
 
 export const PROFILES_QUERY = gql`
-  query Profiles($filter: String!) {
+  query CP_Profiles($filter: String!) {
     profiles(search: $filter) {
       edges {
         node {

--- a/src/SmartComponents/EditPolicy/constants.js
+++ b/src/SmartComponents/EditPolicy/constants.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const BENCHMARKS_QUERY = gql`
-  query Benchmarks($filter: String!, $enableRuleTree: Boolean = false) {
+  query EP_Benchmarks($filter: String!, $enableRuleTree: Boolean = false) {
     benchmarks(search: $filter) {
       nodes {
         id
@@ -26,7 +26,7 @@ export const BENCHMARKS_QUERY = gql`
 `;
 
 export const MULTIVERSION_QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
+  query EP_Profile($policyId: String!, $enableRuleTree: Boolean = false) {
     profile(id: $policyId) {
       id
       name
@@ -86,7 +86,10 @@ export const MULTIVERSION_QUERY = gql`
 `;
 
 export const RULE_VALUE_DEFINITIONS_QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
+  query EP_ProfileValueDefinitions(
+    $policyId: String!
+    $enableRuleTree: Boolean = false
+  ) {
     profile(id: $policyId) {
       id
       policy {

--- a/src/SmartComponents/PolicyRules/PolicyRules.js
+++ b/src/SmartComponents/PolicyRules/PolicyRules.js
@@ -12,7 +12,7 @@ import { Spinner, Text, TextContent } from '@patternfly/react-core';
 import useFeature from 'Utilities/hooks/useFeature';
 
 const PROFILES_QUERY = gql`
-  query Profile($policyId: String!, $enableRuleTree: Boolean = false) {
+  query PR_Profile($policyId: String!, $enableRuleTree: Boolean = false) {
     profile(id: $policyId) {
       id
       name

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -36,7 +36,7 @@ import { default as ReportDetailsWithNotReportedSystems } from './ReportDetailsW
 import ReportChart from './Components/ReportChart';
 
 export const QUERY = gql`
-  query Profile($policyId: String!) {
+  query RD_Profile($policyId: String!) {
     profile(id: $policyId) {
       id
       name

--- a/src/SmartComponents/ReportDetails/ReportDetailsWithNotReportedSystems.js
+++ b/src/SmartComponents/ReportDetails/ReportDetailsWithNotReportedSystems.js
@@ -35,7 +35,7 @@ import ReportedSystemRow from './Components/ReportedSystemRow';
 import ReportChart from './Components/ReportChart';
 
 export const QUERY = gql`
-  query Profile($policyId: String!) {
+  query RDWNRS_Profile($policyId: String!) {
     profile(id: $policyId) {
       id
       name

--- a/src/SmartComponents/ReportDownload/constants.js
+++ b/src/SmartComponents/ReportDownload/constants.js
@@ -10,7 +10,7 @@ export const DEFAULT_EXPORT_SETTINGS = {
 };
 
 export const GET_SYSTEMS = gql`
-  query getSystems(
+  query PDF_Systems(
     $filter: String!
     $policyId: ID
     $perPage: Int
@@ -50,7 +50,7 @@ export const GET_SYSTEMS = gql`
 `;
 
 export const GET_PROFILE = gql`
-  query Profile($policyId: String!) {
+  query PDF_Profile($policyId: String!) {
     profile(id: $policyId) {
       id
       name
@@ -79,7 +79,7 @@ export const GET_PROFILE = gql`
 `;
 
 export const GET_RULES = gql`
-  query getProfiles($filter: String!, $policyId: ID!) {
+  query PDF_Profiles($filter: String!, $policyId: ID!) {
     profiles(search: $filter) {
       totalCount
       edges {

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -15,7 +15,7 @@ import {
 } from 'PresentationalComponents';
 
 const QUERY = gql`
-  query Profiles($filter: String!) {
+  query R_Profiles($filter: String!) {
     profiles(search: $filter, limit: 1000) {
       edges {
         node {

--- a/src/SmartComponents/SystemDetails/ComplianceDetail.js
+++ b/src/SmartComponents/SystemDetails/ComplianceDetail.js
@@ -14,7 +14,7 @@ import useFeature from 'Utilities/hooks/useFeature';
 import EmptyState from './EmptyState';
 
 const QUERY = gql`
-  query System($systemId: String!, $enableRuleTree: Boolean = false) {
+  query CD_System($systemId: String!, $enableRuleTree: Boolean = false) {
     system(id: $systemId) {
       id
       name

--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -19,7 +19,7 @@ import { InventoryDetails } from 'SmartComponents';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
 
 const QUERY = gql`
-  query System($inventoryId: String!) {
+  query SD_System($inventoryId: String!) {
     system(id: $inventoryId) {
       id
       name

--- a/src/SmartComponents/SystemsTable/constants.js
+++ b/src/SmartComponents/SystemsTable/constants.js
@@ -10,7 +10,7 @@ import { conditionalFilterType } from '@redhat-cloud-services/frontend-component
 import { entitiesReducer } from 'Store/Reducers/SystemStore';
 
 export const GET_MINIMAL_SYSTEMS = gql`
-  query getSystems(
+  query ST_Systems(
     $filter: String!
     $perPage: Int
     $page: Int
@@ -44,7 +44,7 @@ export const GET_MINIMAL_SYSTEMS = gql`
 `;
 
 export const GET_SYSTEMS_OSES = gql`
-  query getSystems($filter: String!) {
+  query ST_SystemOS($filter: String!) {
     systems(search: $filter) {
       osVersions
     }

--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -135,7 +135,7 @@ export const constructQuery = (columns) => {
       tags
     }
 
-    query getSystems(
+    query U_Systems(
       $filter: String!
       $policyId: ID
       $perPage: Int

--- a/src/Utilities/hooks/usePolicyQuery/constants.js
+++ b/src/Utilities/hooks/usePolicyQuery/constants.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const POLICY_QUERY = gql`
-  query Profile($policyId: String!) {
+  query PQ_Profile($policyId: String!) {
     profile(id: $policyId) {
       id
       name
@@ -67,7 +67,7 @@ export const POLICY_QUERY = gql`
 `;
 
 export const POLICY_RULE_TREES_QUERY = gql`
-  query Profile($policyId: String!) {
+  query PQ_Profile($policyId: String!) {
     profile(id: $policyId) {
       policy {
         profiles {
@@ -82,7 +82,7 @@ export const POLICY_RULE_TREES_QUERY = gql`
 `;
 
 export const POLICY_VALUE_DEFINITONS_QUERY = gql`
-  query Profile($policyId: String!) {
+  query PQ_Profile($policyId: String!) {
     profile(id: $policyId) {
       policy {
         profiles {


### PR DESCRIPTION
There are 4-5 unique query names that make our GQL metrics useless as we cannot see which query is slow. I am now prefixing the query names with some unique few letter combination describing in which class are they being used. This way if a query is slow, we can look it up in the codebase.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
