### PR TITLE
feat(useQuery): add debounce

### DIFF
--- a/src/SmartComponents/SystemsTable/hooks.test.js
+++ b/src/SmartComponents/SystemsTable/hooks.test.js
@@ -189,16 +189,18 @@ describe('useOsMinorVersionFilterRest', () => {
     );
 
     await waitFor(() => expect(result.current).not.toEqual([]));
-    expect(result.current[0].items[0]).toEqual({
-      groupSelectable: true,
-      items: [
-        {
-          label: 'RHEL 7.8',
-          value: '8',
-        },
-      ],
-      label: 'RHEL 7',
-      value: 7,
-    });
+    await waitFor(() =>
+      expect(result.current[0].items[0]).toEqual({
+        groupSelectable: true,
+        items: [
+          {
+            label: 'RHEL 7.8',
+            value: '8',
+          },
+        ],
+        label: 'RHEL 7',
+        value: 7,
+      })
+    );
   });
 });

--- a/src/Utilities/hooks/useQuery/useComplianceQuery.test.js
+++ b/src/Utilities/hooks/useQuery/useComplianceQuery.test.js
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import useComplianceQuery from './useComplianceQuery';
 import { useSerialisedTableState } from '../../../Frameworks/AsyncTableTools/hooks/useTableState';
 import usePagination from '../../../Frameworks/AsyncTableTools/hooks/usePagination';
@@ -53,43 +53,54 @@ describe('useComplianceQuery', () => {
   beforeEach(() => {
     fakeApi.mockReset();
   });
-  it('verifies pagination', () => {
+  it('verifies pagination', async () => {
     const { result } = renderHook(() => useTableStateHelper(), {
       wrapper,
     });
 
-    expect(fakeApi).toHaveBeenNthCalledWith(1, initialSerializedState);
+    await waitFor(() =>
+      expect(fakeApi).toHaveBeenNthCalledWith(1, initialSerializedState)
+    );
 
     act(() =>
       result.current.paginate.toolbarProps.pagination.onSetPage(undefined, 2)
     );
 
-    expect(fakeApi).toHaveBeenNthCalledWith(2, {
-      ...initialSerializedState,
-      offset: 10,
-    });
+    await waitFor(() =>
+      expect(fakeApi).toHaveBeenNthCalledWith(2, {
+        ...initialSerializedState,
+        offset: 10,
+      })
+    );
+
     act(() =>
       result.current.paginate.toolbarProps.pagination.onPerPageSelect(null, 50)
     );
 
-    expect(fakeApi).toHaveBeenNthCalledWith(3, {
-      ...initialSerializedState,
-      limit: 50,
-    });
+    await waitFor(() =>
+      expect(fakeApi).toHaveBeenNthCalledWith(3, {
+        ...initialSerializedState,
+        limit: 50,
+      })
+    );
   });
 
-  it('verifies sorting', () => {
+  it('verifies sorting', async () => {
     const { result } = renderHook(() => useTableStateHelper(), {
       wrapper,
     });
 
-    expect(fakeApi).toHaveBeenNthCalledWith(1, initialSerializedState);
+    await waitFor(() =>
+      expect(fakeApi).toHaveBeenNthCalledWith(1, initialSerializedState)
+    );
 
     act(() => result.current.sort.tableProps.onSort(null, 1, 'desc'));
 
-    expect(fakeApi).toHaveBeenNthCalledWith(2, {
-      ...initialSerializedState,
-      sortBy: 'systems:desc',
-    });
+    await waitFor(() =>
+      expect(fakeApi).toHaveBeenNthCalledWith(2, {
+        ...initialSerializedState,
+        sortBy: 'systems:desc',
+      })
+    );
   });
 });

--- a/src/Utilities/hooks/useQuery/useQuery.js
+++ b/src/Utilities/hooks/useQuery/useQuery.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import debounce from '@redhat-cloud-services/frontend-components-utilities/debounce';
 
 /**
  *
@@ -59,8 +60,10 @@ const useQuery = (fn, { params = [], skip = false } = {}) => {
     }
   }, [fnRef, paramsRef]);
 
+  const debouncedRefetch = useCallback(debounce(refetch, 200), []);
+
   useEffect(() => {
-    if (!skip) refetch();
+    if (!skip) debouncedRefetch();
   }, [JSON.stringify(paramsRef.current)]);
 
   return { data, error, loading, refetch };


### PR DESCRIPTION
Previously a new API request was made exactly on the moment of a filter change.  E.g. a text filter would make a request on each keystroke.
Now the fetching function is debounced to 200ms.

Updated the tests accordingly since we need to wait some time for the debounce to resolve.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
