### PR TITLE
fix(SystemsTable): RHINENG-2222 - Filter correctly when fetching selection

### DIFF
--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -90,10 +90,18 @@ export const useFetchSystems = ({
       requestVariables.filter !== undefined &&
       typeof requestVariables.filter === 'string'
     ) {
-      filter = [
+      variables.filter = [
         ...filter.split(' and '),
         ...requestVariables.filter.split(' and '),
       ].join(' and ');
+    }
+
+    if (requestVariables.exclusiveFilter) {
+      const { exclusiveFilter, requestVariablesRest } = requestVariables;
+      requestVariables = {
+        ...requestVariablesRest,
+        filter: exclusiveFilter,
+      };
     }
 
     return client
@@ -106,7 +114,6 @@ export const useFetchSystems = ({
           page,
           ...variables,
           ...requestVariables,
-          filter,
         },
       })
       .then(({ data }) => {
@@ -365,17 +372,19 @@ export const useSystemBulkSelect = ({
 
     const idFilter = toIdFilter(fetchIds);
     const results = await fetchBatched(fetchSystems, fetchIds.length, {
-      ...(idFilter && { filter: idFilter }),
+      ...(idFilter && { exclusiveFilter: idFilter }),
     });
 
     return results.flatMap((result) => result.entities);
   };
 
   const onSelectCallback = async (selectedIds) => {
-    await dispatch(setDisabledSelection(true));
+    dispatch(setDisabledSelection(true));
+
     const systems = await fetchFunc(selectedIds);
     setSelectedSystems(systems);
-    await dispatch(setDisabledSelection(false));
+
+    dispatch(setDisabledSelection(false));
     onSelect && onSelect(systems);
   };
 


### PR DESCRIPTION

This fixes an issue where the selection is lost due to passing improper filters when fetching systems.

**How to test:**

1. Open a SCAP policy with already assigned systems to edit
2. Open the "Systems" tab and search for a (specific) host.
3. Select the host (while the filter is active)
4. The host should have been added to the selection (including previously selected hosts)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
