### PR TITLE
feat(Reports): RHINENG-13445 - Enable async filtering, sorting & pagination

### DIFF
--- a/src/Frameworks/AsyncTableTools/hooks/usePagination/hooks/usePaginationState.js
+++ b/src/Frameworks/AsyncTableTools/hooks/usePagination/hooks/usePaginationState.js
@@ -8,35 +8,40 @@ import { TABLE_STATE_NAMESPACE } from '../constants';
 
 const usePaginationState = (options) => {
   const { perPage = 10, serialisers } = options;
+  const defaultState = useMemo(() => {
+    return {
+      perPage,
+      page: 1,
+    };
+  }, [perPage]);
   const resetPage = useCallback(
-    (currentState) => ({
-      ...currentState,
-      state: {
-        ...(currentState?.state || {}),
-        page: 1,
-      },
-    }),
-    []
+    (currentState) => {
+      return {
+        ...currentState,
+        state: {
+          ...(currentState?.state || defaultState),
+          page: 1,
+        },
+      };
+    },
+    [defaultState]
   );
 
   const stateObservers = useMemo(
     () => ({
       [VIEW_TABLE_NAMESPACE]: (currentState, _previousView, nextView) => ({
-        ...currentState,
+        ...(currentState || { state: defaultState }),
         isDisabled: (nextView || _previousView) !== 'rows',
       }),
       [SORT_TABLE_NAMESPACE]: resetPage,
       [FILTERS_TABLE_NAMESPACE]: resetPage,
     }),
-    [resetPage]
+    [resetPage, defaultState]
   );
   const [paginationState, setPaginationState] = useTableState(
     TABLE_STATE_NAMESPACE,
     {
-      state: {
-        perPage,
-        page: 1,
-      },
+      state: defaultState,
       isDisabled: false,
     },
     {

--- a/src/Frameworks/AsyncTableTools/hooks/usePagination/usePagination.js
+++ b/src/Frameworks/AsyncTableTools/hooks/usePagination/usePagination.js
@@ -16,9 +16,7 @@ import usePaginationState from './hooks/usePaginationState';
  *
  */
 const usePagination = (options = {}) => {
-  const { perPage = 10, numberOfItems } = options;
-  const enablePagination =
-    options?.pagination !== false && (numberOfItems || 0) > perPage;
+  const { numberOfItems, pagination = true } = options;
   const [paginationState, setPaginationState] = usePaginationState(options);
 
   const setPagination = useCallback(
@@ -49,7 +47,7 @@ const usePagination = (options = {}) => {
     [setPaginationState]
   );
 
-  return enablePagination && !(paginationState || {}).isDisabled
+  return pagination && !(paginationState || {}).isDisabled
     ? {
         toolbarProps: {
           pagination: {

--- a/src/Frameworks/AsyncTableTools/hooks/usePagination/usePagination.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/usePagination/usePagination.test.js
@@ -8,9 +8,13 @@ describe('usePagination', () => {
   const defaultOptions = {
     numberOfItems: 300,
   };
-  it('returns no paginate configuration by default', () => {
+
+  it('returns no paginate configuration by default if disabled', () => {
     const { result } = renderHook(
-      () => usePagination(),
+      () =>
+        usePagination({
+          pagination: false,
+        }),
       DEFAULT_RENDER_OPTIONS
     );
     expect(result.current).toEqual({});

--- a/src/Frameworks/AsyncTableTools/hooks/useTableState/helpers/compileState.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableState/helpers/compileState.js
@@ -1,12 +1,3 @@
-import merge from 'lodash/merge';
-import mergeWith from 'lodash/mergeWith';
-
-const preserveUndefinedCustomizer = (objValue, srcValue, key, obj) => {
-  if (objValue !== srcValue && typeof srcValue === 'undefined') {
-    obj[key] = srcValue;
-  }
-};
-
 const applySerialisers = (serialisers, newState) =>
   Object.entries(serialisers).reduce(
     (newSerialisedState, [serialiserNamespace, serialiser]) => {
@@ -56,11 +47,8 @@ const applyObservers = (namespace, observers, newState, currentState) => {
         ...applyNameSpaceObserver(
           stateKey,
           observers,
-          {
-            ...newState,
-            ...currentStateSnapshot,
-          },
-          currentState
+          currentStateSnapshot,
+          currentStateSnapshot
         ),
       }),
       {}
@@ -71,7 +59,7 @@ const applyObservers = (namespace, observers, newState, currentState) => {
     }
 
     return updateStateRecursively(
-      merge(currentStateSnapshot, nextStateChanges),
+      { ...currentStateSnapshot, ...nextStateChanges },
       nextStateChanges
     );
   };
@@ -81,11 +69,12 @@ const applyObservers = (namespace, observers, newState, currentState) => {
     newObserverStates
   );
 
-  return mergeWith(
-    currentState,
-    mergeWith(newState, finalObserverStates, preserveUndefinedCustomizer),
-    preserveUndefinedCustomizer
-  );
+  return {
+    ...currentState,
+    ...newState,
+    ...newObserverStates,
+    ...finalObserverStates,
+  };
 };
 
 const compileState = (

--- a/src/Frameworks/AsyncTableTools/hooks/useTableState/helpers/compileState.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableState/helpers/compileState.test.js
@@ -138,7 +138,8 @@ describe('compileState', function () {
             }),
           },
           view: {
-            pagination: () => ({
+            pagination: (currentState) => ({
+              ...currentState,
               isDisabled: false,
             }),
           },
@@ -175,6 +176,51 @@ describe('compileState', function () {
     ).toEqual({
       tableState: {
         items: undefined,
+      },
+    });
+  });
+
+  it('should not merge states themselves', () => {
+    expect(
+      compileState(
+        'items',
+        {
+          tableState: {
+            items: ['abc'],
+          },
+        },
+        ['def'],
+        {},
+        {}
+      )
+    ).toEqual({
+      tableState: {
+        items: ['def'],
+      },
+    });
+
+    expect(
+      compileState(
+        'filters',
+        {
+          tableState: {
+            filters: {
+              check: ['abc'],
+              apple: true,
+            },
+          },
+        },
+        {
+          apple: true,
+        },
+        {},
+        {}
+      )
+    ).toEqual({
+      tableState: {
+        filters: {
+          apple: true,
+        },
       },
     });
   });

--- a/src/Frameworks/AsyncTableTools/hooks/useTableState/useTableState.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableState/useTableState.js
@@ -39,13 +39,21 @@ const useTableState = (namespace, initialState, options = {}) => {
             ? newStateForNameSpace(currentState?.tableState?.[namespace])
             : newStateForNameSpace;
 
-        return compileState(
+        const nextState = compileState(
           namespace,
           currentState,
           newState,
           observers.current,
           serialisers.current
         );
+
+        console.group('State change by', namespace);
+        console.log('New state for namespace', newState);
+        console.log('Current state:', currentState?.tableState);
+        console.log('Next State:', nextState?.tableState);
+        console.groupEnd();
+
+        return nextState;
       });
     },
     [observers, serialisers, setState, namespace]

--- a/src/PresentationalComponents/ComplianceTable/serialisers.js
+++ b/src/PresentationalComponents/ComplianceTable/serialisers.js
@@ -91,4 +91,4 @@ export const filtersSerialiser = (state, filters) => {
  *
  */
 export const sortSerialiser = ({ index, direction } = {}, columns) =>
-  columns[index - 1]?.sortable && `${columns[index - 1].sortable}:${direction}`;
+  columns[index]?.sortable && `${columns[index].sortable}:${direction}`;

--- a/src/PresentationalComponents/ComplianceTable/serialisers.test.js
+++ b/src/PresentationalComponents/ComplianceTable/serialisers.test.js
@@ -90,7 +90,7 @@ describe('sortSerialiser', () => {
     expect(
       sortSerialiser(
         {
-          index: 1,
+          index: 0,
           direction: 'asc',
         },
         exampleColumns
@@ -100,7 +100,7 @@ describe('sortSerialiser', () => {
     expect(
       sortSerialiser(
         {
-          index: 2,
+          index: 1,
           direction: 'desc',
         },
         exampleColumns

--- a/src/PresentationalComponents/ReportsTable/Columns.js
+++ b/src/PresentationalComponents/ReportsTable/Columns.js
@@ -10,8 +10,7 @@ import {
 export const Name = {
   title: 'Policy',
   sortByProp: 'name',
-  // TODO this "sortBy" is an example to test the sortability to show in the AsyncTable for the sortSerialiser
-  sortable: 'name',
+  sortable: 'title',
   props: {
     width: 60,
   },
@@ -23,8 +22,7 @@ export const OperatingSystem = {
   title: 'Operating system',
   transforms: [fitContent],
   sortByProp: 'osMajorVersion',
-  // TODO same as with above "sortBy"
-  sortable: 'osMajorVersion',
+  sortable: 'os_major_version',
   props: {
     width: 20,
   },
@@ -35,6 +33,7 @@ export const OperatingSystem = {
 export const CompliantSystems = {
   title: 'Systems meeting compliance',
   transforms: [fitContent],
+  sortable: 'percent_compliant',
   sortByFunction: ({ testResultHostCount, compliantHostCount }) =>
     (100 / testResultHostCount) * compliantHostCount,
   props: {

--- a/src/PresentationalComponents/ReportsTable/Filters.js
+++ b/src/PresentationalComponents/ReportsTable/Filters.js
@@ -1,11 +1,10 @@
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
-// TODO unless this comment is removed, all "filterAttribute"s and "filterSerialiser"s in this file are examples!
 
 export const policyNameFilter = [
   {
     type: conditionalFilterType.text,
     label: 'Policy name',
-    filterAttribute: 'name',
+    filterAttribute: 'title',
     filter: (profiles, value) => {
       const lowerCaseValue = value.toLowerCase();
       return profiles.filter((profile) =>
@@ -22,7 +21,8 @@ export const policyTypeFilter = (policyTypes) => [
   {
     type: conditionalFilterType.checkbox,
     label: 'Policy type',
-    filterAttribute: 'policy_type',
+    // TODO profile_title needs to be added as scoped_search attribute for REST API
+    // filterAttribute: 'profile_title',
     filter: (profiles, values) =>
       profiles.filter(({ policyType }) => values.includes(policyType)),
     items: policyTypes.map((policyType) => ({
@@ -41,7 +41,7 @@ export const operatingSystemFilter = (operatingSystems) => [
       profiles.filter(({ osMajorVersion }) => values.includes(osMajorVersion)),
     items: operatingSystems.map((operatingSystem) => ({
       label: `RHEL ${operatingSystem}`,
-      value: operatingSystem,
+      value: `${operatingSystem}`,
     })),
   },
 ];
@@ -50,13 +50,14 @@ export const policyComplianceFilter = [
   {
     type: conditionalFilterType.checkbox,
     label: 'Systems meeting compliance',
-    filterSerialiser: (_, values) =>
-      values
-        .map((value) => {
-          const scoreRange = value.split('-');
-          return `compliance_score >= ${scoreRange[0]} and compliance_score <= ${scoreRange[1]}`;
-        })
-        .join(' OR '),
+    // TODO compliance_threshold needs to be added as a search attribute in the backend
+    // filterSerialiser: (_, values) =>
+    //   values
+    //     .map((value) => {
+    //       const scoreRange = value.split('-');
+    //       return `compliance_score >= ${scoreRange[0]} and compliance_score <= ${scoreRange[1]}`;
+    //     })
+    //     .join(' OR '),
     filter: (profiles, values) =>
       profiles.filter(({ testResultHostCount, compliantHostCount }) => {
         const compliantHostsPercent = Math.round(

--- a/src/PresentationalComponents/ReportsTable/ReportsTable.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.js
@@ -3,7 +3,6 @@ import propTypes from 'prop-types';
 import { COMPLIANCE_TABLE_DEFAULTS } from '@/constants';
 import { emptyRows } from '../../Utilities/hooks/useTableTools/Components/NoResultsTable';
 import { ComplianceTable as TableToolsTable } from 'PresentationalComponents';
-import { uniq } from 'Utilities/helpers';
 import columns, { exportableColumns, PDFExportDownload } from './Columns';
 import {
   policyNameFilter,
@@ -13,46 +12,50 @@ import {
 } from './Filters';
 import '../../App.scss';
 
-const ReportsTable = ({ reports }) => {
-  const policyTypes = uniq(
-    reports.map(({ policyType }) => policyType).filter((i) => !!i)
-  );
-  const operatingSystems = uniq(
-    reports.map(({ osMajorVersion }) => osMajorVersion).filter((i) => !!i)
-  );
-
-  return (
-    <TableToolsTable
-      aria-label="Reports"
-      ouiaId="ReportsTable"
-      columns={[...columns, PDFExportDownload]}
-      items={reports}
-      isStickyHeader
-      filters={{
-        filterConfig: [
-          ...policyNameFilter,
-          ...((policyTypes.length > 0 && policyTypeFilter(policyTypes)) || []),
-          ...((operatingSystems.length > 0 &&
-            operatingSystemFilter(operatingSystems)) ||
-            []),
-          ...policyComplianceFilter,
-        ],
-      }}
-      options={{
-        ...COMPLIANCE_TABLE_DEFAULTS,
-        exportable: {
-          ...COMPLIANCE_TABLE_DEFAULTS.exportable,
-          columns: exportableColumns,
-        },
-        emptyRows: emptyRows('reports', columns.length),
-      }}
-      className={'reports-table'}
-    />
-  );
-};
+const ReportsTable = ({
+  reports,
+  operatingSystems,
+  policyTypes,
+  options,
+  total,
+}) => (
+  <TableToolsTable
+    aria-label="Reports"
+    ouiaId="ReportsTable"
+    columns={[...columns, PDFExportDownload]}
+    items={reports}
+    total={total}
+    isStickyHeader
+    filters={{
+      filterConfig: [
+        ...policyNameFilter,
+        ...(policyTypes?.length > 0 ? policyTypeFilter(policyTypes) : []),
+        ...(operatingSystems?.length > 0
+          ? operatingSystemFilter(operatingSystems)
+          : []),
+        ...policyComplianceFilter,
+      ],
+    }}
+    options={{
+      ...COMPLIANCE_TABLE_DEFAULTS,
+      exportable: {
+        ...COMPLIANCE_TABLE_DEFAULTS.exportable,
+        columns: exportableColumns,
+      },
+      pagination: true,
+      emptyRows: emptyRows('reports', columns.length),
+      ...options,
+    }}
+    className={'reports-table'}
+  />
+);
 
 ReportsTable.propTypes = {
   reports: propTypes.array.isRequired,
+  total: propTypes.number,
+  operatingSystems: propTypes.array.isRequired,
+  policyTypes: propTypes.array.isRequired,
+  options: propTypes.object,
 };
 
 export default ReportsTable;

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -1,10 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import PageHeader, {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-
 import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable';
 import {
   ReportsTable,
@@ -12,13 +12,15 @@ import {
   StateViewWithError,
   ReportsEmptyState,
 } from 'PresentationalComponents';
-import TableStateProvider from '@/Frameworks/AsyncTableTools/components/TableStateProvider';
-import PropTypes from 'prop-types';
-import useReports from 'Utilities/hooks/api/useReports';
-import dataSerialiser from 'Utilities/dataSerialiser';
-import { QUERY } from './constants';
-import { reportDataMap as dataMap } from '../../constants';
 import GatedComponents from '@/PresentationalComponents/GatedComponents';
+import TableStateProvider from '@/Frameworks/AsyncTableTools/components/TableStateProvider';
+import useComplianceQuery from 'Utilities/hooks/api/useComplianceQuery';
+import useReportsOS from 'Utilities/hooks/api/useReportsOs';
+import dataSerialiser from 'Utilities/dataSerialiser';
+import { reportDataMap as dataMap } from '../../constants';
+import { uniq } from 'Utilities/helpers';
+import { QUERY } from './constants';
+import useReportsExporter from './hooks/useReportsExporter';
 
 const profilesFromEdges = (data) =>
   (data?.profiles?.edges || []).map((profile) => profile.node);
@@ -29,7 +31,7 @@ const ReportsHeader = () => (
   </PageHeader>
 );
 
-export const ReportsBase = ({ data, loading, error }) => {
+export const ReportsBase = ({ data, loading, error, operatingSystems }) => {
   const showView = data && data.length > 0;
   return (
     <>
@@ -42,7 +44,14 @@ export const ReportsBase = ({ data, loading, error }) => {
         </StateViewPart>
         <StateViewPart stateKey="data">
           <section className="pf-v5-c-page__main-section">
-            {showView ? <ReportsTable reports={data} /> : <ReportsEmptyState />}
+            {showView ? (
+              <ReportsTable
+                reports={data}
+                operatingSystems={operatingSystems}
+              />
+            ) : (
+              <ReportsEmptyState />
+            )}
           </section>
         </StateViewPart>
       </StateViewWithError>
@@ -52,6 +61,7 @@ export const ReportsBase = ({ data, loading, error }) => {
 
 ReportsBase.propTypes = {
   data: PropTypes.array,
+  operatingSystems: PropTypes.array,
   error: PropTypes.string,
   loading: PropTypes.bool,
 };
@@ -75,38 +85,85 @@ const ReportsWithGrahpQL = () => {
     error = undefined;
     loading = undefined;
   }
+  const operatingSystems =
+    data &&
+    uniq(
+      profiles?.map(({ osMajorVersion }) => osMajorVersion).filter((i) => !!i)
+    );
+  const policyTypes =
+    data &&
+    uniq(profiles?.map(({ policyType }) => policyType).filter((i) => !!i));
 
-  return <ReportsBase {...{ data: profiles, error, loading, refetch }} />;
+  return (
+    <ReportsBase
+      {...{
+        data: profiles,
+        operatingSystems,
+        policyTypes,
+        error,
+        loading,
+        refetch,
+      }}
+    />
+  );
 };
 
 const ReportsWithRest = () => {
-  const options = {
-    params: {
-      filter: 'with_reported_systems = true',
-    },
-  };
-  let { data: { data } = {}, error, loading, refetch } = useReports(options);
+  const { data: operatingSystems } = useReportsOS();
+  const {
+    data: { data: reportsData, meta: { total } = {} } = {},
+    fetch: fetchReports,
+    error,
+  } = useComplianceQuery('reports', {
+    params: { filter: 'with_reported_systems = true' },
+    useTableState: true,
+    debounced: false,
+  });
+  const fetchForExport = useCallback(
+    async (offset, limit) => await fetchReports({ offset, limit }, false),
+    [fetchReports]
+  );
+  const reportsExporter = useReportsExporter(fetchForExport);
+  const serialisedData = reportsData && dataSerialiser(reportsData, dataMap);
+  const data = operatingSystems;
+  const loading = !data ? true : undefined;
 
-  if (data) {
-    data = dataSerialiser(data, dataMap);
-    error = undefined;
-    loading = undefined;
-  }
-
-  return <ReportsBase {...{ data, error, loading, refetch }} />;
+  return (
+    <StateViewWithError stateValues={{ error, data, loading }}>
+      <StateViewPart stateKey="loading">
+        <section className="pf-v5-c-page__main-section">
+          <SkeletonTable colSize={3} rowSize={10} />
+        </section>
+      </StateViewPart>
+      <StateViewPart stateKey="data">
+        <ReportsHeader />
+        <section className="pf-v5-c-page__main-section">
+          <ReportsTable
+            reports={serialisedData}
+            operatingSystems={operatingSystems}
+            total={total}
+            options={{
+              exporter: async () =>
+                dataSerialiser(await reportsExporter(), dataMap),
+            }}
+          />
+        </section>
+      </StateViewPart>
+    </StateViewWithError>
+  );
 };
+
+const ReportsWithTableStateProvider = () => (
+  <TableStateProvider>
+    <ReportsWithRest />
+  </TableStateProvider>
+);
 
 const ReportsWrapper = () => (
   <GatedComponents
-    RestComponent={ReportsWithRest}
+    RestComponent={ReportsWithTableStateProvider}
     GraphQLComponent={ReportsWithGrahpQL}
   />
 );
 
-const ReportsWithTableStateProvider = () => (
-  <TableStateProvider>
-    <ReportsWrapper />
-  </TableStateProvider>
-);
-
-export default ReportsWithTableStateProvider;
+export default ReportsWrapper;

--- a/src/SmartComponents/Reports/Reports.test.js
+++ b/src/SmartComponents/Reports/Reports.test.js
@@ -7,7 +7,6 @@ import { profiles } from '@/__fixtures__/profiles.js';
 
 import useAPIV2FeatureFlag from '@/Utilities/hooks/useAPIV2FeatureFlag.js';
 import Reports from './Reports.js';
-import useReports from 'Utilities/hooks/api/useReports';
 
 jest.mock('@apollo/client');
 jest.mock('@/Utilities/hooks/useAPIV2FeatureFlag');
@@ -81,7 +80,7 @@ describe('Reports - REST', () => {
   });
 
   it('should use REST api', () => {
-    useReports.mockImplementation(() => ({
+    useQuery.mockImplementation(() => ({
       data: [],
       loading: false,
       error: null,
@@ -94,6 +93,6 @@ describe('Reports - REST', () => {
       </TestWrapper>
     );
 
-    expect(useReports).toHaveBeenCalled();
+    expect(useQuery).toHaveBeenCalled();
   });
 });

--- a/src/SmartComponents/Reports/hooks/useReportsExporter.js
+++ b/src/SmartComponents/Reports/hooks/useReportsExporter.js
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import pMap from 'p-map';
+
+const useReportsExporter = (fetchData, { batchSize = 10 } = {}) => {
+  const fetchExportData = useCallback(async () => {
+    const firstPage = await fetchData(0, batchSize);
+    const total = firstPage?.meta?.total;
+
+    if (total > batchSize) {
+      const pages = Math.ceil(total / batchSize) || 1;
+
+      const pagesParams = [...new Array(pages)]
+        .map((_, pageIdx) => {
+          const page = pageIdx;
+          if (page >= 1) {
+            const offset = page * batchSize;
+
+            return [offset, batchSize];
+          }
+        })
+        .filter((v) => !!v);
+      const fetchPage = ([offset, limit]) => fetchData(offset, limit);
+      const result = await pMap(pagesParams, fetchPage, { concurrency: 2 });
+
+      return [firstPage, ...result];
+    } else {
+      return [firstPage];
+    }
+  }, [fetchData, batchSize]);
+
+  const exporter = useCallback(
+    async () => (await fetchExportData()).flatMap((result) => result.data),
+    [fetchExportData]
+  );
+
+  return exporter;
+};
+
+export default useReportsExporter;

--- a/src/Utilities/hooks/api/useComplianceQuery.test.js
+++ b/src/Utilities/hooks/api/useComplianceQuery.test.js
@@ -110,7 +110,7 @@ describe('useComplianceQuery', () => {
       )
     );
 
-    act(() => result.current.sort.tableProps.onSort(null, 2, 'desc'));
+    act(() => result.current.sort.tableProps.onSort(null, 1, 'desc'));
 
     await waitFor(() =>
       expect(mockFakeApi).toHaveBeenNthCalledWith(3, expect.anything(), {

--- a/src/Utilities/hooks/useQuery/useQuery.js
+++ b/src/Utilities/hooks/useQuery/useQuery.js
@@ -106,7 +106,7 @@ const useQuery = (fn, options = {}) => {
     };
   }, [skip, params, typeof refetch !== 'undefined']);
 
-  return { data, error, loading: loading, fetch, refetch };
+  return { data, error, loading, fetch, refetch };
 };
 
 export default useQuery;


### PR DESCRIPTION
This PR extends the Reports page to not only use the REST API, but also use the table state provided by the `AsyncTableToolsTable`.

This can be reviewed and tested, but some changes from https://github.com/RedHatInsights/compliance-frontend/pull/2226 that allow passing params have already been included here, excluding the tests, so the tests for `useQuery` and `useComplianceQuery` will fail till #2226 is merged and this is rebased. 

~Sorting and pagination (with more than 10 reports) works as expected, however filters are not yet properly updating, most likely due to the issue with `compileState` mention in the tests[0].~ Fixed via https://github.com/RedHatInsights/compliance-frontend/pull/2243


[0] https://github.com/RedHatInsights/compliance-frontend/blob/master/src/Frameworks/AsyncTableTools/hooks/useTableState/helpers/compileState.test.js#L38


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
