### PR TITLE
refactor(AsyncTableTools): Enable glue code for Async hooks

### DIFF
--- a/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useAsyncTableTools.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useAsyncTableTools.js
@@ -47,19 +47,18 @@ const useAsyncTableTools = (items, columns, options = {}) => {
     ],
   });
 
-  const { toolbarProps: paginationToolbarProps } = usePagination(options);
+  const { toolbarProps: paginationToolbarProps, resetPage } =
+    usePagination(options);
 
   const { toolbarProps: conditionalFilterProps } = useFilterConfig({
     ...options,
-    // TODO enable when paginaton hook is added
-    // onFilterUpdate: () => setPage?.(1),
-    // onDeleteFilter: () => setPage?.(1),
+    onFilterUpdate: resetPage,
+    onDeleteFilter: resetPage,
   });
 
   const { tableProps: sortableTableProps } = useTableSort(managedColumns, {
     ...options,
-    // TODO enable when usePaginate hook is ready
-    // onSort: () => setPage(1),
+    onSort: resetPage,
   });
   const { tableProps: expandableTableProps, openItem } = useExpandable(options);
 
@@ -71,7 +70,6 @@ const useAsyncTableTools = (items, columns, options = {}) => {
     markRowSelected,
   } = useBulkSelect({
     ...options,
-    setPage: () => {}, //TODO: apply proper setPage function after pagination hook
     itemIdsOnPage: usableItems.map(({ id }) => id),
   });
 
@@ -99,9 +97,9 @@ const useAsyncTableTools = (items, columns, options = {}) => {
   };
 
   const tableProps = {
+    // TODO we should have a hook that maintains columns.
+    // at least the columns manager and table sort hook "act" on columns, currently without a good interface
     cells: managedColumns,
-    // TODO: The sortable hook will override the `cells` prop.
-    // This is not ideal, but for now good enough
     ...sortableTableProps,
     ...rowBuilderTableProps,
     ...bulkSelectTableProps,

--- a/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useItems.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useItems.js
@@ -12,6 +12,8 @@ import { useSerialisedTableState, useRawTableState } from '../useTableState';
  *  @category AsyncTableTools
  *  @subcategory internal
  *
+ * TODO it might be good to use this hook as well to "identify" items similar to the `useItemIdentify` hook
+ *
  */
 const useItems = (itemsProp) => {
   const mounted = useRef(true);

--- a/src/Frameworks/AsyncTableTools/hooks/useBulkSelect/__snapshots__/useBulkSelect.test.js.snap
+++ b/src/Frameworks/AsyncTableTools/hooks/useBulkSelect/__snapshots__/useBulkSelect.test.js.snap
@@ -26,6 +26,10 @@ exports[`useBulkSelect returns a bulk select configuration 1`] = `
             "onClick": [Function],
             "title": "Select page (0 items)",
           },
+          {
+            "onClick": [Function],
+            "title": "Unselect all (0 items)",
+          },
         ],
         "onSelect": undefined,
         "toggleProps": {
@@ -52,6 +56,10 @@ exports[`useBulkSelect returns a bulk select configuration with select all 1`] =
     "onClick": [Function],
     "title": "Select page (2 items)",
   },
+  {
+    "onClick": [Function],
+    "title": "Select all (2 items)",
+  },
 ]
 `;
 
@@ -67,6 +75,10 @@ exports[`useBulkSelect returns a bulk select configuration without select all 1`
   {
     "onClick": [Function],
     "title": "Select page (2 items)",
+  },
+  {
+    "onClick": [Function],
+    "title": "Select all (2 items)",
   },
 ]
 `;

--- a/src/Frameworks/AsyncTableTools/hooks/useBulkSelect/useBulkSelect.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useBulkSelect/useBulkSelect.js
@@ -23,7 +23,7 @@ const useBulkSelect = ({
   total = 0,
   onSelect,
   preselected,
-  fetchAllIds,
+  itemIdsInTable,
   itemIdsOnPage,
   identifier = 'itemId',
 }) => {
@@ -51,23 +51,21 @@ const useBulkSelect = ({
   const title = compileTitle(selectedIdsTotal, isLoading);
 
   const selectOne = useCallback(
-    (_, selected, _key, row) => {
-      console.log(row, selected, 'unselecting row');
-      return row.selected ? deselect(row[identifier]) : select(row[identifier]);
-    },
-
+    (_, _selected, _key, row) =>
+      row.selected ? deselect(row[identifier]) : select(row[identifier]),
     [select, deselect]
   );
-  const selectPage = useCallback(() => {
-    !currentPageSelected ? select(itemIdsOnPage) : deselect(itemIdsOnPage);
-  }, [select, deselect]);
+  const selectPage = useCallback(
+    () =>
+      !currentPageSelected ? select(itemIdsOnPage) : deselect(itemIdsOnPage),
+    [select, deselect]
+  );
 
   const selectAll = async () => {
-    const items = await fetchBatched(fetchAllIds, total);
     if (allSelected) {
       clear();
     } else {
-      set(items);
+      set(await fetchBatched(itemIdsInTable, total));
     }
   };
 
@@ -79,7 +77,7 @@ const useBulkSelect = ({
   return enableBulkSelect
     ? {
         selectedIds,
-        selectNone: () => clear(),
+        selectNone: clear,
         markRowSelected,
         tableProps: {
           onSelect: total > 0 ? selectOne : undefined,
@@ -107,7 +105,7 @@ const useBulkSelect = ({
                     },
                   ]
                 : []),
-              ...(fetchAllIds
+              ...(itemIdsInTable
                 ? [
                     {
                       title: `${selectOrUnselect(

--- a/src/Frameworks/AsyncTableTools/hooks/usePagination/usePagination.js
+++ b/src/Frameworks/AsyncTableTools/hooks/usePagination/usePagination.js
@@ -48,9 +48,12 @@ const usePagination = (options = {}) => {
     });
   };
 
+  const resetPage = () => setPage?.(1);
+
   return enablePagination
     ? {
         setPage,
+        resetPage,
         toolbarProps: {
           pagination: {
             ...paginationState,


### PR DESCRIPTION
This enables some code to make async table hooks interact properly.

**How to test:**

1) Enable the AsyncTable
2) Open a table/page with the an async table that paginates
3) Change to a different page than the first one.
4) Filter or sort the table
5) Verify that the page in both cases is reset to the first page

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
