### PR TITLE
fix(webpack): Append routes to config

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -16,7 +16,8 @@ const proxyConfiguration = {
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
   env: process.env.BETA ? 'stage-beta' : 'stage-stable',
   proxyVerbose: true,
-  debug: true
+  debug: true,
+  routes
 };
 
 const { config: webpackConfig, plugins } = config(proxyConfiguration);


### PR DESCRIPTION
This restores the possibility of having API routes for applications as well.


**How to test:***

Start the proxy with `LOCAL_APIS` like:

```sh
$ LOCAL_APIS=compliance:3000,inventory:8081,ingress:8080 npm run start:proxy
```

Verify that routes are proxied for the apps mentioned in the env variable.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
