### PR TITLE
fix(RHICOMPL-3518): Fix create policy button on Inventory

### DIFF
--- a/src/PresentationalComponents/LinkButton/LinkButton.js
+++ b/src/PresentationalComponents/LinkButton/LinkButton.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
-import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 
 const LinkButton = ({ children, to, ...props }) => {
-  const navigate = useNavigate();
+  const navigate = useInsightsNavigate('compliance');
 
   return (
     <Button onClick={() => navigate(to)} {...props}>


### PR DESCRIPTION
[RHICOMPL-3518](https://issues.redhat.com/browse/RHICOMPL-3518)

The issue mentioned in the ticket has been partially fixed by the router upgrade, but new issue has appeared when you click the button, you're not redirected to Compliance. This PR fixes this.

I've replaced `useNavigate` with `useInsightsNavigate` and set the app to compliance. This shouldn't affect any functionality other than when you click the link from Inventory, you're redirected to compliance + the provided link.

## How to test
1. Open Inventory and select a system
2. Go to the Compliance tab
3. You should see something like this
![image](https://github.com/RedHatInsights/compliance-frontend/assets/20592948/68a2b001-58a1-4d1d-bbe9-266ac7a2e213)
4. Click `Create new policy` and make sure you're redirected to /compliance/scappolicies/new and a modal is opened.


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
