### PR TITLE
fix(RHINENG-10400): Policy details systems minor fixes

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
+++ b/src/SmartComponents/PolicyDetails/PolicySystemsTab.js
@@ -51,11 +51,12 @@ const PolicySystemsTab = ({ policy }) => {
       ]}
       showOsMinorVersionFilter={[policy.osMajorVersion]}
       policyId={policy.id}
+      defaultFilter={apiV2Enabled ? null : `policy_id = ${policy.id}`}
       policyRefId={policy.refId}
       showActions={false}
       remediationsEnabled={false}
       noSystemsTable={
-        policy?.hosts?.length === 0 ? (
+        policy?.hosts?.length === 0 || policy?.totalHostCount === 0 ? (
           <NoSystemsTableWithWarning />
         ) : (
           <NoResultsTable kind="systems" />
@@ -78,6 +79,7 @@ PolicySystemsTab.propTypes = {
     osMajorVersion: propTypes.string.isRequired,
     hosts: propTypes.array.isRequired,
     refId: propTypes.string.isRequired,
+    totalHostCount: propTypes.number,
   }),
   dedicatedAction: propTypes.object,
   systemTableProps: propTypes.object,


### PR DESCRIPTION
This PR fixes 2 issues:

1. Getting `defaultFilter` back as it's needed for graphql to show systems correctly on PolicyDetails Systems tab when APIv2 FF is disabled (without this filter we show all Compliance systems, not only systems that are assigned to policy)
2. Checking `policy.totalHostCount` if it's 0 to show correct empty state as when we are using APIv2, we don't have policy.hosts.length info ( You can simply verify it by having APIv2 FF turned on and navigate to PolicyDetails Systems page and check that you can see empty state table when Policy has no systems assigned. See screenshot below )

![image](https://github.com/user-attachments/assets/6bea67b0-982a-4b9f-9f04-d0e0e2f412d6)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
