### PR TITLE
fix(RHINENG-2764): Set filter correctly to show failed rules

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -37,6 +37,7 @@ const RulesTable = ({
     (selectedRules || []).filter((rule) => rule.remediationAvailable);
   const showRuleStateFilter =
     columns.filter((c) => c.title === 'Rule state').length > 0;
+
   const policies = profileRules
     .filter(({ profile }) => !!profile)
     .map(({ profile }) => ({
@@ -80,7 +81,7 @@ const RulesTable = ({
         ...(hidePassed && {
           activeFilters: (currentActiveFilters) => ({
             ...currentActiveFilters,
-            passed: currentActiveFilters.passed
+            rulestate: currentActiveFilters.passed
               ? currentActiveFilters.passed
               : ['failed'],
             ...activeFilters,


### PR DESCRIPTION
Set filter to show failed rules on System details page when navigating from Report details ( when you click on number of failed Rules on Report details page)

Before:
![Screencast from 2024-02-06 10-15-01](https://github.com/RedHatInsights/compliance-frontend/assets/33912805/19ef77ce-9d0e-4486-affb-46b9bfeb742f)


After:
![Screencast from 2024-02-06 10-12-06](https://github.com/RedHatInsights/compliance-frontend/assets/33912805/fab96fb8-6287-46a4-be15-f7bc958e1d3c)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
