### PR TITLE
fix: empty state for PolicySystems tab

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -10,6 +10,7 @@ import useAPIV2FeatureFlag from '@/Utilities/hooks/useAPIV2FeatureFlag';
 import { systemsDataMapper } from '@/constants';
 import dataSerialiser from '@/Utilities/dataSerialiser';
 import { buildOSObject } from '@/Utilities/helpers';
+import NoResultsTable from '../../Utilities/hooks/useTableTools/Components/NoResultsTable';
 
 const fetchApi = (offset, limit, fetchArguments) =>
   apiInstance
@@ -54,7 +55,11 @@ const PolicySystemsTab = ({ policy }) => {
       showActions={false}
       remediationsEnabled={false}
       noSystemsTable={
-        policy?.hosts?.length === 0 && <NoSystemsTableWithWarning />
+        policy?.hosts?.length === 0 ? (
+          <NoSystemsTableWithWarning />
+        ) : (
+          <NoResultsTable kind="systems" />
+        )
       }
       complianceThreshold={policy.complianceThreshold}
       dedicatedAction={<EditSystemsButtonToolbarItem policy={policy} />}


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

This puts an empty state when customers filtering existing systems in Policy systems tab.

To test:
1. Navigate to Policy detail page
2. open systems tab
3. search for non-existing system
4. observe that an empty state exists

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
