### PR TITLE
feat(AsyncTableTools): RHINENG-11637 - Add useTableSort hook

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -26,6 +26,10 @@
                 {
                     "label": "Compliance GitHub repository",
                     "href": "https://github.com/RedHatInsights/compliance-frontend/"
+                },
+                {
+                    "label": "Compliance REST API v2 Documentation",
+                    "href": "https://console.stage.redhat.com/docs/api/compliance/v2"
                 }
             ]
         }

--- a/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useAsyncTableTools.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useAsyncTableTools.js
@@ -1,5 +1,6 @@
 import usePagination from '../usePagination';
 import useFilterConfig from '../useFilterConfig';
+import useTableSort from '../useTableSort';
 import useItems from './useItems';
 import rowsBuilder from './rowsBuilder';
 import useBulkSelect from '../useBulkSelect';
@@ -37,6 +38,12 @@ const useAsyncTableTools = (items, columns, options = {}) => {
     // onDeleteFilter: () => setPage?.(1),
   });
 
+  const { tableProps: sortableTableProps } = useTableSort(columns, {
+    ...options,
+    // TODO enable when usePaginate hook is ready
+    // onSort: () => setPage(1),
+  });
+
   const usableItems = useItems(items);
 
   const {
@@ -67,6 +74,7 @@ const useAsyncTableTools = (items, columns, options = {}) => {
 
   const tableProps = {
     cells: columns,
+    ...sortableTableProps,
     ...rowBuilderTableProps,
     ...bulkSelectTableProps,
     ...tablePropsOption,

--- a/src/Frameworks/AsyncTableTools/hooks/useTableSort/helpers.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableSort/helpers.js
@@ -1,0 +1,20 @@
+import { sortable } from '@patternfly/react-table';
+import uniq from 'lodash/uniq';
+
+const isSortable = (column) => !!column.sortable;
+
+export const addSortableTransform = (columns) =>
+  columns.map((column) => ({
+    ...column,
+    ...(isSortable(column)
+      ? {
+          transforms: uniq([...(column?.transforms || []), sortable]),
+        }
+      : {}),
+  }));
+
+// The sort click event passes an index including the select and/or the expand column
+// Therefore we need to add an offset in these cases to match with the index of the columns passed in
+export const columnOffset = (options = {}) =>
+  (typeof options.onSelect === 'function') +
+  (typeof options.detailsComponent !== 'undefined');

--- a/src/Frameworks/AsyncTableTools/hooks/useTableSort/index.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableSort/index.js
@@ -1,0 +1,3 @@
+export { default } from './useTableSort';
+
+export * from './useTableSort';

--- a/src/Frameworks/AsyncTableTools/hooks/useTableSort/useTableSort.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableSort/useTableSort.js
@@ -1,0 +1,58 @@
+import { addSortableTransform, columnOffset } from './helpers';
+import useTableState from '../useTableState';
+
+/**
+ *  Provides columns with the `sortable` transform mixed in for a Patternfly table.
+ *
+ *  @param {Array} columns Columns for a table, with a "sortable" prop
+ *  @param {object} [options] AsyncTableTools options
+ *  @param {object} [options.sortBy] An initial sortBy state like `{index: 1, direction: 'desc'}`
+ *  @param {object} [options.onSort] A function to call after setting a new sort state.
+ *  @param {object} [options.serialisers.sort] A function to provide a serialiser for the table state
+ *
+ *  @returns {object}
+ *
+ *  @example
+ *
+ * const columns = [{ title: 'Name', sortable: true }]
+ * const tableSort = useTableSort(columns)
+ *
+ *  @category AsyncTableTools
+ *  @subcategory Hooks
+ *
+ */
+const useTableSort = (columns, options = {}) => {
+  const { sortBy: initialSortBy, serialisers } = options;
+  const defaultSortBy = {
+    index: columnOffset(options),
+    direction: 'asc',
+  };
+  const [sortBy, setSortBy] = useTableState(
+    'sort',
+    initialSortBy || defaultSortBy,
+    {
+      ...(serialisers?.sort
+        ? { serialiser: (state) => serialisers.sort(state, columns) }
+        : {}),
+    }
+  );
+
+  const onSort = (_, index, direction) => {
+    setSortBy({
+      index,
+      direction,
+    });
+    options.onSort?.(index, direction);
+  };
+
+  return {
+    sortBy,
+    tableProps: {
+      onSort,
+      sortBy,
+      cells: addSortableTransform(columns),
+    },
+  };
+};
+
+export default useTableSort;

--- a/src/Frameworks/AsyncTableTools/hooks/useTableSort/useTableSort.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableSort/useTableSort.test.js
@@ -1,0 +1,51 @@
+import { renderHook, act } from '@testing-library/react';
+import { DEFAULT_RENDER_OPTIONS } from '../../utils/testHelpers';
+import columns from 'Utilities/hooks/useTableTools/__fixtures__/columns';
+
+import useTableSort from './useTableSort';
+
+describe('useTableSort', () => {
+  const exampleSortBy = {
+    index: 3,
+    direction: 'asc',
+  };
+
+  it('returns a table sort configuration', () => {
+    const { result } = renderHook(
+      () => useTableSort(columns),
+      DEFAULT_RENDER_OPTIONS
+    );
+    expect(result.current.tableProps).toBeDefined();
+  });
+
+  it('returns a table sort configuration with an inital state', () => {
+    const { result } = renderHook(
+      () =>
+        useTableSort(columns, {
+          sortBy: exampleSortBy,
+        }),
+      DEFAULT_RENDER_OPTIONS
+    );
+
+    expect(result.current.tableProps.sortBy).toEqual(exampleSortBy);
+  });
+
+  it('should allow changing the sort via onSort', async () => {
+    const { result } = renderHook(
+      () =>
+        useTableSort(columns, {
+          sortBy: exampleSortBy,
+        }),
+      DEFAULT_RENDER_OPTIONS
+    );
+
+    await act(() => {
+      result.current.tableProps.onSort(undefined, 1, 'desc');
+    });
+
+    expect(result.current.tableProps.sortBy).toEqual({
+      index: 1,
+      direction: 'desc',
+    });
+  });
+});

--- a/src/PresentationalComponents/ComplianceTable/ComplianceTable.js
+++ b/src/PresentationalComponents/ComplianceTable/ComplianceTable.js
@@ -1,13 +1,17 @@
 import React, { useEffect } from 'react';
 import propTypes from 'prop-types';
 import AsyncTableToolsTable from '@/Frameworks/AsyncTableTools/components/AsyncTableToolsTable';
-import { TableToolsTable } from 'Utilities/hooks/useTableTools';
-import { ENABLE_ASYNC_TABLE_HOOKS } from '@/constants';
-import { paginationSerialiser, filtersSerialiser } from './serialisers';
 import {
   useSerialisedTableState,
   useRawTableState,
 } from '@/Frameworks/AsyncTableTools/hooks/useTableState';
+import { TableToolsTable } from 'Utilities/hooks/useTableTools';
+import { ENABLE_ASYNC_TABLE_HOOKS } from '@/constants';
+import {
+  paginationSerialiser,
+  filtersSerialiser,
+  sortSerialiser,
+} from './serialisers';
 
 /**
  *  This component serves as a place to either use the non-async TableTools or the AsyncTableTools
@@ -37,6 +41,7 @@ const ComplianceTable = (props) => {
         serialisers: {
           pagination: paginationSerialiser,
           filters: filtersSerialiser,
+          sort: sortSerialiser,
         },
         ...props.options,
       }}

--- a/src/PresentationalComponents/ComplianceTable/serialisers.js
+++ b/src/PresentationalComponents/ComplianceTable/serialisers.js
@@ -59,3 +59,31 @@ export const filtersSerialiser = (state, filters) => {
 
   return queryParts.length > 0 ? queryParts.join(' AND ') : undefined;
 };
+
+/**
+ *  Returns a string consumable by the Compliance API as a "sort_by" parameter for a given column and direction
+ *  For columns to be sortable they need to have a "sortable" prop, which corresponds to the field name in the Compliance API
+ *
+ *  @param {object} state A "sortBy" table state
+ *  @param {number} state.index Index of the column to sort by
+ *  @param {string} state.direction Direction to sort the column by
+ *  @param {Array}  columns Columns passed in for the AsyncTableToolsTable
+ *
+ *  @returns {string} Compliance "sort_by" parameter string, like "name:desc"
+ *
+ *  @category Compliance
+ *
+ *  @example <caption>Example of a column with an sortable property</caption>
+ *
+ *  const columns = [
+ *     {
+ *       title: 'Name',
+ *       sortable: 'name' // Corresponds to the attribute/field to sort by in the API
+ *     }
+ *  ];
+ *
+ */
+export const sortSerialiser = ({ index, direction }, columns) => {
+  console.log({ index, direction }, columns);
+  return `${columns[index].sortable}:${direction}`;
+};

--- a/src/PresentationalComponents/ComplianceTable/serialisers.test.js
+++ b/src/PresentationalComponents/ComplianceTable/serialisers.test.js
@@ -1,7 +1,7 @@
 import { stringToId } from '@/Frameworks/AsyncTableTools/hooks/useFilterConfig/helpers';
 import filters from 'Utilities/hooks/useTableTools/__fixtures__/filters';
 
-import { filtersSerialiser } from './serialisers';
+import { filtersSerialiser, sortSerialiser } from './serialisers';
 
 const filtersWithIds = filters.map((filter) => ({
   id: stringToId(filter.label),
@@ -71,5 +71,40 @@ describe('filtersSerialiser', () => {
     ).toEqual('filterSerialiser');
 
     expect(filterSerialiser).toHaveBeenCalled();
+  });
+});
+
+describe('sortSerialiser', () => {
+  const exampleColumns = [
+    {
+      title: 'Name',
+      sortable: 'name',
+    },
+    {
+      title: 'Description',
+      sortable: 'description',
+    },
+  ];
+
+  it('returns a string consumable by the Compliance API as a "sort_by" parameter', () => {
+    expect(
+      sortSerialiser(
+        {
+          index: 0,
+          direction: 'asc',
+        },
+        exampleColumns
+      )
+    ).toEqual('name:asc');
+
+    expect(
+      sortSerialiser(
+        {
+          index: 1,
+          direction: 'desc',
+        },
+        exampleColumns
+      )
+    ).toEqual('description:desc');
   });
 });

--- a/src/PresentationalComponents/ReportsTable/Columns.js
+++ b/src/PresentationalComponents/ReportsTable/Columns.js
@@ -10,6 +10,8 @@ import {
 export const Name = {
   title: 'Policy',
   sortByProp: 'name',
+  // TODO this "sortBy" is an example to test the sortability to show in the AsyncTable for the sortSerialiser
+  sortable: 'name',
   props: {
     width: 60,
   },
@@ -21,6 +23,8 @@ export const OperatingSystem = {
   title: 'Operating system',
   transforms: [fitContent],
   sortByProp: 'osMajorVersion',
+  // TODO same as with above "sortBy"
+  sortable: 'osMajorVersion',
   props: {
     width: 20,
   },


### PR DESCRIPTION
This adds the sort functionality for the `AsyncTableToolsTable`.


**How to test:**

1) Open the Reports page
2) Verify that the ReportsTable is still using the current TableToolsTable without any change and without a 'insights:compliance:asynctables' localStorage entry.
3) Add a localStorage entry with the key 'insights:compliance:asynctables' and the value "true"
4) Reload the Reports page
5) Verify that the "Name" column is sortable
6) Verify that clicking the "Name" column header reports the correct column set as "sortable" in the DevTools console as the serialised state.



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
