### PR TITLE
fix(SystemsTable): RHINENG-2222 - Fix variable handling when fetching

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -14,7 +14,6 @@ import { ErrorPage, StateView, StateViewPart } from 'PresentationalComponents';
 import useFilterConfig from 'Utilities/hooks/useTableTools/useFilterConfig';
 import { policyFilter, defaultOnLoad, ssgVersionFilter } from './constants';
 import {
-  useFetchSystems,
   useGetEntities,
   useOsMinorVersionFilter,
   useInventoryUtilities,
@@ -22,6 +21,7 @@ import {
   useSystemsFilter,
   useSystemBulkSelect,
 } from './hooks';
+import useFetchSystems from './hooks/useFetchSystems';
 import { constructQuery } from '../../Utilities/helpers';
 import { COMPLIANCE_REPORT_TABLE_ADDITIONAL_FILTER } from '../../constants';
 

--- a/src/SmartComponents/SystemsTable/SystemsTable.test.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.test.js
@@ -7,11 +7,8 @@ import {
   DEFAULT_SYSTEMS_FILTER_CONFIGURATION,
   COMPLIANT_SYSTEMS_FILTER_CONFIGURATION,
 } from '@/constants';
-import {
-  useGetEntities,
-  useOsMinorVersionFilter,
-  useFetchSystems,
-} from './hooks';
+import { useGetEntities, useOsMinorVersionFilter } from './hooks';
+import useFetchSystems from './hooks/useFetchSystems';
 import { filterHelpers } from 'Utilities/hooks/useTableTools/testHelpers';
 expect.extend(filterHelpers);
 
@@ -32,9 +29,9 @@ jest.mock('react-redux', () => ({
 jest.mock('./hooks', () => ({
   ...jest.requireActual('./hooks'),
   useGetEntities: jest.fn(),
-  useFetchSystems: jest.fn(),
   useOsMinorVersionFilter: jest.fn(),
 }));
+jest.mock('./hooks/useFetchSystems');
 useFetchSystems.mockImplementation(useFetchSystemsMockBuilder());
 useGetEntities.mockImplementation(
   (fetchSystems) => async () => await fetchSystems()

--- a/src/SmartComponents/SystemsTable/__snapshots__/hooks.test.js.snap
+++ b/src/SmartComponents/SystemsTable/__snapshots__/hooks.test.js.snap
@@ -37,5 +37,3 @@ exports[`useSystemsExport returns a export with isDisabled true on total 0  2`] 
   "onSelect": [Function],
 }
 `;
-
-exports[`useSystemsFilter returns a filter string 1`] = `"(default = "filter") and (has_test_results = true and name = "Name")"`;

--- a/src/SmartComponents/SystemsTable/hooks.test.js
+++ b/src/SmartComponents/SystemsTable/hooks.test.js
@@ -14,7 +14,33 @@ describe('useSystemsFilter', () => {
     const { result } = renderHook(() =>
       useSystemsFilter('name = "Name"', true, 'default = "filter"')
     );
-    expect(result.current).toMatchSnapshot();
+    expect(result.current).toEqual(
+      '(default = "filter") and (has_test_results = true and name = "Name")'
+    );
+  });
+
+  it('returns a filter string without default filter', () => {
+    const { result } = renderHook(() =>
+      useSystemsFilter('name = "Name"', true)
+    );
+    expect(result.current).toEqual('has_test_results = true and name = "Name"');
+  });
+
+  it('returns a filter string without test result filter', () => {
+    const { result } = renderHook(() =>
+      useSystemsFilter('name = "Name"', false)
+    );
+    expect(result.current).toEqual('name = "Name"');
+  });
+
+  it('returns an empty string without any filter passed and results disabled', () => {
+    const { result } = renderHook(() => useSystemsFilter('', false));
+    expect(result.current).toEqual('');
+  });
+
+  it('returns only the result filter string with only the results filter enabled', () => {
+    const { result } = renderHook(() => useSystemsFilter('', true));
+    expect(result.current).toEqual('has_test_results = true');
   });
 });
 

--- a/src/SmartComponents/SystemsTable/hooks/useFetchSystems.js
+++ b/src/SmartComponents/SystemsTable/hooks/useFetchSystems.js
@@ -1,0 +1,94 @@
+import { useApolloClient } from '@apollo/client';
+import { systemsWithRuleObjectsFailed } from 'Utilities/ruleHelpers';
+
+const renameInventoryAttributes = ({
+  culledTimestamp,
+  staleWarningTimestamp,
+  staleTimestamp,
+  insightsId,
+  ...system
+}) => ({
+  ...system,
+  insights_id: insightsId,
+  culled_timestamp: culledTimestamp,
+  stale_warning_timestamp: staleWarningTimestamp,
+  stale_timestamp: staleTimestamp,
+});
+
+const combineVariables = (standardVariables, allRequestVariables) => {
+  const { exclusiveFilter, ...requestVariables } = allRequestVariables || {};
+
+  if (exclusiveFilter) {
+    return {
+      ...standardVariables,
+      ...requestVariables,
+      filter: exclusiveFilter,
+    };
+  }
+
+  if (!!requestVariables && typeof requestVariables?.filter === 'string') {
+    const combinedFilter = [
+      ...standardVariables.filter.split(' and '),
+      ...requestVariables.filter.split(' and '),
+    ].join(' and ');
+
+    return {
+      ...standardVariables,
+      ...requestVariables,
+      filter: combinedFilter,
+    };
+  }
+
+  if (standardVariables || requestVariables) {
+    return {
+      ...standardVariables,
+      ...requestVariables,
+    };
+  }
+};
+
+export const useFetchSystems = ({ query, onComplete, variables, onError }) => {
+  const client = useApolloClient();
+
+  return (perPage, page, requestVariables) => {
+    const combinedVariables = combineVariables(variables, requestVariables);
+
+    return client
+      .query({
+        query,
+        fetchResults: true,
+        fetchPolicy: 'no-cache',
+        variables: {
+          perPage,
+          page,
+          ...(combinedVariables ? combinedVariables : {}),
+        },
+      })
+      .then(({ data }) => {
+        const systems = data?.systems?.edges?.map((e) => e.node) || [];
+        const entities = systemsWithRuleObjectsFailed(systems).map(
+          renameInventoryAttributes
+        );
+        const result = {
+          entities,
+          meta: {
+            ...(requestVariables?.tags && { tags: requestVariables.tags }),
+            totalCount: data?.systems?.totalCount || 0,
+          },
+        };
+
+        onComplete && onComplete(result);
+        return result;
+      })
+      .catch((error) => {
+        if (onError) {
+          onError(error);
+          return { entities: [], meta: { totalCount: 0 } };
+        } else {
+          throw error;
+        }
+      });
+  };
+};
+
+export default useFetchSystems;

--- a/src/SmartComponents/SystemsTable/hooks/useFetchSystems.test.js
+++ b/src/SmartComponents/SystemsTable/hooks/useFetchSystems.test.js
@@ -1,0 +1,187 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useApolloClient } from '@apollo/client';
+import { GET_MINIMAL_SYSTEMS } from '../constants';
+import useFetchSystems from './useFetchSystems';
+
+jest.mock('@apollo/client');
+
+describe('useFetchSystems', () => {
+  const perPage = 10;
+  const page = 1;
+
+  const clientQueryMock = jest.fn(() => Promise.resolve({ data: {} }));
+  beforeEach(() => {
+    useApolloClient.mockImplementation(() => ({
+      query: clientQueryMock,
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries with defaults', () => {
+    const { result } = renderHook(() =>
+      useFetchSystems({
+        query: GET_MINIMAL_SYSTEMS,
+      })
+    );
+
+    result.current(perPage, page).then(() => {
+      expect(clientQueryMock).toHaveBeenCalledWith({
+        fetchPolicy: 'no-cache',
+        fetchResults: true,
+        query: GET_MINIMAL_SYSTEMS,
+        variables: {
+          page,
+          perPage,
+        },
+      });
+    });
+  });
+
+  it('queries with a variables and variables from the request call when passed', () => {
+    const variables = {
+      standardVariable: 'standardVarTest',
+    };
+    const additionalVariables = {
+      customVariable: 'testVar',
+    };
+
+    const { result } = renderHook(() =>
+      useFetchSystems({
+        query: GET_MINIMAL_SYSTEMS,
+        variables,
+      })
+    );
+
+    result.current(perPage, page, additionalVariables).then(() => {
+      expect(clientQueryMock).toHaveBeenCalledWith({
+        fetchPolicy: 'no-cache',
+        fetchResults: true,
+        query: GET_MINIMAL_SYSTEMS,
+        variables: {
+          ...variables,
+          ...additionalVariables,
+          page,
+          perPage,
+        },
+      });
+    });
+  });
+
+  it('queries with a request variables over standard variables', () => {
+    const variables = {
+      page: 1,
+      perPage: 10,
+    };
+    const additionalVariables = {
+      perPage: 20,
+      page: 4,
+    };
+
+    const { result } = renderHook(() =>
+      useFetchSystems({
+        query: GET_MINIMAL_SYSTEMS,
+        variables,
+      })
+    );
+
+    result.current(perPage, page, additionalVariables).then(() => {
+      expect(clientQueryMock).toHaveBeenCalledWith({
+        fetchPolicy: 'no-cache',
+        fetchResults: true,
+        query: GET_MINIMAL_SYSTEMS,
+        variables: {
+          ...additionalVariables,
+        },
+      });
+    });
+  });
+
+  describe('filters', () => {
+    const filter = 'id = ID';
+
+    it('queries with a filter from variables when passed', () => {
+      const { result } = renderHook(() =>
+        useFetchSystems({
+          query: GET_MINIMAL_SYSTEMS,
+          variables: {
+            filter,
+          },
+        })
+      );
+
+      result.current(perPage, page).then(() => {
+        expect(clientQueryMock).toHaveBeenCalledWith({
+          fetchPolicy: 'no-cache',
+          fetchResults: true,
+          query: GET_MINIMAL_SYSTEMS,
+          variables: {
+            filter,
+            page,
+            perPage,
+          },
+        });
+      });
+    });
+
+    it('queries with a filter combined from the standard variables and from variables when passed', () => {
+      const requestFilter = 'policy_id = POLICY_ID';
+
+      const { result } = renderHook(() =>
+        useFetchSystems({
+          query: GET_MINIMAL_SYSTEMS,
+          variables: {
+            filter,
+          },
+        })
+      );
+      result
+        .current(perPage, page, {
+          filter: requestFilter,
+        })
+        .then(() => {
+          expect(clientQueryMock).toHaveBeenCalledWith({
+            fetchPolicy: 'no-cache',
+            fetchResults: true,
+            query: GET_MINIMAL_SYSTEMS,
+            variables: {
+              filter: [filter, requestFilter].join(' and '),
+              page,
+              perPage,
+            },
+          });
+        });
+    });
+
+    it('queries with the exclusive filter only when passed', () => {
+      const requestFilter = 'policy_id = POLICY_ID';
+      const { result } = renderHook(() =>
+        useFetchSystems({
+          query: GET_MINIMAL_SYSTEMS,
+          variables: {
+            filter,
+          },
+        })
+      );
+
+      result
+        .current(perPage, page, {
+          exclusiveFilter: requestFilter,
+        })
+        .then(() => {
+          expect(clientQueryMock).toHaveBeenCalledWith({
+            fetchPolicy: 'no-cache',
+            fetchResults: true,
+            query: GET_MINIMAL_SYSTEMS,
+            variables: {
+              filter: requestFilter,
+              page,
+              perPage,
+            },
+          });
+        });
+    });
+  });
+});


### PR DESCRIPTION
This fixes the issues of the SystemsTable loosing the proper default filter when resetting filters, while still fixing the issue with selecting a system while filtering.

**How to test:**

1) Open the systems page note the number of all systems.
2) Filter systems
3) Reset the filter
4) Verify that the count of systems is the same again as initially noted.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
