### PR TITLE
fix(RHINENG-10194): Allow managing and exporting descriptions in poli…

### DIFF
--- a/src/PresentationalComponents/PoliciesTable/Columns.js
+++ b/src/PresentationalComponents/PoliciesTable/Columns.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { TextContent } from '@patternfly/react-core';
-import { fitContent } from '@patternfly/react-table';
 import { LinkWithPermission as Link } from 'PresentationalComponents';
 import { GreySmallText, SystemsCountWarning } from 'PresentationalComponents';
 import { renderComponent } from 'Utilities/helpers';
@@ -22,11 +21,18 @@ PolicyNameCell.propTypes = {
 export const Name = {
   title: 'Name',
   props: {
-    width: 45,
+    width: 25,
   },
   sortByProp: 'name',
   renderExport: (policy) => policy.name,
   renderFunc: renderComponent(PolicyNameCell),
+};
+
+export const Description = {
+  title: 'Description',
+  sortByProp: 'description',
+  renderExport: (policy) => policy.description,
+  hiddenByDefault: true,
 };
 
 const PolicyType = {
@@ -38,10 +44,6 @@ const osString = (policy) => `RHEL ${policy.osMajorVersion}`;
 
 export const OperatingSystem = {
   title: 'Operating system',
-  transforms: [fitContent],
-  props: {
-    width: 15,
-  },
   sortByProp: 'osMajorVersion',
   renderExport: osString,
   renderFunc: (_data, _id, policy) => osString(policy),
@@ -49,9 +51,6 @@ export const OperatingSystem = {
 
 export const Systems = {
   title: 'Systems',
-  props: {
-    width: 15,
-  },
   sortByProp: 'totalHostCount',
   renderExport: (policy) => policy.totalHostCount,
   // eslint-disable-next-line react/display-name
@@ -89,6 +88,7 @@ export const exportableColumns = [
   Systems,
   BusinessObjective,
   ComplianceThreshold,
+  Description,
 ];
 
 export default [
@@ -97,4 +97,5 @@ export default [
   Systems,
   BusinessObjective,
   ComplianceThreshold,
+  Description,
 ];

--- a/src/Utilities/hooks/useTableTools/useColumnManager.js
+++ b/src/Utilities/hooks/useTableTools/useColumnManager.js
@@ -11,7 +11,7 @@ const useColumnManager = (columns = [], options = {}) => {
     )
     .filter((column) => column.managable === true);
   const [selectedColumns, setSelectedColumns] = useState(
-    columns.map(({ title }) => title)
+    columns.map(({ hiddenByDefault, title }) => !hiddenByDefault && title)
   );
   const [isManagerOpen, setIsManagerOpen] = useState(false);
   const { manageColumns: enableColumnManager } = options;


### PR DESCRIPTION
Allows to display the Description column in the table. This is mostly done for the purpose of exporting, there is not so much space for the description in the table, so some widths needed to be readjusted.

Description column will be hidden by default.