### PR TITLE
DRAFT: feat(RHINENG-2085): Detect when user has not access to all hosts

### DIFF
--- a/src/PresentationalComponents/PoliciesTable/Columns.js
+++ b/src/PresentationalComponents/PoliciesTable/Columns.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import propTypes from 'prop-types';
-import { TextContent } from '@patternfly/react-core';
+import { TextContent, Tooltip } from '@patternfly/react-core';
 import { fitContent } from '@patternfly/react-table';
 import { LinkWithPermission as Link } from 'PresentationalComponents';
 import { GreySmallText, SystemsCountWarning } from 'PresentationalComponents';
 import { renderComponent } from 'Utilities/helpers';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 const PolicyNameCell = ({ id, policy, policyType }) => (
   <TextContent>
@@ -48,7 +49,21 @@ export const OperatingSystem = {
 };
 
 export const Systems = {
-  title: 'Systems',
+  title: (
+    <Tooltip
+      position="top"
+      content={
+        <Fragment>
+          This count only reflects the systems you have permission to access.
+        </Fragment>
+      }
+    >
+      <span className="pf-c-table__text">
+        Systems &nbsp;
+        <OutlinedQuestionCircleIcon className="grey-icon" />
+      </span>
+    </Tooltip>
+  ),
   props: {
     width: 15,
   },

--- a/src/PresentationalComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
+++ b/src/PresentationalComponents/PoliciesTable/__snapshots__/PoliciesTable.test.js.snap
@@ -938,7 +938,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "United States Government Standard",
         "refId": "xccdf_org.ssgproject.content_profile_ospp23",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1013,7 +1013,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
         "refId": "xccdf_org.ssgproject.content_profile_pci-dss3",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1039,7 +1039,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "United States Government Configuration Baseline2",
         "refId": "xccdf_org.ssgproject.content_profile_ospp2",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1065,7 +1065,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "C2S for Red Hat Enterprise Linux 7",
         "refId": "xccdf_org.ssgproject.content_profile_C2S",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1091,7 +1091,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "Criminal Justice Information Services (CJIS) Security Policy",
         "refId": "xccdf_org.ssgproject.content_profile_cjis",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1117,7 +1117,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
         "refId": "xccdf_org.ssgproject.content_profile_nist-800-171-cui",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1143,7 +1143,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1169,7 +1169,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
         "refId": "xccdf_org.ssgproject.content_profile_rht-ccp",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1195,7 +1195,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "Health Insurance Portability and Accountability Act (HIPAA)",
         "refId": "xccdf_org.ssgproject.content_profile_hipaa",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1221,7 +1221,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "United States Government Configuration Baseline",
         "refId": "xccdf_org.ssgproject.content_profile_ospp",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1247,7 +1247,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "Standard System Security Profile for Red Hat Enterprise Linux 7",
         "refId": "xccdf_org.ssgproject.content_profile_standard",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1273,7 +1273,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "DISA STIG for Red Hat Enterprise Linux 7",
         "refId": "xccdf_org.ssgproject.content_profile_stig-rhel7-disa",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -1299,7 +1299,7 @@ exports[`PoliciesTable expect to render without error 1`] = `
         "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72",
         "refId": "xccdf_org.ssgproject.content_profile_pci-dss2",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
     ]
   }

--- a/src/PresentationalComponents/ReportDetailsDescription/__snapshots__/ReportDetailsDescription.test.js.snap
+++ b/src/PresentationalComponents/ReportDetailsDescription/__snapshots__/ReportDetailsDescription.test.js.snap
@@ -123,7 +123,7 @@ exports[`ReportDetailsDescription expect to render without error 1`] = `
         "policyType": "United States Government Standard",
         "refId": "xccdf_org.ssgproject.content_profile_ospp23",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       }
     }
   />

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/Filters.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/Filters.test.js.snap
@@ -119,7 +119,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "United States Government Standard",
     "refId": "xccdf_org.ssgproject.content_profile_ospp23",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -194,7 +194,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
     "refId": "xccdf_org.ssgproject.content_profile_pci-dss3",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -220,7 +220,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "United States Government Configuration Baseline2",
     "refId": "xccdf_org.ssgproject.content_profile_ospp2",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -246,7 +246,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "C2S for Red Hat Enterprise Linux 7",
     "refId": "xccdf_org.ssgproject.content_profile_C2S",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -272,7 +272,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "Criminal Justice Information Services (CJIS) Security Policy",
     "refId": "xccdf_org.ssgproject.content_profile_cjis",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -298,7 +298,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
     "refId": "xccdf_org.ssgproject.content_profile_nist-800-171-cui",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -324,7 +324,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
     "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -350,7 +350,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
     "refId": "xccdf_org.ssgproject.content_profile_rht-ccp",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -376,7 +376,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "Health Insurance Portability and Accountability Act (HIPAA)",
     "refId": "xccdf_org.ssgproject.content_profile_hipaa",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -402,7 +402,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "United States Government Configuration Baseline",
     "refId": "xccdf_org.ssgproject.content_profile_ospp",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -428,7 +428,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "Standard System Security Profile for Red Hat Enterprise Linux 7",
     "refId": "xccdf_org.ssgproject.content_profile_standard",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -454,7 +454,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "DISA STIG for Red Hat Enterprise Linux 7",
     "refId": "xccdf_org.ssgproject.content_profile_stig-rhel7-disa",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
   {
     "__typename": "Profile",
@@ -480,7 +480,7 @@ exports[`operatingSystemFilter expect to return results 1`] = `
     "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72",
     "refId": "xccdf_org.ssgproject.content_profile_pci-dss2",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
 ]
 `;
@@ -513,7 +513,7 @@ exports[`policyNameFilter expect to return results 1`] = `
     "policyType": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
     "refId": "xccdf_org.ssgproject.content_profile_nist-800-171-cui",
     "testResultHostCount": 8,
-    "totalHostCount": 10,
+    "totalHostCount": 1,
   },
 ]
 `;

--- a/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
+++ b/src/PresentationalComponents/ReportsTable/__snapshots__/ReportsTable.test.js.snap
@@ -270,7 +270,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "United States Government Standard",
         "refId": "xccdf_org.ssgproject.content_profile_ospp23",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -345,7 +345,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
         "refId": "xccdf_org.ssgproject.content_profile_pci-dss3",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -371,7 +371,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "United States Government Configuration Baseline2",
         "refId": "xccdf_org.ssgproject.content_profile_ospp2",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -397,7 +397,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "C2S for Red Hat Enterprise Linux 7",
         "refId": "xccdf_org.ssgproject.content_profile_C2S",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -423,7 +423,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "Criminal Justice Information Services (CJIS) Security Policy",
         "refId": "xccdf_org.ssgproject.content_profile_cjis",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -449,7 +449,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
         "refId": "xccdf_org.ssgproject.content_profile_nist-800-171-cui",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -475,7 +475,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -501,7 +501,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
         "refId": "xccdf_org.ssgproject.content_profile_rht-ccp",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -527,7 +527,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "Health Insurance Portability and Accountability Act (HIPAA)",
         "refId": "xccdf_org.ssgproject.content_profile_hipaa",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -553,7 +553,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "United States Government Configuration Baseline",
         "refId": "xccdf_org.ssgproject.content_profile_ospp",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -579,7 +579,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "Standard System Security Profile for Red Hat Enterprise Linux 7",
         "refId": "xccdf_org.ssgproject.content_profile_standard",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -605,7 +605,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "DISA STIG for Red Hat Enterprise Linux 7",
         "refId": "xccdf_org.ssgproject.content_profile_stig-rhel7-disa",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
       {
         "__typename": "Profile",
@@ -631,7 +631,7 @@ exports[`ReportsTable expect to render without error 1`] = `
         "policyType": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 72",
         "refId": "xccdf_org.ssgproject.content_profile_pci-dss2",
         "testResultHostCount": 8,
-        "totalHostCount": 10,
+        "totalHostCount": 1,
       },
     ]
   }

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import gql from 'graphql-tag';
 import { useLocation } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
-import { Grid } from '@patternfly/react-core';
+import { Alert, Grid } from '@patternfly/react-core';
 import PageHeader, {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
@@ -75,6 +75,15 @@ export const CompliancePolicies = () => {
     <React.Fragment>
       <PageHeader className="page-header">
         <PageHeaderTitle title="SCAP policies" />
+        <Alert
+          isInline
+          variant="info"
+          ouiaId="SystemsListIsDifferentAlert"
+          title={
+            'These policies only reflect the systems you have permission to access.'
+          }
+          className="pf-u-mt-md"
+        />
       </PageHeader>
       <section className="pf-c-page__main-section">
         <StateView stateValues={{ error, data, loading }}>

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TextContent } from '@patternfly/react-core';
+import { Alert, Text, TextContent } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import { SystemsTable } from 'SmartComponents';
 import * as Columns from '../SystemsTable/Columns';
@@ -24,7 +24,15 @@ EmptyState.propTypes = {
 
 const PrependComponent = ({ osMajorVersion }) => (
   <React.Fragment>
-    <TextContent className="pf-u-mb-md">
+    <Alert
+      isInline
+      variant="info"
+      ouiaId="SystemsListIsDifferentAlert"
+      title={
+        'These policy details only reflect the systems you have permission to access.'
+      }
+    />
+    <TextContent className="pf-u-mb-md pf-u-mt-md">
       <Text>
         Select which of your <b>RHEL {osMajorVersion}</b> systems should be
         included in this policy.

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -2,6 +2,7 @@ import React, { Fragment, useEffect } from 'react';
 import propTypes from 'prop-types';
 import { useParams, useLocation } from 'react-router-dom';
 import {
+  Alert,
   Breadcrumb,
   BreadcrumbItem,
   Grid,
@@ -76,9 +77,19 @@ export const PolicyDetails = ({ route }) => {
                 </BreadcrumbLinkItem>
                 <BreadcrumbItem isActive>{policy.name}</BreadcrumbItem>
               </Breadcrumb>
-              <Grid gutter="lg">
+              <Grid gutter="lg" hasGutter>
                 <GridItem xl2={11} xl={10} lg={12} md={12} sm={12}>
                   <PageHeaderTitle title={policy.name} />
+                </GridItem>
+                <GridItem>
+                  <Alert
+                    isInline
+                    variant="info"
+                    ouiaId="SystemsListIsDifferentAlert"
+                    title={
+                      'These policy details only reflect the systems you have permission to access.'
+                    }
+                  />
                 </GridItem>
               </Grid>
               <RoutedTabs

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -5,29 +5,42 @@ import { NoSystemsTableWithWarning } from 'PresentationalComponents';
 import { SystemsTable } from 'SmartComponents';
 import * as Columns from '../SystemsTable/Columns';
 import EditSystemsButtonToolbarItem from './EditSystemsButtonToolbarItem';
+import { Alert } from '@patternfly/react-core';
 
 const PolicySystemsTab = ({ policy }) => {
+  const hasDifferentSystemCount =
+    policy?.totalHostCount !== policy?.hosts.length;
   return (
-    <SystemsTable
-      columns={[
-        Columns.customName({
-          showLink: true,
-        }),
-        Columns.inventoryColumn('tags'),
-        Columns.OS,
-        Columns.SsgVersion,
-      ]}
-      showOsMinorVersionFilter={[policy.osMajorVersion]}
-      policyId={policy.id}
-      defaultFilter={`policy_id = ${policy.id}`}
-      showActions={false}
-      remediationsEnabled={false}
-      noSystemsTable={
-        policy?.hosts?.length === 0 && <NoSystemsTableWithWarning />
-      }
-      complianceThreshold={policy.complianceThreshold}
-      dedicatedAction={<EditSystemsButtonToolbarItem policy={policy} />}
-    />
+    <>
+      {hasDifferentSystemCount && (
+        <Alert
+          isInline
+          variant="info"
+          ouiaId="SystemsListIsDifferentAlert"
+          title={'System count is different'}
+        />
+      )}
+      <SystemsTable
+        columns={[
+          Columns.customName({
+            showLink: true,
+          }),
+          Columns.inventoryColumn('tags'),
+          Columns.OS,
+          Columns.SsgVersion,
+        ]}
+        showOsMinorVersionFilter={[policy.osMajorVersion]}
+        policyId={policy.id}
+        defaultFilter={`policy_id = ${policy.id}`}
+        showActions={false}
+        remediationsEnabled={false}
+        noSystemsTable={
+          policy?.hosts?.length === 0 && <NoSystemsTableWithWarning />
+        }
+        complianceThreshold={policy.complianceThreshold}
+        dedicatedAction={<EditSystemsButtonToolbarItem policy={policy} />}
+      />
+    </>
   );
 };
 
@@ -37,6 +50,7 @@ PolicySystemsTab.propTypes = {
     complianceThreshold: propTypes.number.isRequired,
     osMajorVersion: propTypes.string.isRequired,
     hosts: propTypes.array.isRequired,
+    totalHostCount: propTypes.number.isRequired,
   }),
   dedicatedAction: propTypes.object,
   systemTableProps: propTypes.object,

--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.test.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.test.js
@@ -23,7 +23,19 @@ describe('PolicySystemsTab', () => {
   it('expect to render with no systems table', () => {
     const policy = {
       ...policies.edges[0].node,
+      totalHostCount: 0,
       hosts: [],
+    };
+
+    const wrapper = shallow(<PolicySystemsTab {...{ policy }} />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('expect to render with differentHostCount info', () => {
+    const policy = {
+      ...policies.edges[0].node,
+      totalHostCount: policies.edges[0].node.totalHostCount + 1,
     };
 
     const wrapper = shallow(<PolicySystemsTab {...{ policy }} />);

--- a/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
+++ b/src/SmartComponents/PolicyDetails/__snapshots__/PolicySystemsTab.test.js.snap
@@ -1,416 +1,638 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PolicySystemsTab expect to render with no systems table 1`] = `
-<SystemsTable
-  columns={
-    [
-      {
-        "key": "name",
-        "props": {
-          "showLink": true,
-          "width": 40,
-        },
-        "renderExport": [Function],
-        "renderFunc": [Function],
-        "sortBy": [
-          "name",
-        ],
-        "title": "Name",
-      },
-      {
-        "key": "tags",
-      },
-      {
-        "dataLabel": "OS",
-        "key": "operatingSystem",
-        "original": "Operating System",
-        "props": {
-          "width": 10,
-        },
-        "renderExport": [Function],
-        "renderFunc": [Function],
-        "sortBy": [
-          "osMajorVersion",
-          "osMinorVersion",
-        ],
-        "title": <Tooltip
-          content={
-            <span>
-              Operating System
-            </span>
-          }
-        >
-          <span>
-            OS
-          </span>
-        </Tooltip>,
-        "transforms": [
-          [Function],
-        ],
-      },
-      {
-        "exportKey": "testResultProfiles",
-        "key": "ssg_version",
-        "renderExport": [Function],
-        "renderFunc": [Function],
-        "sortBy": [
-          "ssg_version",
-        ],
-        "title": "SSG version",
-        "transforms": [
-          [Function],
-        ],
-      },
-    ]
-  }
-  compact={false}
-  complianceThreshold={100}
-  compliantFilter={false}
-  dedicatedAction={
-    <EditSystemsButtonToolbarItem
-      policy={
+exports[`PolicySystemsTab expect to render with differentHostCount info 1`] = `
+<Fragment>
+  <Alert
+    isInline={true}
+    ouiaId="SystemsListIsDifferentAlert"
+    title="System count is different"
+    variant="info"
+  />
+  <SystemsTable
+    columns={
+      [
         {
-          "__typename": "Profile",
-          "benchmark": {
-            "title": "Guide to the Secure Configuration of RHEL 7",
-            "version": "0.1.49",
+          "key": "name",
+          "props": {
+            "showLink": true,
+            "width": 40,
           },
-          "businessObjective": null,
-          "complianceThreshold": 100,
-          "compliantHostCount": 4,
-          "hosts": [],
-          "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
-          "name": "United States Government Configuration Baseline23",
-          "osMajorVersion": "7",
-          "policy": {
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "name",
+          ],
+          "title": "Name",
+        },
+        {
+          "key": "tags",
+        },
+        {
+          "dataLabel": "OS",
+          "key": "operatingSystem",
+          "original": "Operating System",
+          "props": {
+            "width": 10,
+          },
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "osMajorVersion",
+            "osMinorVersion",
+          ],
+          "title": <Tooltip
+            content={
+              <span>
+                Operating System
+              </span>
+            }
+          >
+            <span>
+              OS
+            </span>
+          </Tooltip>,
+          "transforms": [
+            [Function],
+          ],
+        },
+        {
+          "exportKey": "testResultProfiles",
+          "key": "ssg_version",
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "ssg_version",
+          ],
+          "title": "SSG version",
+          "transforms": [
+            [Function],
+          ],
+        },
+      ]
+    }
+    compact={false}
+    complianceThreshold={100}
+    compliantFilter={false}
+    dedicatedAction={
+      <EditSystemsButtonToolbarItem
+        policy={
+          {
             "__typename": "Profile",
-            "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
-            "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
-            "profiles": [
+            "benchmark": {
+              "title": "Guide to the Secure Configuration of RHEL 7",
+              "version": "0.1.49",
+            },
+            "businessObjective": null,
+            "complianceThreshold": 100,
+            "compliantHostCount": 4,
+            "hosts": [
               {
-                "benchmark": {
-                  "version": "0.1.49",
-                },
-                "id": "b71376fd-015e-4209-99af",
-                "name": "United States Government Configuration Baseline123",
-                "osMajorVersion": "7",
-                "osMinorVersion": "9",
-                "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                "rules": [
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter the localtime File",
-                  },
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter Time Through clock_settime",
-                  },
-                ],
-              },
-              {
-                "benchmark": {
-                  "version": "0.1.45",
-                },
-                "id": "b71376fd-015e-4209-99ac",
-                "name": "United States Government Configuration Baseline123",
-                "osMajorVersion": "7",
-                "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                "rules": [
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter the localtime File",
-                  },
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter Time Through clock_settime",
-                  },
-                ],
-              },
-              {
-                "benchmark": {
-                  "version": "0.1.46",
-                },
-                "id": "b71376fd-015e-4209-99ad",
-                "name": "United States Government Configuration Baseline123",
-                "osMajorVersion": "7",
-                "osMinorVersion": "8",
-                "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                "rules": [
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter the localtime File",
-                  },
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter Time Through clock_settime",
-                  },
-                ],
+                "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                "osMinorVersion": 7,
               },
             ],
