### PR TITLE
fix(RHINENG-10871): edit rules close should close modal

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -31,7 +31,10 @@ export const EditPolicy = ({ route }) => {
     hosts: selectedSystems,
     values: ruleValues,
   };
-  const onSaveCallback = () => navigate(location.state?.returnTo || -1);
+  const onSaveCallback = (isClose) =>
+    navigate(
+      isClose ? `/scappolicies/${policyId}` : location.state?.returnTo || -1
+    );
 
   const [isSaving, onSave] = useOnSave(policy, updatedPolicyHostsAndRules, {
     onSave: onSaveCallback,
@@ -72,7 +75,7 @@ export const EditPolicy = ({ route }) => {
       key="cancel"
       ouiaId="EditPolicyCancelButton"
       variant="link"
-      onClick={onSaveCallback}
+      onClick={() => onSaveCallback(true)}
     >
       Cancel
     </Button>,
@@ -89,7 +92,7 @@ export const EditPolicy = ({ route }) => {
       variant={'large'}
       ouiaId="EditPolicyModal"
       title={`Edit ${policy ? policy.name : ''}`}
-      onClose={onSaveCallback}
+      onClose={() => onSaveCallback(true)}
       actions={actions}
     >
       <StateViewWithError


### PR DESCRIPTION
- SCAP Policies
- Edit Rules
- clicking through various tabs,
- clicking the “cancel” link or the “x”

and

- SCAP Policies
- clicking kebab on a policy
- clicking "Edit policy"
- clicking through various tabs
- clicking the "cancel" link or the "x"

Notice how it goes back to the previous tab, functioning like a "back" button rather than a "cancel" or  "close"

Closing the modal in both instances should take you to the policy details page for that policy

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
