### PR TITLE
feat(RHINENG-1840): Support sort by group column (#679)

### DIFF
--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -46,6 +46,7 @@ export const ComplianceSystems = () => {
                   }),
                   Columns.inventoryColumn('groups', {
                     requiresDefault: true,
+                    sortBy: ['groups'],
                   }),
                   Columns.inventoryColumn('tags'),
                   Columns.OS,

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -103,6 +103,7 @@ export const EditPolicySystems = ({
               },
               Columns.inventoryColumn('groups', {
                 requiresDefault: true,
+                sortBy: ['groups'],
               }),
               Columns.inventoryColumn('tags'),
               Columns.OperatingSystem,

--- a/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
+++ b/src/SmartComponents/CreatePolicy/__snapshots__/EditPolicySystems.test.js.snap
@@ -31,6 +31,9 @@ exports[`EditPolicySystems expect to render without error 1`] = `
             {
               "key": "groups",
               "requiresDefault": true,
+              "sortBy": [
+                "groups",
+              ],
             },
             {
               "key": "tags",

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -171,6 +171,7 @@ export const ReportDetails = ({ route }) => {
                   }),
                   Columns.inventoryColumn('groups', {
                     requiresDefault: true,
+                    sortBy: ['groups'],
                   }),
                   Columns.inventoryColumn('tags'),
                   Columns.SsgVersion,

--- a/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
+++ b/src/SmartComponents/ReportDetails/__snapshots__/ReportDetails.test.js.snap
@@ -345,6 +345,9 @@ exports[`ReportDetails expect to render without error 1`] = `
                 {
                   "key": "groups",
                   "requiresDefault": true,
+                  "sortBy": [
+                    "groups",
+                  ],
                 },
                 {
                   "key": "tags",
@@ -791,6 +794,9 @@ exports[`ReportDetails expect to render without error and ssg Version 1`] = `
                 {
                   "key": "groups",
                   "requiresDefault": true,
+                  "sortBy": [
+                    "groups",
+                  ],
                 },
                 {
                   "key": "tags",

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -115,8 +115,12 @@ export const useGetEntities = (fetchEntities, { selected, columns } = {}) => {
   const appendDirection = (attributes, direction) =>
     attributes.map((attribute) => `${attribute}:${direction}`);
 
-  const findColumnByKey = (key) =>
-    (columns || []).find((column) => column.key === key);
+  const findColumnByKey = (sortKey) =>
+    (columns || []).find(
+      (column) =>
+        column.key === sortKey || // group column has a sort key different to its main key
+        (column.key === 'groups' && sortKey === 'group_name')
+    );
 
   return async (
     _ids,


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-1840.

Recognise group column sort parameter (when available). This updates the systems table on the following views:
- /systems
- /reports/%id
- /scappolicies/new

## How to test

The Inventory change is not yet merged to ensure that the tenant apps support sorting first and avoid breaking change.

1. Pull this Inventory PR locally https://github.com/RedHatInsights/insights-inventory-frontend/pull/2070.
2. Run Compliance with this PR `npm run start -- --port=8004`
3. Run Inventory with `LOCAL_APPS=compliance:8004~http npm run start:proxy`
4. Navigate to the updated views (in stage-stable environment) and make sure you can sort by system groups.

## Screenshots

<img width="1512" alt="image" src="https://github.com/RedHatInsights/compliance-frontend/assets/31385370/2a69f051-4901-408d-8b3a-31cf5106c3c6">

<img width="1512" alt="image" src="https://github.com/RedHatInsights/compliance-frontend/assets/31385370/e2b41169-32c5-41b4-88a1-284cf483075b">

<img width="1512" alt="image" src="https://github.com/RedHatInsights/compliance-frontend/assets/31385370/713356d4-cfa7-410c-9891-c34efa0dcdb5">
