### PR TITLE
fix(RHINENG-5929): Look only for RHEL systems for ZeroState

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -166,7 +166,10 @@ const ComplianceRoutes = () => {
   useEffect(() => {
     try {
       axios
-        .get(`${INVENTORY_TOTAL_FETCH_URL}?page=1&per_page=1`)
+        .get(
+          // look only for RHEL systems, https://issues.redhat.com/browse/RHINENG-5929
+          `${INVENTORY_TOTAL_FETCH_URL}?page=1&per_page=1&filter[system_profile][operating_system][RHEL][version][gte]=0`
+        )
         .then(({ data }) => {
           setHasSystems(data.total > 0);
         });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-5929.

This changes the zero state logic and makes Compliance request only RHEL systems. If there are only CentOS systems available for account, the zero state must be displayed in this case as well.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
