### PR TITLE
feat(APIV2): Policy detail page (detail tab)

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -86,7 +86,7 @@ const policiesRoutes = [
     defaultTitle: defaultPoliciesTitle,
     component: lazy(() =>
       import(
-        /* webpackChunkName: "PolicyDetails" */ 'SmartComponents/PolicyDetails/PolicyDetails'
+        /* webpackChunkName: "PolicyDetailsWrapper" */ 'SmartComponents/PolicyDetails/PolicyDetails'
       )
     ),
   },

--- a/src/SmartComponents/EditPolicy/EditPolicy.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.test.js
@@ -9,7 +9,13 @@ jest.mock('Utilities/hooks/useDocumentTitle', () => ({
   setTitle: () => ({}),
 }));
 
+import useAPIV2FeatureFlag from '../../Utilities/hooks/useAPIV2FeatureFlag';
+jest.mock('../../Utilities/hooks/useAPIV2FeatureFlag');
+
 describe('EditPolicy', () => {
+  beforeEach(() => {
+    useAPIV2FeatureFlag.mockImplementation(() => false);
+  });
   const defaultProps = {
     onClose: jest.fn(),
     dispatch: jest.fn(),

--- a/src/SmartComponents/EditPolicy/hooks.test.js
+++ b/src/SmartComponents/EditPolicy/hooks.test.js
@@ -12,6 +12,9 @@ jest.mock('Utilities/hooks/useAnchor', () => ({
   default: () => () => ({}),
 }));
 
+import useAPIV2FeatureFlag from '../../Utilities/hooks/useAPIV2FeatureFlag';
+jest.mock('../../Utilities/hooks/useAPIV2FeatureFlag');
+
 describe('useOnSave', function () {
   const policy = {};
   const updatedPolicy = {};
@@ -23,6 +26,7 @@ describe('useOnSave', function () {
     onSaveCallBack.mockReset();
     onErrorCallback.mockReset();
     dispatchNotification.mockImplementation(mockedNotification);
+    useAPIV2FeatureFlag.mockImplementation(() => false);
   });
 
   it('returns a function to call with a policy and updated policy', async () => {

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.test.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.test.js
@@ -60,6 +60,11 @@ jest.mock('Utilities/hooks/useDocumentTitle', () => ({
   setTitle: () => ({}),
 }));
 
+jest.mock('../../Utilities/hooks/useAPIV2FeatureFlag', () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
 describe('PolicyDetails', () => {
   it('expect to render without error', () => {
     render(

--- a/src/Utilities/dataSerialiser.js
+++ b/src/Utilities/dataSerialiser.js
@@ -1,0 +1,24 @@
+import set from 'lodash/set';
+
+const serialiseObject = (object, map) => {
+  if (!object || !map) {
+    return object;
+  }
+
+  const result = {};
+
+  Object.entries(object).forEach(([key, value]) => {
+    let paths = Array.isArray(map[key]) ? map[key] : [map[key]];
+    paths.forEach((path) => {
+      const newPath = path || key;
+      set(result, newPath, value);
+    });
+  });
+
+  return result;
+};
+
+export default (data, map) =>
+  Array.isArray(data)
+    ? data.map((entry) => serialiseObject(entry, map))
+    : serialiseObject(data, map);

--- a/src/Utilities/hooks/usePolicyQuery/usePolicyQuery2.js
+++ b/src/Utilities/hooks/usePolicyQuery/usePolicyQuery2.js
@@ -1,0 +1,7 @@
+import useQuery, { apiInstance } from '../useQuery';
+
+const usePolicyQuery = ({ policyId }) => {
+  return useQuery(apiInstance.policy, { params: [policyId] });
+};
+
+export default usePolicyQuery;


### PR DESCRIPTION
[RHINENG-10398](https://issues.redhat.com/browse/RHINENG-10398)
Divided work from [this PR](https://github.com/RedHatInsights/compliance-frontend/pull/2091)

Includes code for the policy detail tab and inline editing.
Policy rules tab and systems tab are expected to not function properly.

### API Compatibility
This PR keeps compatibility between both of the APIs. We use the `compliance-api-v2` feature flag to switch between the APIs. You can switch it in unleash or manually set the values to `true` or `false`. Search for `apiV2Enabled`, it exists in two places.

### How to test
1. To test the API V2 version, you need to manually fetch the policies, since the old IDs don't match on the list page.
2. Put this in the console on the compliance page:
`fetch("/api/compliance/v2/policies/").then(res => res.json()).then(data => console.log(data))`
3. Pick an ID from the response and append it to the url.
4. Verify the details page loads and test the inline editing. Different tabs don't need to work.
5. Test the GraphQL version, here everything should work as it did previously.


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
