### PR TITLE
fix(tests): Make Travis respect test failures

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -3,6 +3,8 @@
 # Merges coverage reports from cypress and jest tests
 # and generates an HTML report to view and json report to submit to codecov
 #
+set -e
+
 case $(uname) in
 Darwin)
         export CODECOV_BIN="https://uploader.codecov.io/latest/macos/codecov"
@@ -19,11 +21,12 @@ rm -rf ./coverage
 
 mkdir -p coverage/src
 
-npm run test
+npm run test || { echo "Tests failed"; exit 1; }
+
 cp ./coverage-jest/coverage-final.json ./coverage/src/jest.json
 
 if [ -f cypress.config.js ]; then
-        npm run test:ct
+        npm run test:ct || { echo "Cypress tests failed"; exit 1; }
         cp ./coverage-cypress/coverage-final.json ./coverage/src/cypress.json
 else
         echo "No cypress config found!"


### PR DESCRIPTION
Currently if unit tests or cypress tests are failing but other stages pass - travis returns 0. To save time and make it more reliable - it's better to fail on test errors. Right now travis passes even with test errors and then pr_check fails on unit tests.

Before:
```
Test Suites: 1 failed, 3 skipped, 114 passed, 115 of 118 total
Tests:       1 failed, 6 skipped, 402 passed, 409 total
Snapshots:   110 passed, 110 total
Time:        112.28 s
Ran all test suites.
...
...
[2024-10-01T09:25:23.316Z] ['verbose'] End of uploader: 609 milliseconds
The command "npm run travis:verify" exited with 0.
```

After:
```Test Suites: 1 failed, 3 skipped, 114 passed, 115 of 118 total
Tests:       1 failed, 6 skipped, 402 passed, 409 total
Snapshots:   110 passed, 110 total
Time:        114.018 s
Ran all test suites.
Tests failed
The command "npm run travis:verify" exited with 1.```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
