### PR TITLE
fix(CreateSCAPPolicyGraphQL): Return the "In use" label

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy/CreateSCAPPolicyGraphQL.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy/CreateSCAPPolicyGraphQL.js
@@ -13,13 +13,28 @@ const CreateSCAPPolicyGraphQL = ({
   const { data, error, loading } = useQuery(SUPPORTED_PROFILES, {
     fetchPolicy: 'no-cache',
   });
+
+  const isInUse = (profileRefId, benchmarkRedId) =>
+    !!data?.profiles?.edges
+      .map(({ node }) => node)
+      .find(
+        (profile) =>
+          profile.refId === profileRefId &&
+          benchmarkRedId === profile.benchmark.refId
+      );
+
   const availableOsMajorVersions = data?.osMajorVersions?.edges?.map(
     ({ node }) => node.osMajorVersion
   );
   const selectedOsMajorVersionObject = data?.osMajorVersions?.edges?.find(
     ({ node }) => node.osMajorVersion === selectedOsMajorVersion
   );
-  const availableProfiles = selectedOsMajorVersionObject?.node?.profiles;
+  const availableProfiles = selectedOsMajorVersionObject?.node?.profiles.map(
+    (profile) => ({
+      ...profile,
+      disabled: isInUse(profile.refId, profile.benchmark.refId),
+    })
+  );
 
   return (
     <CreateSCAPPolicyBase


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-12789.

After the last commits, we have accidentally removed the In use label which identifies the policy types that are already in use. Such policy types must be disabled when creating a new policy since the GraphQL doesn't support duplicates.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
