### PR TITLE
fix(RHINENG-2136): Fix spacing in Create policy wizard review step

### DIFF
--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
@@ -24,10 +24,8 @@ const ReviewCreatedPolicy = ({
   <TextContent>
     <Text component={TextVariants.h1}>Review</Text>
     <Text>Review your SCAP policy before finishing.</Text>
-    <Text component={TextVariants.h3} style={{ marginTop: 0 }}>
-      {name}
-    </Text>
-    <TextList component={TextListVariants.dl}>
+    <Text component={TextVariants.h3}>{name}</Text>
+    <TextList component={TextListVariants.dl} className="pf-u-mt-md">
       <TextListItem component={TextListItemVariants.dt}>
         Policy type
       </TextListItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-2136

To test:
1. Open the wizard to create a new SCAP policy
2. Go to the Review step
3. Observe the spacing between the rows
  - space below policy name (C2S for Red Hat Enterprise Linux 6) should be the same as spacing between (Policy type and Compliance threshold) and (Compliance threshold and Systems)
  - space above policy name (C2S for Red Hat Enterprise Linux 6) should be the larger than spacing below the policy name

## Before
![Screenshot from 2024-08-12 23-33-28](https://github.com/user-attachments/assets/61f2eedb-1f6e-4d7d-974f-50e4ac1bafd8)

## After
![Screenshot from 2024-08-12 23-33-24](https://github.com/user-attachments/assets/8368b622-a5c1-4a64-b570-c2e077b1ca65)
