### PR TITLE
fix(ESSNTL-3718): Wrap group names in brackets

### DIFF
--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -177,7 +177,7 @@ const buildApiFilters = (filters = {}) => {
   // filtering by group_name is enabled in gq filter
   if (hostGroupFilter !== undefined && Array.isArray(hostGroupFilter)) {
     otherFilters.filter = `(${hostGroupFilter
-      .map((value) => `group_name = ${value}`)
+      .map((value) => `group_name = "${value}"`)
       .join(' or ')})`;
   }
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-3718.

Fixes improper group_name filter construction in gq filter.

## How to test

Have a group which name has spaces (like "Test group"). Add some compliance systems to it, and make sure you are able to filter by this group on /compliance/systems.