### PR TITLE
fix(SystemsTable): Enable selection and refactor useSystemBulkSelect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30280,7 +30280,9 @@
       "version": "1.12.0"
     },
     "axios": {
-      "version": "1.7.2",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -40894,7 +40896,7 @@
         "ast-types": "^0.12.2",
         "hash-sum": "^1.0.2",
         "lru-cache": "^4.1.5",
-        "pug": "^2.0.3",
+        "pug": "^3.0.1",
         "recast": "^0.17.3",
         "ts-map": "^1.0.3",
         "typescript": "^3.2.2",

--- a/src/SmartComponents/SystemsTable/SystemsTableGraphQL.js
+++ b/src/SmartComponents/SystemsTable/SystemsTableGraphQL.js
@@ -54,7 +54,7 @@ export const SystemsTable = ({
   prependComponent,
   showOsMinorVersionFilter,
   preselectedSystems,
-  onSelect: onSelectProp,
+  onSelect,
   noSystemsTable,
   tableProps,
   ssgVersions,
@@ -67,7 +67,6 @@ export const SystemsTable = ({
   const [isLoaded, setIsLoaded] = useState(false);
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
-  const [perPage, setPerPage] = useState(50);
   const [currentTags, setCurrentTags] = useState([]);
   const navigateToInventory = useNavigate('inventory');
   const osMinorVersionFilter = useOsMinorVersionFilter(
@@ -131,22 +130,16 @@ export const SystemsTable = ({
     [constructedQuery, currentTags, systemsFilter, policyId]
   );
 
-  const preselection = useMemo(
-    () => preselectedSystems.map(({ id }) => id),
-    [preselectedSystems]
-  );
-
   const {
     selectedIds,
     tableProps: bulkSelectTableProps,
     toolbarProps: bulkSelectToolBarProps,
   } = useSystemBulkSelect({
     total,
-    perPage,
-    onSelect: onSelectProp,
-    preselected: preselection,
+    onSelect,
+    preselectedSystems,
     fetchArguments: systemFetchArguments,
-    currentPageIds: items.map(({ id }) => id),
+    currentPageItems: items,
   });
 
   useInventoryUtilities(inventory, selectedIds, activeFilterValues);
@@ -155,7 +148,6 @@ export const SystemsTable = ({
     (result) => {
       setTotal(result.meta.totalCount);
       setItems(result.entities);
-      setPerPage(result.perPage);
       setIsLoaded(true);
       setCurrentTags && setCurrentTags(result.meta.tags);
 

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -339,10 +339,13 @@ export const useSystemBulkSelect = ({
   const dispatch = useDispatch();
   const { isLoading, fetchBatched } = useFetchBatched();
   const apiV2Enabled = useAPIV2FeatureFlag();
-  const { loadedItems, addToLoadedItems, allLoaded } = useLoadedItems(
-    currentPageItems,
-    total
-  );
+  const { loadedItems, addToLoadedItems, resetLoadedItems, allLoaded } =
+    useLoadedItems(currentPageItems, total);
+
+  useEffect(() => {
+    resetLoadedItems();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(fetchArguments), resetLoadedItems]);
 
   const onError = useCallback((error) => {
     dispatchNotification({

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -1,9 +1,4 @@
-import React, {
-  useEffect,
-  useLayoutEffect,
-  useState,
-  useCallback,
-} from 'react';
+import React, { useEffect, useLayoutEffect, useCallback, useMemo } from 'react';
 import { useQuery } from '@apollo/client';
 import { useDispatch } from 'react-redux';
 import { Spinner } from '@patternfly/react-core';
@@ -25,6 +20,7 @@ import { useFetchSystems, useFetchSystemsV2 } from './hooks/useFetchSystems';
 import useAPIV2FeatureFlag from '../../Utilities/hooks/useAPIV2FeatureFlag';
 import useOperatingSystemsQuery from '../../Utilities/hooks/api/useOperatingSystems';
 import { buildOSObject } from '../../Utilities/helpers';
+import useLoadedItems from './hooks/useLoadedItems';
 
 const groupByMajorVersion = (versions = [], showFilter = []) => {
   const showVersion = (version) => {
@@ -335,16 +331,18 @@ export const useSystemsExport = ({
 export const useSystemBulkSelect = ({
   total,
   onSelect,
-  preselected,
+  preselectedSystems,
   fetchArguments,
-  currentPageIds,
-  dataMap,
+  currentPageItems,
+  fetchApi,
 }) => {
   const dispatch = useDispatch();
   const { isLoading, fetchBatched } = useFetchBatched();
-  const apiV2Enabled = false; //TODO: enable REST when the API implements ID search over endpoints. Use this hook => useAPIV2FeatureFlag();
-  // This is meant as a compatibility layer and to be removed
-  const [selectedSystems, setSelectedSystems] = useState([]);
+  const apiV2Enabled = useAPIV2FeatureFlag();
+  const { loadedItems, addToLoadedItems, allLoaded } = useLoadedItems(
+    currentPageItems,
+    total
+  );
 
   const onError = useCallback((error) => {
     dispatchNotification({
@@ -359,57 +357,61 @@ export const useSystemBulkSelect = ({
     onError,
   });
 
-  const fetchSystemsRest = useFetchSystemsV2({
-    dataMap,
-    systemFetchArguments: fetchArguments,
+  const fetchSystemsRest = useFetchSystemsV2(
+    fetchApi,
+    undefined,
     onError,
-  });
-
-  const fetchFunc = async (fetchIds) => {
-    if (fetchIds.length === 0) {
-      return [];
-    }
-
-    const idFilter = toIdFilter(fetchIds);
-    const results = await fetchBatched(
-      apiV2Enabled ? fetchSystemsRest : fetchSystemsGraphQL,
-      fetchIds.length,
-      {
-        ...(idFilter && { exclusiveFilter: idFilter }),
-      }
-    );
-
-    return results.flatMap((result) => result.entities);
-  };
+    fetchArguments
+  );
 
   const onSelectCallback = async (selectedIds) => {
     dispatch(setDisabledSelection(true));
-
-    const systems = await fetchFunc(selectedIds);
-    setSelectedSystems(systems);
-
+    const systemsSelection = loadedItems.filter(({ id }) =>
+      selectedIds.includes(id)
+    );
+    onSelect && onSelect(systemsSelection);
     dispatch(setDisabledSelection(false));
-    onSelect && onSelect(systems);
   };
+
+  const getItemsInTable = async () => {
+    let items = [];
+
+    if (allLoaded) {
+      items = loadedItems;
+    } else {
+      const results = await fetchBatched(
+        apiV2Enabled ? fetchSystemsRest : fetchSystemsGraphQL,
+        total
+      );
+      items = results.flatMap((result) => result.entities);
+      addToLoadedItems(items);
+    }
+
+    return items;
+  };
+
+  const preselected = useMemo(
+    () => preselectedSystems.map(({ id }) => id),
+    [preselectedSystems]
+  );
 
   const itemIdsInTable = async () => {
-    const results = await fetchBatched(
-      apiV2Enabled ? fetchSystemsRest : fetchSystemsGraphQL,
-      total
-    );
-    return results.flatMap((result) => result.entities.map(({ id }) => id));
+    const items = await getItemsInTable();
+
+    return items.map(({ id }) => id);
   };
+
+  const itemIdsOnPage = () => currentPageItems.map(({ id }) => id);
 
   const bulkSelect = useBulkSelect({
     total,
     onSelect: onSelectCallback,
     preselected,
     itemIdsInTable,
-    itemIdsOnPage: () => currentPageIds,
+    itemIdsOnPage,
   });
 
   return {
-    selectedSystems,
     ...bulkSelect,
     toolbarProps: {
       ...bulkSelect.toolbarProps,

--- a/src/SmartComponents/SystemsTable/hooks/useLoadedItems.js
+++ b/src/SmartComponents/SystemsTable/hooks/useLoadedItems.js
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useState } from 'react';
+import unionBy from '../../../Utilities/unionBy';
+
+const useLoadedItems = (currentPageItems, total, key = 'id') => {
+  const [loadedItems, setLoadedItems] = useState([]);
+  const [allLoaded, setAllLoaded] = useState(false); // to avoid unnecessary requests
+
+  const addToLoadedItems = useCallback(
+    (items) => {
+      setLoadedItems((loadedItems) => unionBy(items, loadedItems, key));
+    },
+    [key]
+  );
+
+  useEffect(() => {
+    setAllLoaded(total <= loadedItems.length);
+  }, [total, loadedItems]);
+
+  useEffect(() => {
+    addToLoadedItems(currentPageItems);
+  }, [currentPageItems, addToLoadedItems]);
+
+  return { loadedItems, addToLoadedItems, allLoaded };
+};
+
+export default useLoadedItems;

--- a/src/SmartComponents/SystemsTable/hooks/useLoadedItems.js
+++ b/src/SmartComponents/SystemsTable/hooks/useLoadedItems.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import unionBy from '../../../Utilities/unionBy';
+import debounce from '@redhat-cloud-services/frontend-components-utilities/debounce';
 
 const useLoadedItems = (currentPageItems, total, key = 'id') => {
   const [loadedItems, setLoadedItems] = useState([]);
@@ -12,6 +13,15 @@ const useLoadedItems = (currentPageItems, total, key = 'id') => {
     [key]
   );
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const resetLoadedItems = useCallback(
+    debounce(() => {
+      setLoadedItems([]);
+      setAllLoaded(false);
+    }, 200),
+    []
+  );
+
   useEffect(() => {
     setAllLoaded(total <= loadedItems.length);
   }, [total, loadedItems]);
@@ -20,7 +30,7 @@ const useLoadedItems = (currentPageItems, total, key = 'id') => {
     addToLoadedItems(currentPageItems);
   }, [currentPageItems, addToLoadedItems]);
 
-  return { loadedItems, addToLoadedItems, allLoaded };
+  return { loadedItems, addToLoadedItems, resetLoadedItems, allLoaded };
 };
 
 export default useLoadedItems;

--- a/src/SmartComponents/SystemsTable/hooks/useLoadedItems.test.js
+++ b/src/SmartComponents/SystemsTable/hooks/useLoadedItems.test.js
@@ -1,0 +1,62 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useLoadedItems from './useLoadedItems';
+
+describe('useLoadedItems', () => {
+  let loadedItems = [];
+
+  it('returns basic values', () => {
+    const { result } = renderHook(() => useLoadedItems(loadedItems, 50));
+
+    expect(result.current).toStrictEqual({
+      loadedItems: [],
+      addToLoadedItems: expect.anything(),
+      allLoaded: false,
+    });
+  });
+
+  it('returns basic values with loaded items', () => {
+    loadedItems = [{ id: 'abc' }];
+    const { result } = renderHook(() => useLoadedItems(loadedItems, 50));
+
+    expect(result.current).toStrictEqual({
+      loadedItems: [{ id: 'abc' }],
+      addToLoadedItems: expect.anything(),
+      allLoaded: false,
+    });
+  });
+
+  it('can update loaded items', async () => {
+    loadedItems = [{ id: 'abc' }];
+    const { result } = renderHook(() => useLoadedItems(loadedItems, 50));
+
+    act(() => {
+      result.current.addToLoadedItems([{ id: 'test' }]);
+    });
+
+    await waitFor(() => {
+      expect(result.current).toStrictEqual({
+        loadedItems: [{ id: 'test' }, { id: 'abc' }],
+        addToLoadedItems: expect.anything(),
+        allLoaded: false,
+      });
+    });
+  });
+
+  it('identifies if all items are loaded', async () => {
+    loadedItems = [{ id: 'abc' }];
+    const { result } = renderHook(() => useLoadedItems(loadedItems, 1));
+
+    await waitFor(() => {
+      expect(result.current.allLoaded).toBe(true);
+    });
+  });
+
+  it('identifies if not all items are loaded', async () => {
+    loadedItems = [{ id: 'abc' }];
+    const { result } = renderHook(() => useLoadedItems(loadedItems, 2));
+
+    await waitFor(() => {
+      expect(result.current.allLoaded).toBe(false);
+    });
+  });
+});

--- a/src/SmartComponents/SystemsTable/hooks/useLoadedItems.test.js
+++ b/src/SmartComponents/SystemsTable/hooks/useLoadedItems.test.js
@@ -10,6 +10,7 @@ describe('useLoadedItems', () => {
     expect(result.current).toStrictEqual({
       loadedItems: [],
       addToLoadedItems: expect.anything(),
+      resetLoadedItems: expect.anything(),
       allLoaded: false,
     });
   });
@@ -21,6 +22,7 @@ describe('useLoadedItems', () => {
     expect(result.current).toStrictEqual({
       loadedItems: [{ id: 'abc' }],
       addToLoadedItems: expect.anything(),
+      resetLoadedItems: expect.anything(),
       allLoaded: false,
     });
   });
@@ -37,6 +39,7 @@ describe('useLoadedItems', () => {
       expect(result.current).toStrictEqual({
         loadedItems: [{ id: 'test' }, { id: 'abc' }],
         addToLoadedItems: expect.anything(),
+        resetLoadedItems: expect.anything(),
         allLoaded: false,
       });
     });
@@ -57,6 +60,29 @@ describe('useLoadedItems', () => {
 
     await waitFor(() => {
       expect(result.current.allLoaded).toBe(false);
+    });
+  });
+
+  it('can reset loaded items', async () => {
+    loadedItems = [{ id: 'abc' }];
+    const { result } = renderHook(() => useLoadedItems(loadedItems, 1));
+
+    const {
+      loadedItems: resultLoadedItems,
+      resetLoadedItems,
+      allLoaded,
+    } = result.current;
+
+    expect(allLoaded).toBe(true);
+    expect(resultLoadedItems).toStrictEqual(loadedItems);
+    resetLoadedItems();
+
+    await waitFor(() => {
+      expect(result.current.allLoaded).toBe(false);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loadedItems).toStrictEqual([]);
     });
   });
 });

--- a/src/Utilities/unionBy.js
+++ b/src/Utilities/unionBy.js
@@ -1,0 +1,15 @@
+const unionBy = (arr, ...args) => {
+  let iteratee = args.pop();
+  if (typeof iteratee === 'string') {
+    const prop = iteratee;
+    iteratee = (item) => item[prop];
+  }
+
+  return arr
+    .concat(...args)
+    .filter(
+      (x, i, self) => i === self.findIndex((y) => iteratee(x) === iteratee(y))
+    );
+};
+
+export default unionBy;

--- a/src/Utilities/unionBy.test.js
+++ b/src/Utilities/unionBy.test.js
@@ -22,4 +22,18 @@ describe('unionBy', () => {
   it('union of two empty arrays', () => {
     expect(unionBy([], [], 'id')).toStrictEqual([]);
   });
+
+  it('union of two arrays with the same item', () => {
+    expect(unionBy([{ id: 1 }, { id: 2 }], [{ id: 2 }], 'id')).toStrictEqual([
+      { id: 1 },
+      { id: 2 },
+    ]);
+  });
+
+  it('union of just one array', () => {
+    expect(unionBy([{ id: 1 }, { id: 2 }], 'id')).toStrictEqual([
+      { id: 1 },
+      { id: 2 },
+    ]);
+  });
 });

--- a/src/Utilities/unionBy.test.js
+++ b/src/Utilities/unionBy.test.js
@@ -1,0 +1,25 @@
+import unionBy from './unionBy';
+
+describe('unionBy', () => {
+  it('union of basic array with string identifier', () => {
+    expect(unionBy([{ id: 1 }, { id: 2 }], [{ id: 3 }], 'id')).toStrictEqual([
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+    ]);
+  });
+
+  it('union of basic array with func identifier', () => {
+    expect(
+      unionBy([{ id: 1 }, { id: 2 }], [{ id: 3 }], (item) => item.id)
+    ).toStrictEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it('union of an empty and non-empty arrays', () => {
+    expect(unionBy([], [{ id: 3 }], 'id')).toStrictEqual([{ id: 3 }]);
+  });
+
+  it('union of two empty arrays', () => {
+    expect(unionBy([], [], 'id')).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-13404.

This enables selection in the Systems table when the REST API feature flag is set on. This also revisits useSystemBulkSelect and makes it cache the items fetched in the table. This way the table does the required minimum number of requests to REST API GET /systems when paginating or selecting all items.

## Test

### With REST API

Go to /systems, /reports/:id pages or open the /scappolicies/new (Create policy, the systems step) wizard and check that the selection works properly. The table shouldn't do unnecessary requests to GET /systems if the data is already loaded.

For example, if you have more than one page of systems and you select all via bulk select, unselecting and selecting back shouldn't trigger any new requests nor render a spinner.

### With GraphQL

No change in the behaviour is expected.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
