### PR TITLE
fix(code-climate): Exclude cypress tests as well

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,5 @@
 exclude_patterns:
   - "src/__fixtures__/*.js"
   - "src/**/*.test.js"
+  - "src/**/*.cy.js"
+


### PR DESCRIPTION
The cypress tests currently affect the Maintainability score on Code Climate negatively.
We should exclude them like other test files.

See https://codeclimate.com/github/RedHatInsights/compliance-frontend/src/SmartComponents/CompliancePolicies/CompliancePolicies.cy.js/source#issue-3bf6d23b3b7ded49362dd50d603846b4


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
