### PR TITLE
fix(fec): NODE_ENV is only explicitly set for prod

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -31,7 +31,7 @@ module.exports = {
     exposes: {
       './RootApp': resolve(
         __dirname,
-        `/src/${process.env.NODE_ENV === 'development' ? 'Dev' : ''}AppEntry`
+        `/src/${process.env.NODE_ENV !== 'production' ? 'Dev' : ''}AppEntry`
       ),
       './SystemDetail': resolve(__dirname, '/src/Modules/ComplianceDetails'),
     },


### PR DESCRIPTION
`fec` only sets the `NODE_ENV` when building for production.


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
