### PR TITLE
fix(RHINENG-2764): Follow up fix

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -81,8 +81,8 @@ const RulesTable = ({
         ...(hidePassed && {
           activeFilters: (currentActiveFilters) => ({
             ...currentActiveFilters,
-            rulestate: currentActiveFilters.passed
-              ? currentActiveFilters.passed
+            rulestate: currentActiveFilters.rulestate
+              ? currentActiveFilters.rulestate
               : ['failed'],
             ...activeFilters,
           }),


### PR DESCRIPTION
Just found out that it works when you navigate on systems page, but if you clear filter and set some other filter - Rule state filter is automatically set to show Failed rules (even if I didn't touch it). Was able to catch it by automation.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
