### PR TITLE
fix(RHINENG-10329): Fix input value clear for filter type text

### DIFF
--- a/src/SmartComponents/SystemsTable/Cells.test.js
+++ b/src/SmartComponents/SystemsTable/Cells.test.js
@@ -82,7 +82,7 @@ describe('LastScanned', () => {
   it('returns the relative date the system was last scanned', () => {
     render(<LastScanned {...testSystem} />);
 
-    expect(screen.getByText('4 years ago')).toBeInTheDocument();
+    expect(screen.getByText('5 years ago')).toBeInTheDocument();
   });
 
   it('returns NEVER', () => {

--- a/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterConfigBuilder.js
+++ b/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterConfigBuilder.js
@@ -146,8 +146,7 @@ class FilterConfigBuilder {
       const filterStateName = stringToId(filter.key || filter.label);
       const state =
         defaultStates[filterStateName] || this.defaultValueForFilter(filter);
-      acc[filterStateName] = state ? state : undefined;
-
+      acc[filterStateName] = typeof state !== 'undefined' ? state : undefined;
       return acc;
     }, {});
 

--- a/src/Utilities/hooks/useTableTools/FilterConfigBuilder/__snapshots__/FilterConfigBuilder.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/FilterConfigBuilder/__snapshots__/FilterConfigBuilder.test.js.snap
@@ -9,7 +9,7 @@ exports[`FilterConfigBuilder categoryLabelForValue to return a matching category
 exports[`FilterConfigBuilder initialDefaultState to return a matching category label 1`] = `
 {
   "compliance": [],
-  "name": undefined,
+  "name": "",
   "systemsmeetingcompliance": [],
 }
 `;

--- a/src/Utilities/hooks/useTableTools/__snapshots__/useFilterConfig.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__snapshots__/useFilterConfig.test.js.snap
@@ -8,9 +8,9 @@ exports[`useFilterConfig returns a filter config configuration 1`] = `
   "activeFilters": {
     "checkboxfilter": [],
     "filtergroup": undefined,
-    "hiddenfilter": undefined,
+    "hiddenfilter": false,
     "invalidfilter": undefined,
-    "name": undefined,
+    "name": "",
     "radiofilter": undefined,
   },
   "addConfigItem": [Function],
@@ -268,7 +268,7 @@ exports[`useFilterConfig returns a filter config configuration 1`] = `
         {
           "filterValues": {
             "onChange": [Function],
-            "value": undefined,
+            "value": "",
           },
           "id": "name",
           "label": "Name",


### PR DESCRIPTION
Seems after migration, behavior of components changed. `defaultValueForFilter` was always return us empty string if filter type was text but at the end we got state `undefined` as:

```
< a = ''
< a ? a : undefined
> undefined
```
after PF change it stopped working and seems we need to send an empty string as value for text filters.

It works with the current fix:
[Screencast from 2024-05-28 14-04-49.webm](https://github.com/RedHatInsights/compliance-frontend/assets/33912805/7ee7c5d2-7d96-4c43-b6dd-52ec142b8733)



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
