### PR TITLE
fix(RHICOMPL-3936): Disable inline policy editing for Compliance viewer

### DIFF
--- a/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
+++ b/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
@@ -16,6 +16,7 @@ import Truncate from '@redhat-cloud-services/frontend-components/Truncate';
 // import Prompt from '@redhat-cloud-services/frontend-components/Prompt';
 import { useOnSave as useOnSavePolicyDetails } from '../EditPolicy/hooks';
 import { thresholdValid } from '../CreatePolicy/validate';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 
 const EditPolicyDetailsInline = ({
   text,
@@ -34,6 +35,14 @@ const EditPolicyDetailsInline = ({
   const copiedData = policy;
   // TODO Re-enable when there is a alternative to Prompt
   // const [dirty, setDirty] = useState(false);
+
+  const { hasAccess, isLoading } = usePermissionsWithContext(
+    ['compliance:policy:write'],
+    false,
+    false
+  );
+
+  const hasPermission = !isLoading && hasAccess;
 
   const [value, setValue] = useState(text);
   const [validThreshold, setValidThreshold] = useState(true);
@@ -84,13 +93,15 @@ const EditPolicyDetailsInline = ({
     <FormGroup className="pf-c-inline-edit pf-m-inline-editable">
       <Text component={TextVariants.h5}>
         {label}
-        <Button
-          onClick={handleToggle}
-          variant="plain"
-          style={{ 'margin-left': '5px' }}
-        >
-          <i className="fas fa-pencil-alt" aria-hidden="true" />
-        </Button>
+        {hasPermission && (
+          <Button
+            onClick={handleToggle}
+            variant="plain"
+            style={{ 'margin-left': '5px' }}
+          >
+            <i className="fas fa-pencil-alt" aria-hidden="true" />
+          </Button>
+        )}
         {variant === 'threshold' ? (
           <PolicyThresholdTooltip />
         ) : variant === 'business' ? (


### PR DESCRIPTION
[RHICOMPL-3936](https://issues.redhat.com/browse/RHICOMPL-3936)

Previously there was no permission check for editing of the policy details
Now if you don't have `compliance:policy:write` you don't see the pen.


### Compliance viewer
| Before              | After               |
| ---------------------- | ---------------------- |
| ![image](https://github.com/RedHatInsights/compliance-frontend/assets/20592948/0b384098-0ad9-453e-8737-23d29029703d)|![image](https://github.com/RedHatInsights/compliance-frontend/assets/20592948/adb6c7f1-73b2-4c7e-99b1-209828ee4002)|


### How to test
Test with and without the `compliance:policy:write` permission

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