-          },
-          "policyType": "United States Government Standard",
-          "refId": "xccdf_org.ssgproject.content_profile_ospp23",
-          "testResultHostCount": 8,
-          "totalHostCount": 10,
+            "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
+            "name": "United States Government Configuration Baseline23",
+            "osMajorVersion": "7",
+            "policy": {
+              "__typename": "Profile",
+              "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+              "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+              "profiles": [
+                {
+                  "benchmark": {
+                    "version": "0.1.49",
+                  },
+                  "id": "b71376fd-015e-4209-99af",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "osMinorVersion": "9",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+                {
+                  "benchmark": {
+                    "version": "0.1.45",
+                  },
+                  "id": "b71376fd-015e-4209-99ac",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+                {
+                  "benchmark": {
+                    "version": "0.1.46",
+                  },
+                  "id": "b71376fd-015e-4209-99ad",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "osMinorVersion": "8",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+              ],
+            },
+            "policyType": "United States Government Standard",
+            "refId": "xccdf_org.ssgproject.content_profile_ospp23",
+            "testResultHostCount": 8,
+            "totalHostCount": 2,
+          }
         }
-      }
-    />
-  }
-  defaultFilter="policy_id = b71376fd-015e-4209-99af-4543e82e5dc5"
-  enableExport={true}
-  noSystemsTable={<NoSystemsTableWithWarning />}
-  policyId="b71376fd-015e-4209-99af-4543e82e5dc5"
-  preselectedSystems={[]}
-  remediationsEnabled={false}
-  ruleSeverityFilter={false}
-  showActions={false}
-  showComplianceSystemsInfo={false}
-  showGroupsFilter={false}
-  showOnlySystemsWithTestResults={false}
-  showOsMinorVersionFilter={
-    [
-      "7",
-    ]
-  }
-/>
+      />
+    }
+    defaultFilter="policy_id = b71376fd-015e-4209-99af-4543e82e5dc5"
+    enableExport={true}
+    noSystemsTable={false}
+    policyId="b71376fd-015e-4209-99af-4543e82e5dc5"
+    preselectedSystems={[]}
+    remediationsEnabled={false}
+    ruleSeverityFilter={false}
+    showActions={false}
+    showComplianceSystemsInfo={false}
+    showGroupsFilter={false}
+    showOnlySystemsWithTestResults={false}
+    showOsMinorVersionFilter={
+      [
+        "7",
+      ]
+    }
+  />
+</Fragment>
+`;
+
+exports[`PolicySystemsTab expect to render with no systems table 1`] = `
+<Fragment>
+  <SystemsTable
+    columns={
+      [
+        {
+          "key": "name",
+          "props": {
+            "showLink": true,
+            "width": 40,
+          },
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "name",
+          ],
+          "title": "Name",
+        },
+        {
+          "key": "tags",
+        },
+        {
+          "dataLabel": "OS",
+          "key": "operatingSystem",
+          "original": "Operating System",
+          "props": {
+            "width": 10,
+          },
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "osMajorVersion",
+            "osMinorVersion",
+          ],
+          "title": <Tooltip
+            content={
+              <span>
+                Operating System
+              </span>
+            }
+          >
+            <span>
+              OS
+            </span>
+          </Tooltip>,
+          "transforms": [
+            [Function],
+          ],
+        },
+        {
+          "exportKey": "testResultProfiles",
+          "key": "ssg_version",
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "ssg_version",
+          ],
+          "title": "SSG version",
+          "transforms": [
+            [Function],
+          ],
+        },
+      ]
+    }
+    compact={false}
+    complianceThreshold={100}
+    compliantFilter={false}
+    dedicatedAction={
+      <EditSystemsButtonToolbarItem
+        policy={
+          {
+            "__typename": "Profile",
+            "benchmark": {
+              "title": "Guide to the Secure Configuration of RHEL 7",
+              "version": "0.1.49",
+            },
+            "businessObjective": null,
+            "complianceThreshold": 100,
+            "compliantHostCount": 4,
+            "hosts": [],
+            "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
+            "name": "United States Government Configuration Baseline23",
+            "osMajorVersion": "7",
+            "policy": {
+              "__typename": "Profile",
+              "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+              "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+              "profiles": [
+                {
+                  "benchmark": {
+                    "version": "0.1.49",
+                  },
+                  "id": "b71376fd-015e-4209-99af",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "osMinorVersion": "9",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+                {
+                  "benchmark": {
+                    "version": "0.1.45",
+                  },
+                  "id": "b71376fd-015e-4209-99ac",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+                {
+                  "benchmark": {
+                    "version": "0.1.46",
+                  },
+                  "id": "b71376fd-015e-4209-99ad",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "osMinorVersion": "8",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+              ],
+            },
+            "policyType": "United States Government Standard",
+            "refId": "xccdf_org.ssgproject.content_profile_ospp23",
+            "testResultHostCount": 8,
+            "totalHostCount": 0,
+          }
+        }
+      />
+    }
+    defaultFilter="policy_id = b71376fd-015e-4209-99af-4543e82e5dc5"
+    enableExport={true}
+    noSystemsTable={<NoSystemsTableWithWarning />}
+    policyId="b71376fd-015e-4209-99af-4543e82e5dc5"
+    preselectedSystems={[]}
+    remediationsEnabled={false}
+    ruleSeverityFilter={false}
+    showActions={false}
+    showComplianceSystemsInfo={false}
+    showGroupsFilter={false}
+    showOnlySystemsWithTestResults={false}
+    showOsMinorVersionFilter={
+      [
+        "7",
+      ]
+    }
+  />
+</Fragment>
 `;
 
 exports[`PolicySystemsTab expect to render without error 1`] = `
-<SystemsTable
-  columns={
-    [
-      {
-        "key": "name",
-        "props": {
-          "showLink": true,
-          "width": 40,
-        },
-        "renderExport": [Function],
-        "renderFunc": [Function],
-        "sortBy": [
-          "name",
-        ],
-        "title": "Name",
-      },
-      {
-        "key": "tags",
-      },
-      {
-        "dataLabel": "OS",
-        "key": "operatingSystem",
-        "original": "Operating System",
-        "props": {
-          "width": 10,
-        },
-        "renderExport": [Function],
-        "renderFunc": [Function],
-        "sortBy": [
-          "osMajorVersion",
-          "osMinorVersion",
-        ],
-        "title": <Tooltip
-          content={
-            <span>
-              Operating System
-            </span>
-          }
-        >
-          <span>
-            OS
-          </span>
-        </Tooltip>,
-        "transforms": [
-          [Function],
-        ],
-      },
-      {
-        "exportKey": "testResultProfiles",
-        "key": "ssg_version",
-        "renderExport": [Function],
-        "renderFunc": [Function],
-        "sortBy": [
-          "ssg_version",
-        ],
-        "title": "SSG version",
-        "transforms": [
-          [Function],
-        ],
-      },
-    ]
-  }
-  compact={false}
-  complianceThreshold={100}
-  compliantFilter={false}
-  dedicatedAction={
-    <EditSystemsButtonToolbarItem
-      policy={
+<Fragment>
+  <SystemsTable
+    columns={
+      [
         {
-          "__typename": "Profile",
-          "benchmark": {
-            "title": "Guide to the Secure Configuration of RHEL 7",
-            "version": "0.1.49",
+          "key": "name",
+          "props": {
+            "showLink": true,
+            "width": 40,
           },
-          "businessObjective": null,
-          "complianceThreshold": 100,
-          "compliantHostCount": 4,
-          "hosts": [
-            {
-              "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
-              "osMinorVersion": 7,
-            },
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "name",
           ],
-          "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
-          "name": "United States Government Configuration Baseline23",
-          "osMajorVersion": "7",
-          "policy": {
+          "title": "Name",
+        },
+        {
+          "key": "tags",
+        },
+        {
+          "dataLabel": "OS",
+          "key": "operatingSystem",
+          "original": "Operating System",
+          "props": {
+            "width": 10,
+          },
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "osMajorVersion",
+            "osMinorVersion",
+          ],
+          "title": <Tooltip
+            content={
+              <span>
+                Operating System
+              </span>
+            }
+          >
+            <span>
+              OS
+            </span>
+          </Tooltip>,
+          "transforms": [
+            [Function],
+          ],
+        },
+        {
+          "exportKey": "testResultProfiles",
+          "key": "ssg_version",
+          "renderExport": [Function],
+          "renderFunc": [Function],
+          "sortBy": [
+            "ssg_version",
+          ],
+          "title": "SSG version",
+          "transforms": [
+            [Function],
+          ],
+        },
+      ]
+    }
+    compact={false}
+    complianceThreshold={100}
+    compliantFilter={false}
+    dedicatedAction={
+      <EditSystemsButtonToolbarItem
+        policy={
+          {
             "__typename": "Profile",
-            "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
-            "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
-            "profiles": [
+            "benchmark": {
+              "title": "Guide to the Secure Configuration of RHEL 7",
+              "version": "0.1.49",
+            },
+            "businessObjective": null,
+            "complianceThreshold": 100,
+            "compliantHostCount": 4,
+            "hosts": [
               {
-                "benchmark": {
-                  "version": "0.1.49",
-                },
-                "id": "b71376fd-015e-4209-99af",
-                "name": "United States Government Configuration Baseline123",
-                "osMajorVersion": "7",
-                "osMinorVersion": "9",
-                "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                "rules": [
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter the localtime File",
-                  },
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter Time Through clock_settime",
-                  },
-                ],
-              },
-              {
-                "benchmark": {
-                  "version": "0.1.45",
-                },
-                "id": "b71376fd-015e-4209-99ac",
-                "name": "United States Government Configuration Baseline123",
-                "osMajorVersion": "7",
-                "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                "rules": [
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter the localtime File",
-                  },
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter Time Through clock_settime",
-                  },
-                ],
-              },
-              {
-                "benchmark": {
-                  "version": "0.1.46",
-                },
-                "id": "b71376fd-015e-4209-99ad",
-                "name": "United States Government Configuration Baseline123",
-                "osMajorVersion": "7",
-                "osMinorVersion": "8",
-                "refId": "xccdf_org.ssgproject.content_profile_ospp123",
-                "rules": [
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter the localtime File",
-                  },
-                  {
-                    "__typename": "Rule",
-                    "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
-                    "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
-                    "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
-                    "remediationAvailable": false,
-                    "severity": "medium",
-                    "title": "Record Attempts to Alter Time Through clock_settime",
-                  },
-                ],
+                "id": "f7d15113-1ac8-4aee-b367-e1777e60979d",
+                "osMinorVersion": 7,
               },
             ],
-          },
-          "policyType": "United States Government Standard",
-          "refId": "xccdf_org.ssgproject.content_profile_ospp23",
-          "testResultHostCount": 8,
-          "totalHostCount": 10,
+            "id": "b71376fd-015e-4209-99af-4543e82e5dc5",
+            "name": "United States Government Configuration Baseline23",
+            "osMajorVersion": "7",
+            "policy": {
+              "__typename": "Profile",
+              "id": "b71376fd-015e-4209-99af-4543e82e5dc5-policy",
+              "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73",
+              "profiles": [
+                {
+                  "benchmark": {
+                    "version": "0.1.49",
+                  },
+                  "id": "b71376fd-015e-4209-99af",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "osMinorVersion": "9",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+                {
+                  "benchmark": {
+                    "version": "0.1.45",
+                  },
+                  "id": "b71376fd-015e-4209-99ac",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+                {
+                  "benchmark": {
+                    "version": "0.1.46",
+                  },
+                  "id": "b71376fd-015e-4209-99ad",
+                  "name": "United States Government Configuration Baseline123",
+                  "osMajorVersion": "7",
+                  "osMinorVersion": "8",
+                  "refId": "xccdf_org.ssgproject.content_profile_ospp123",
+                  "rules": [
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -w /etc/localtime -p wa -k audit_time_rules If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -w /etc/localtime -p wa -k audit_time_rules The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport and should always be used.",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_watch_localtime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter the localtime File",
+                    },
+                    {
+                      "__typename": "Rule",
+                      "description": "If the auditd daemon is configured to use the augenrules program to read audit rules during daemon startup (the default), add the following line to a file with suffix .rules in the directory /etc/audit/rules.d: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change If the auditd daemon is configured to use the auditctl utility to read audit rules during daemon startup, add the following line to /etc/audit/audit.rules file: -a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -F key=time-change If the system is 64 bit then also add the following line: -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -F key=time-change The -k option allows for the specification of a key in string form that can be used for better reporting capability through ausearch and aureport. Multiple system calls can be defined on the same line to save space if desired, but is not required. See an example of multiple combined syscalls: -a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules",
+                      "rationale": "Arbitrary changes to the system time can be used to obfuscate nefarious activities in log files, as well as to confuse network services that are highly dependent upon an accurate system time (such as sshd). All changes to the system time should be audited.",
+                      "refId": "xccdf_org.ssgproject.content_rule_audit_rules_time_clock_settime",
+                      "remediationAvailable": false,
+                      "severity": "medium",
+                      "title": "Record Attempts to Alter Time Through clock_settime",
+                    },
+                  ],
+                },
+              ],
+            },
+            "policyType": "United States Government Standard",
+            "refId": "xccdf_org.ssgproject.content_profile_ospp23",
+            "testResultHostCount": 8,
+            "totalHostCount": 1,
+          }
         }
-      }
-    />
-  }
-  defaultFilter="policy_id = b71376fd-015e-4209-99af-4543e82e5dc5"
-  enableExport={true}
-  noSystemsTable={false}
-  policyId="b71376fd-015e-4209-99af-4543e82e5dc5"
-  preselectedSystems={[]}
-  remediationsEnabled={false}
-  ruleSeverityFilter={false}
-  showActions={false}
-  showComplianceSystemsInfo={false}
-  showGroupsFilter={false}
-  showOnlySystemsWithTestResults={false}
-  showOsMinorVersionFilter={
-    [
-      "7",
-    ]
-  }
-/>
+      />
+    }
+    defaultFilter="policy_id = b71376fd-015e-4209-99af-4543e82e5dc5"
+    enableExport={true}
+    noSystemsTable={false}
+    policyId="b71376fd-015e-4209-99af-4543e82e5dc5"
+    preselectedSystems={[]}
+    remediationsEnabled={false}
+    ruleSeverityFilter={false}
+    showActions={false}
+    showComplianceSystemsInfo={false}
+    showGroupsFilter={false}
+    showOnlySystemsWithTestResults={false}
+    showOsMinorVersionFilter={
+      [
+        "7",
+      ]
+    }
+  />
+</Fragment>
 `;

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -78,6 +78,8 @@ export const Reports = () => {
     showView = profiles && profiles.length > 0;
   }
 
+  console.log("DATA", data)
+
   return (
     <>
       <ReportsHeader />

--- a/src/__fixtures__/policies.js
+++ b/src/__fixtures__/policies.js
@@ -8,7 +8,7 @@ export const policies = {
                 policyType: 'United States Government Standard',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 compliantHostCount: 4,
                 osMajorVersion: '7',
@@ -121,7 +121,7 @@ export const policies = {
                 policyType: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 73',
                 complianceThreshold: 67,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 policy: {
@@ -194,7 +194,7 @@ export const policies = {
                 policyType: 'United States Government Configuration Baseline2',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -220,7 +220,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_C2S',
                 complianceThreshold: 69.5,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -246,7 +246,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_cjis',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -272,7 +272,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_nist-800-171-cui',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -298,7 +298,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -324,7 +324,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_rht-ccp',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -349,7 +349,7 @@ export const policies = {
                 policyType: 'Health Insurance Portability and Accountability Act (HIPAA)',
                 refId: 'xccdf_org.ssgproject.content_profile_hipaa',
                 complianceThreshold: 100,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 businessObjective: null,
                 osMajorVersion: '7',
@@ -376,7 +376,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_ospp',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -402,7 +402,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_standard',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -428,7 +428,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_stig-rhel7-disa',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [
@@ -454,7 +454,7 @@ export const policies = {
                 refId: 'xccdf_org.ssgproject.content_profile_pci-dss2',
                 complianceThreshold: 100,
                 businessObjective: null,
-                totalHostCount: 10,
+                totalHostCount: 1,
                 testResultHostCount: 8,
                 osMajorVersion: '7',
                 hosts: [


### PR DESCRIPTION
Detects when a user has not access to all systems in a policy, because of Inventory groups.

How to test:
1. Use an account that has two users
2. Create a Inventory group and some systems in it
3. In Compliance create a SCAP Policy that has systems from the group and also outside of the group
4. First User
4.1. has permissions for all systems
4.2. In Compliance --> SCAP Policies system count matches system count in the SCAP Policy detail page --> Systems tab
4.3. No alert above the SystemTable in 
5. Second User
5.1. has group:read and host:read only for the group
5.2. In Compliance --> SCAP Policies system count is different from the system count in the SCAP Policy detail page --> Systems tab
5.3. Alert above the SystemTable

### Temporary UI
| First user               | Second user               |
| ---------------------- | ---------------------- |
| ![image](https://github.com/RedHatInsights/compliance-frontend/assets/20592948/54a39bd7-0894-44cf-9049-fa4ee7a20d90) | ![image](https://github.com/RedHatInsights/compliance-frontend/assets/20592948/e51636a4-ea17-4123-b52c-4138425965c4)|

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
