### PR TITLE
feat(RHINENG-5544): System title - Remove prefix

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -125,7 +125,7 @@ const policiesRoutes = [
   },
 ];
 
-const defaultSystemsTitle = 'Compliance systems';
+const defaultSystemsTitle = 'Systems';
 const systemsRoutes = [
   {
     path: 'systems',

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -33,7 +33,7 @@ export const ComplianceSystems = () => {
   return (
     <React.Fragment>
       <PageHeader className="page-header">
-        <PageHeaderTitle title="Compliance systems" />
+        <PageHeaderTitle title="Systems" />
       </PageHeader>
       <section className="pf-c-page__main-section">
         <StateViewWithError stateValues={{ error, data, loading }}>

--- a/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
+++ b/src/SmartComponents/ComplianceSystems/__snapshots__/ComplianceSystems.test.js.snap
@@ -6,7 +6,7 @@ exports[`ComplianceSystems expect to render without error 1`] = `
     className="page-header"
   >
     <PageHeaderTitle
-      title="Compliance systems"
+      title="Systems"
     />
   </PageHeader>
   <section


### PR DESCRIPTION
# Description

This PR addresses the title change, "remove the 'Compliance' prefix in 'Systems' page."

Associated Jira ticket: [#RHINENG-5544](https://issues.redhat.com/browse/RHINENG-5544)


Checklist: 

- [X] Get a review from the UX department 
- [X] Attach relevant screenshots
- [X] Update relevant snapshots


# How to test the PR

Check the presented title in Systems page is shown without the "Compliance" prefix.


# Before the change

Systems Page:

![Before: Systems Page](https://github.com/RedHatInsights/compliance-frontend/assets/93318917/cea23c42-b58a-421d-8e5b-8f52e6874a96)



# After the change


Systems Page:

![After: Systems Page](https://github.com/RedHatInsights/compliance-frontend/assets/93318917/a685462f-ec0b-47f4-8ba0-3d3654871e0c)