### PR TITLE
fix(RHINENG-1931): Make onSaveCallback work correctly

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -31,7 +31,10 @@ export const EditPolicy = ({ route }) => {
     hosts: selectedSystems,
     values: ruleValues,
   };
-  const onSaveCallback = () => navigate(location.state?.returnTo || -1);
+  const onSaveCallback = () =>
+    navigate(
+      location.state?.returnTo || `/scappolicies/${policyId + location.hash}`
+    );
 
   const [isSaving, onSave] = useOnSave(policy, updatedPolicyHostsAndRules, {
     onSave: onSaveCallback,


### PR DESCRIPTION
I think instead of '-1' we can use policy details location + hash to navigate to the tab where we made changes. This is a quick fix that comes to my mind and can prevent being stuck on Edit modal. Can I ask for your oppinion, @bastilian ? :smile: 

Before:
[Screencast from 2024-02-17 21-47-05.webm](https://github.com/RedHatInsights/compliance-frontend/assets/33912805/ce9f3281-5a0e-4f71-a5b9-85ac34a2ad0a)

After:
[Screencast from 2024-02-17 21-46-35.webm](https://github.com/RedHatInsights/compliance-frontend/assets/33912805/f3e023b1-477a-4872-ba16-179ac9253120)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
