### PR TITLE
feat(APIV2): Delete Policy modal

### DIFF
--- a/src/SmartComponents/DeletePolicy/DeletePolicy.test.js
+++ b/src/SmartComponents/DeletePolicy/DeletePolicy.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { useLocation } from 'react-router-dom';
@@ -7,6 +7,20 @@ import { dispatchAction } from 'Utilities/Dispatcher';
 import TestWrapper from '@/Utilities/TestWrapper';
 
 import DeletePolicy from './DeletePolicy.js';
+
+import useAPIV2FeatureFlag from '../../Utilities/hooks/useAPIV2FeatureFlag';
+
+import { apiInstance } from '../../Utilities/hooks/useQuery';
+
+jest.mock('../../Utilities/hooks/useQuery', () => ({
+  __esModule: true,
+  apiInstance: { deletePolicy: jest.fn() },
+  default: () => ({
+    data: { data: { title: 'Test Policy 1', id: 'teste_polict_ID' } },
+    error: undefined,
+    loading: undefined,
+  }),
+}));
 
 jest.mock('Utilities/Dispatcher');
 
@@ -19,6 +33,8 @@ jest.mock('@apollo/client', () => ({
     loading: undefined,
   }),
 }));
+
+jest.mock('../../Utilities/hooks/useAPIV2FeatureFlag');
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -42,6 +58,7 @@ describe('DeletePolicy', () => {
       },
     }));
     dispatchAction.mockImplementation(() => {});
+    useAPIV2FeatureFlag.mockReturnValue(false);
   });
 
   it('expect to render a modal to delete a policy', () => {
@@ -57,5 +74,66 @@ describe('DeletePolicy', () => {
       )
     ).toBeInTheDocument();
     expect(screen.getByText('Test Policy 1')).toBeInTheDocument();
+  });
+});
+
+describe('DeletePolicy API V2', () => {
+  const policy = { id: 1, name: 'foo' };
+
+  beforeEach(() => {
+    useLocation.mockImplementation(() => ({
+      state: {
+        policy,
+      },
+    }));
+    dispatchAction.mockImplementation(() => {});
+    useAPIV2FeatureFlag.mockImplementation(() => true);
+  });
+
+  it('expect to render a modal and delete a policy', () => {
+    render(
+      <TestWrapper>
+        <DeletePolicy />
+      </TestWrapper>
+    );
+
+    expect(
+      screen.getByText(
+        'I understand this will delete the policy and all associated reports'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test Policy 1')).toBeInTheDocument();
+
+    act(() => {
+      screen
+        .getByRole('checkbox', {
+          checked: false,
+          id: 'deleting-policy-check-teste_polict_ID',
+        })
+        .click();
+    });
+
+    act(() => {
+      screen.getByRole('button', { name: 'delete' }).click();
+    });
+
+    expect(apiInstance.deletePolicy).toBeCalled();
+  });
+});
+
+describe('DeletePolicyWrapper', () => {
+  beforeEach(() => {
+    useAPIV2FeatureFlag.mockReturnValue(undefined);
+  });
+  it('shows loading when flag not resolved', () => {
+    render(
+      <TestWrapper>
+        <DeletePolicy />
+      </TestWrapper>
+    );
+
+    expect(
+      screen.getByRole('progressbar', { value: { text: 'Loading...' } })
+    ).toBeInTheDocument();
   });
 });

--- a/src/SmartComponents/DeletePolicy/constants.js
+++ b/src/SmartComponents/DeletePolicy/constants.js
@@ -1,0 +1,4 @@
+export const dataMap = {
+  id: 'profile.id',
+  title: 'profile.name',
+};

--- a/src/Utilities/hooks/useQuery/apiInstance.js
+++ b/src/Utilities/hooks/useQuery/apiInstance.js
@@ -5,6 +5,7 @@ import policy from '@redhat-cloud-services/compliance-client/dist/Policy';
 import policySystems from '@redhat-cloud-services/compliance-client/dist/PolicySystems';
 import tailorings from '@redhat-cloud-services/compliance-client/dist/Tailorings';
 import updatePolicy from '@redhat-cloud-services/compliance-client/dist/UpdatePolicy';
+import deletePolicy from '@redhat-cloud-services/compliance-client/dist/DeletePolicy';
 import report from '@redhat-cloud-services/compliance-client/dist/Report';
 import reports from '@redhat-cloud-services/compliance-client/dist/Reports';
 
@@ -20,6 +21,7 @@ const apiInstance = APIFactory(
     policySystems,
     tailorings,
     updatePolicy,
+    deletePolicy,
     report,
     reports,
   },


### PR DESCRIPTION
[RHINENG-11723](https://issues.redhat.com/browse/RHINENG-11723)

Policy deletion using both APIs. Both should work.

How to test:
1. Test the V2 version
2. Enable the `compliance-api-v2` feature flag or manually hardcode `apiV2Enabled` to true in `CompliancePolicies` and `DeletePolicy`
3. Test the policy gets deleted and table is updated
4. Repeat for GraphQL version

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
