### PR TITLE
feat(RHINENG-12792): Migrate the Review (final) wizard step

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy/CreateSCAPPolicyRest.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy/CreateSCAPPolicyRest.js
@@ -7,11 +7,10 @@ import useSupportedProfiles from 'Utilities/hooks/api/useSupportedProfiles';
 import useSecurityGuidesOS from 'Utilities/hooks/api/useSecurityGuidesOS';
 
 const profilesDataMap = {
-  id: 'id',
+  id: ['id', 'benchmark.id'],
   description: 'description',
   title: 'name',
   ref_id: 'refId',
-  security_guide_id: 'benchmark.id',
   supportedOsVersions: 'supportedOsVersions',
 };
 

--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy/CreateSCAPPolicyRest.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy/CreateSCAPPolicyRest.js
@@ -57,7 +57,7 @@ const CreateSCAPPolicyRest = ({
             : {
                 availableOsMajorVersions,
                 availableProfiles: dataSerialiser(
-                  serialiseOsVersions(availableProfiles),
+                  serialiseOsVersions(availableProfiles?.data),
                   profilesDataMap
                 ),
               },

--- a/src/SmartComponents/CreatePolicy/CreateSCAPPolicy/CreateSCAPPolicyRest.test.js
+++ b/src/SmartComponents/CreatePolicy/CreateSCAPPolicy/CreateSCAPPolicyRest.test.js
@@ -92,7 +92,7 @@ describe('CreateSCAPPolicyRest', () => {
       error: undefined,
     });
     useSupportedProfiles.mockReturnValue({
-      data: [],
+      data: { data: [] },
       loading: false,
       error: undefined,
     });
@@ -116,7 +116,7 @@ describe('CreateSCAPPolicyRest', () => {
       error: undefined,
     });
     useSupportedProfiles.mockReturnValue({
-      data: supportedProfiles,
+      data: { data: supportedProfiles },
       loading: false,
       error: undefined,
     });
@@ -138,7 +138,7 @@ describe('CreateSCAPPolicyRest', () => {
       error: undefined,
     });
     useSupportedProfiles.mockReturnValue({
-      data: supportedProfiles,
+      data: { data: supportedProfiles },
       loading: false,
       error: undefined,
     });

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import useAPIV2FeatureFlag from '../../../Utilities/hooks/useAPIV2FeatureFlag';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import FinishedCreatePolicyRest from './FinishedCreatePolicyRest';
+import FinishedCreatePolicyGraphQL from './FinishedCreatePolicyGraphQL';
+
+const FinishedCreatePolicyWrapper = (props) => {
+  const apiV2Enabled = useAPIV2FeatureFlag();
+
+  return apiV2Enabled === undefined ? (
+    <Bullseye>
+      <Spinner />
+    </Bullseye>
+  ) : apiV2Enabled ? (
+    <FinishedCreatePolicyRest {...props} />
+  ) : (
+    <FinishedCreatePolicyGraphQL {...props} />
+  );
+};
+
+export default FinishedCreatePolicyWrapper;

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
@@ -4,7 +4,7 @@ import { Bullseye, Spinner } from '@patternfly/react-core';
 import FinishedCreatePolicyRest from './FinishedCreatePolicyRest';
 import FinishedCreatePolicyGraphQL from './FinishedCreatePolicyGraphQL';
 
-const FinishedCreatePolicyWrapper = (props) => {
+const FinishedCreatePolicy = (props) => {
   const apiV2Enabled = useAPIV2FeatureFlag();
 
   return apiV2Enabled === undefined ? (
@@ -18,4 +18,4 @@ const FinishedCreatePolicyWrapper = (props) => {
   );
 };
 
-export default FinishedCreatePolicyWrapper;
+export default FinishedCreatePolicy;

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.test.js
@@ -1,0 +1,45 @@
+import TestWrapper from '@redhat-cloud-services/frontend-components-utilities/TestingUtils/JestUtils/TestWrapper';
+import FinishedCreatePolicyRest from './FinishedCreatePolicyRest';
+import FinishedCreatePolicyGraphQL from './FinishedCreatePolicyGraphQL';
+import FinishedCreatePolicy from './FinishedCreatePolicy';
+import useAPIV2FeatureFlag from '../../../Utilities/hooks/useAPIV2FeatureFlag';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('./FinishedCreatePolicyRest');
+jest.mock('./FinishedCreatePolicyGraphQL');
+jest.mock('../../../Utilities/hooks/useAPIV2FeatureFlag');
+
+describe('FinishedCreatePolicy', () => {
+  it('renders the loading state when the flag is not yet fetched', () => {
+    useAPIV2FeatureFlag.mockReturnValue(undefined);
+    render(
+      <TestWrapper>
+        <FinishedCreatePolicy />
+      </TestWrapper>
+    );
+
+    screen.getByRole('progressbar');
+  });
+
+  it('renders the GraphQL component if the flag is off', () => {
+    useAPIV2FeatureFlag.mockReturnValue(false);
+    render(
+      <TestWrapper>
+        <FinishedCreatePolicy />
+      </TestWrapper>
+    );
+
+    expect(FinishedCreatePolicyGraphQL).toBeCalled();
+  });
+
+  it('renders the REST API component if the flag is on', () => {
+    useAPIV2FeatureFlag.mockReturnValue(true);
+    render(
+      <TestWrapper>
+        <FinishedCreatePolicy />
+      </TestWrapper>
+    );
+
+    expect(FinishedCreatePolicyRest).toBeCalled();
+  });
+});

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyBase.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyBase.js
@@ -22,7 +22,6 @@ import { reduxForm, formValueSelector } from 'redux-form';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withApollo } from '@apollo/client/react/hoc';
-import { usePolicy } from 'Mutations';
 import { dispatchNotification } from 'Utilities/Dispatcher';
 
 const EmptyStateWithErrors = ({ errors }) =>
@@ -40,7 +39,7 @@ EmptyStateWithErrors.propTypes = {
   errors: propTypes.array,
 };
 
-export const FinishedCreatePolicy = ({
+export const FinishedCreatePolicyBase = ({
   onWizardFinish,
   cloneFromProfileId,
   description,
@@ -52,12 +51,12 @@ export const FinishedCreatePolicy = ({
   systems,
   selectedRuleRefIds,
   ruleValues: values,
+  updatePolicy,
 }) => {
   const [percent, setPercent] = useState(0);
   const [message, setMessage] = useState('This usually takes a minute or two.');
   const [errors, setErrors] = useState(null);
   const [failed, setFailed] = useState(false);
-  const updatePolicy = usePolicy();
 
   const onProgress = (progress) => {
     setPercent(progress * 100);
@@ -146,7 +145,7 @@ export const FinishedCreatePolicy = ({
   );
 };
 
-FinishedCreatePolicy.propTypes = {
+FinishedCreatePolicyBase.propTypes = {
   benchmarkId: propTypes.string.isRequired,
   businessObjective: propTypes.object,
   cloneFromProfileId: propTypes.string.isRequired,
@@ -158,6 +157,7 @@ FinishedCreatePolicy.propTypes = {
   onWizardFinish: propTypes.func,
   selectedRuleRefIds: propTypes.arrayOf(propTypes.string).isRequired,
   ruleValues: propTypes.object,
+  updatePolicy: propTypes.func.isRequired,
 };
 
 export const selector = formValueSelector('policyForm');
@@ -184,4 +184,4 @@ export default compose(
     forceUnregisterOnUnmount: true,
   }),
   withApollo
-)(FinishedCreatePolicy);
+)(FinishedCreatePolicyBase);

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyGraphQL.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyGraphQL.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import FinishedCreatePolicyBase from './FinishedCreatePolicyBase';
+import { usePolicy } from '../../../Mutations';
+
+const FinishedCreatePolicyGraphQL = (props) => {
+  const updatePolicy = usePolicy();
+
+  return <FinishedCreatePolicyBase updatePolicy={updatePolicy} {...props} />;
+};
+
+export default FinishedCreatePolicyGraphQL;

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyGraphQL.test.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyGraphQL.test.js
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+import TestWrapper from '@redhat-cloud-services/frontend-components-utilities/TestingUtils/JestUtils/TestWrapper';
+import FinishedCreatePolicyGraphQL from './FinishedCreatePolicyGraphQL';
+import FinishedCreatePolicyBase from './FinishedCreatePolicyBase';
+import { usePolicy } from '../../../Mutations';
+
+jest.mock('./FinishedCreatePolicyBase', () => jest.fn());
+jest.mock('../../../Mutations');
+
+describe('FinishedCreatePolicyGraphQL', () => {
+  it('passes params to the base component', () => {
+    const params = { test: 'xyz' };
+    render(
+      <TestWrapper>
+        <FinishedCreatePolicyGraphQL {...params} />
+      </TestWrapper>
+    );
+
+    expect(FinishedCreatePolicyBase).toBeCalledWith(
+      {
+        ...params,
+      },
+      expect.anything()
+    );
+  });
+
+  it('uses update policy mutation', () => {
+    render(
+      <TestWrapper>
+        <FinishedCreatePolicyGraphQL />
+      </TestWrapper>
+    );
+
+    expect(usePolicy).toBeCalled();
+  });
+});

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import FinishedCreatePolicyBase from './FinishedCreatePolicyBase';
+import useCreatePolicy from '../../../Utilities/hooks/api/useCreatePolicy';
+import useAssignRules from '../../../Utilities/hooks/api/useAssignRules';
+import useAssignSystems from '../../../Utilities/hooks/api/useAssignSystems';
+
+const FinishedCreatePolicyRest = (props) => {
+  const createPolicy = useCreatePolicy();
+  const assignSystems = useAssignSystems();
+  const assingRules = useAssignRules();
+
+  const updatePolicy = async (_, newPolicy, onProgress) => {
+    console.log('### on updatePolicy', _, newPolicy, onProgress);
+  };
+
+  return <FinishedCreatePolicyBase updatePolicy={updatePolicy} {...props} />;
+};
+
+export default FinishedCreatePolicyRest;

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.js
@@ -3,9 +3,9 @@ import FinishedCreatePolicyBase from './FinishedCreatePolicyBase';
 import useCreatePolicy from '../../../Utilities/hooks/api/useCreatePolicy';
 import useAssignRules from '../../../Utilities/hooks/api/useAssignRules';
 import useAssignSystems from '../../../Utilities/hooks/api/useAssignSystems';
-import { useTailorings } from '../../../Utilities/hooks/api/useTailorings';
+import useTailorings from '../../../Utilities/hooks/api/useTailorings';
 
-const useUpdatePolicy = () => {
+export const useUpdatePolicy = () => {
   const { fetch: createPolicy } = useCreatePolicy({ skip: true });
   const { fetch: assignRules } = useAssignRules({ skip: true });
   const { fetch: assignSystems } = useAssignSystems({ skip: true });

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.js
@@ -1,17 +1,110 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import FinishedCreatePolicyBase from './FinishedCreatePolicyBase';
 import useCreatePolicy from '../../../Utilities/hooks/api/useCreatePolicy';
 import useAssignRules from '../../../Utilities/hooks/api/useAssignRules';
 import useAssignSystems from '../../../Utilities/hooks/api/useAssignSystems';
+import { useTailorings } from '../../../Utilities/hooks/api/useTailorings';
+
+const useUpdatePolicy = () => {
+  const { fetch: createPolicy } = useCreatePolicy({ skip: true });
+  const { fetch: assignRules } = useAssignRules({ skip: true });
+  const { fetch: assignSystems } = useAssignSystems({ skip: true });
+  const { fetch: fetchTailorings } = useTailorings({ skip: true });
+
+  const updatedPolicy = useCallback(
+    async (
+      _,
+      {
+        name,
+        description,
+        businessObjective,
+        complianceThreshold,
+        benchmarkId,
+        selectedRuleRefIds,
+        hosts,
+      },
+      onProgress
+    ) => {
+      const minorVersions = selectedRuleRefIds.map(
+        ({ osMinorVersion }) => osMinorVersion
+      );
+      const expectedUpdates = 3 + minorVersions.length;
+      let progress = 0;
+
+      const dispatchProgress = () => {
+        if (onProgress) {
+          onProgress(++progress / expectedUpdates);
+        }
+      };
+
+      const createPolicyResponse = await createPolicy(
+        [
+          undefined,
+          {
+            title: name,
+            description,
+            business_objective: businessObjective.title,
+            compliance_threshold: complianceThreshold,
+            profile_id: benchmarkId,
+          },
+        ],
+        false
+      );
+
+      dispatchProgress();
+
+      const { id: newPolicyId } = createPolicyResponse.data;
+
+      await assignSystems(
+        [newPolicyId, undefined, { ids: hosts.map(({ id }) => id) }],
+        false
+      );
+
+      dispatchProgress();
+
+      const fetchPolicyResponse = await fetchTailorings(
+        [
+          newPolicyId,
+          undefined,
+          100 /** to ensure we fetch all tailorings at once */,
+        ],
+        false
+      );
+      const tailorings = fetchPolicyResponse.data;
+
+      dispatchProgress();
+
+      tailorings.forEach(async (tailoring) => {
+        const rulesToAssign = selectedRuleRefIds.find(
+          ({ osMinorVersion }) =>
+            Number(osMinorVersion) === tailoring.os_minor_version
+        ).ruleRefIds;
+
+        await assignRules(
+          [
+            newPolicyId,
+            tailoring.id,
+            undefined,
+            {
+              ids: rulesToAssign,
+            },
+          ],
+          false
+        );
+
+        dispatchProgress();
+      });
+
+      return { id: newPolicyId };
+    },
+    [createPolicy, assignRules, assignSystems, fetchTailorings]
+  );
+
+  return updatedPolicy;
+};
 
 const FinishedCreatePolicyRest = (props) => {
-  const createPolicy = useCreatePolicy();
-  const assignSystems = useAssignSystems();
-  const assingRules = useAssignRules();
-
-  const updatePolicy = async (_, newPolicy, onProgress) => {
-    console.log('### on updatePolicy', _, newPolicy, onProgress);
-  };
+  const updatePolicy = useUpdatePolicy();
 
   return <FinishedCreatePolicyBase updatePolicy={updatePolicy} {...props} />;
 };

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.test.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.test.js
@@ -1,0 +1,145 @@
+import TestWrapper from '@redhat-cloud-services/frontend-components-utilities/TestingUtils/JestUtils/TestWrapper';
+import { render, renderHook } from '@testing-library/react';
+import FinishedCreatePolicyRest, {
+  useUpdatePolicy,
+} from './FinishedCreatePolicyRest';
+import useCreatePolicy from '../../../Utilities/hooks/api/useCreatePolicy';
+import useAssignRules from '../../../Utilities/hooks/api/useAssignRules';
+import useAssignSystems from '../../../Utilities/hooks/api/useAssignSystems';
+import useTailorings from '../../../Utilities/hooks/api/useTailorings';
+import FinishedCreatePolicyBase from './FinishedCreatePolicyBase';
+
+jest.mock('./FinishedCreatePolicyBase', () => jest.fn());
+jest.mock('../../../Utilities/hooks/api/useCreatePolicy');
+jest.mock('../../../Utilities/hooks/api/useAssignRules');
+jest.mock('../../../Utilities/hooks/api/useAssignSystems');
+jest.mock('../../../Utilities/hooks/api/useTailorings');
+
+describe('FinishedCreatePolicyRest', () => {
+  it('renders the base component with update policy callback', () => {
+    render(
+      <TestWrapper>
+        <FinishedCreatePolicyRest />
+      </TestWrapper>
+    );
+
+    expect(FinishedCreatePolicyBase).toBeCalledWith(
+      { updatePolicy: expect.anything() },
+      expect.anything()
+    );
+  });
+});
+
+describe('useUpdatePolicy', () => {
+  const createdPolicyId = '93529cba-c28e-4a29-8ac3-058689a0b7d1';
+  const createdTailoringId = '86412da4-ab6b-4783-82e3-74ee6a3cc270';
+
+  let createPolicy = jest.fn(() => ({
+    data: { id: createdPolicyId },
+  }));
+  let assignRules = jest.fn();
+  let assignSystems = jest.fn();
+  let fetchTailorings = jest.fn(() => ({
+    data: [{ id: createdTailoringId, os_minor_version: 7 }],
+  }));
+
+  useCreatePolicy.mockImplementation(() => ({ fetch: createPolicy }));
+  useAssignRules.mockImplementation(() => ({ fetch: assignRules }));
+  useAssignSystems.mockImplementation(() => ({ fetch: assignSystems }));
+  useTailorings.mockImplementation(() => ({ fetch: fetchTailorings }));
+
+  const onProgress = jest.fn();
+
+  afterEach(() => {
+    useCreatePolicy.mockClear();
+    useAssignRules.mockClear();
+    useAssignSystems.mockClear();
+    useTailorings.mockClear();
+    onProgress.mockClear();
+  });
+
+  const policyDataToSubmit = {
+    name: 'Some policy name',
+    description: 'Some policy description',
+    businessObjective: { title: 'Some defined business objective' },
+    complianceThreshold: 100,
+    benchmarkId: '4610092b-2e7f-4155-b101-964fede3566b',
+    selectedRuleRefIds: [
+      {
+        ruleRefIds: ['474129f9-1168-429e-833a-8d69e38284b8'],
+        osMinorVersion: 7,
+      },
+    ],
+    hosts: [{ id: '166ba579-20a6-436b-a712-5b1f5085a9eb' }],
+  };
+
+  it('calls create policy with the submitted data', async () => {
+    const { result } = renderHook(() => useUpdatePolicy());
+
+    await result.current(undefined, policyDataToSubmit, onProgress);
+
+    expect(createPolicy).toBeCalledWith(
+      [
+        undefined, // X-RH identity
+        {
+          business_objective: policyDataToSubmit.businessObjective.title,
+          compliance_threshold: policyDataToSubmit.complianceThreshold,
+          description: policyDataToSubmit.description,
+          profile_id: policyDataToSubmit.benchmarkId,
+          title: policyDataToSubmit.name,
+        },
+      ],
+      false // to return response data
+    );
+  });
+
+  it('assigns systems', async () => {
+    const { result } = renderHook(() => useUpdatePolicy());
+
+    await result.current(undefined, policyDataToSubmit, onProgress);
+
+    expect(assignSystems).toBeCalledWith(
+      [
+        createdPolicyId,
+        undefined, // X-RH identity
+        {
+          ids: policyDataToSubmit.hosts.map(({ id }) => id),
+        },
+      ],
+      false // to return response data
+    );
+  });
+
+  it('fetches tailorings and adds rules to these tailorings', async () => {
+    const { result } = renderHook(() => useUpdatePolicy());
+
+    await result.current(undefined, policyDataToSubmit, onProgress);
+
+    expect(fetchTailorings).toBeCalledWith(
+      [
+        createdPolicyId,
+        undefined, // X-RH identity
+        100,
+      ],
+      false // to return response data
+    );
+
+    expect(assignRules).toBeCalledWith(
+      [
+        createdPolicyId,
+        createdTailoringId,
+        undefined,
+        { ids: policyDataToSubmit.selectedRuleRefIds[0].ruleRefIds },
+      ],
+      false
+    );
+  });
+
+  it('updates progress', async () => {
+    const { result } = renderHook(() => useUpdatePolicy());
+
+    await result.current(undefined, policyDataToSubmit, onProgress);
+
+    expect(onProgress).toBeCalledTimes(4);
+  });
+});

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/index.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/index.js
@@ -1,0 +1,1 @@
+export { default } from './FinishedCreatePolicy';

--- a/src/Utilities/hooks/api/useAssignRules.js
+++ b/src/Utilities/hooks/api/useAssignRules.js
@@ -1,0 +1,7 @@
+import useQuery, { apiInstance } from '../useQuery';
+
+const useAssignRules = () => {
+  return useQuery(apiInstance.assignRules);
+};
+
+export default useAssignRules;

--- a/src/Utilities/hooks/api/useAssignRules.js
+++ b/src/Utilities/hooks/api/useAssignRules.js
@@ -1,7 +1,5 @@
-import useQuery, { apiInstance } from '../useQuery';
+import useComplianceQuery from './useComplianceQuery';
 
-const useAssignRules = () => {
-  return useQuery(apiInstance.assignRules);
-};
+const useAssignRules = (options) => useComplianceQuery('assignRules', options);
 
 export default useAssignRules;

--- a/src/Utilities/hooks/api/useAssignSystems.js
+++ b/src/Utilities/hooks/api/useAssignSystems.js
@@ -1,0 +1,7 @@
+import useQuery, { apiInstance } from '../useQuery';
+
+const useAssignSystems = () => {
+  return useQuery(apiInstance.assignSystems);
+};
+
+export default useAssignSystems;

--- a/src/Utilities/hooks/api/useAssignSystems.js
+++ b/src/Utilities/hooks/api/useAssignSystems.js
@@ -1,7 +1,6 @@
-import useQuery, { apiInstance } from '../useQuery';
+import useComplianceQuery from './useComplianceQuery';
 
-const useAssignSystems = () => {
-  return useQuery(apiInstance.assignSystems);
-};
+const useAssignSystems = (options) =>
+  useComplianceQuery('assignSystems', options);
 
 export default useAssignSystems;

--- a/src/Utilities/hooks/api/useCreatePolicy.js
+++ b/src/Utilities/hooks/api/useCreatePolicy.js
@@ -1,0 +1,7 @@
+import useQuery, { apiInstance } from '../useQuery';
+
+const useCreatePolicy = () => {
+  return useQuery(apiInstance.createPolicy);
+};
+
+export default useCreatePolicy;

--- a/src/Utilities/hooks/api/useCreatePolicy.js
+++ b/src/Utilities/hooks/api/useCreatePolicy.js
@@ -1,7 +1,6 @@
-import useQuery, { apiInstance } from '../useQuery';
+import useComplianceQuery from './useComplianceQuery';
 
-const useCreatePolicy = () => {
-  return useQuery(apiInstance.createPolicy);
-};
+const useCreatePolicy = (options) =>
+  useComplianceQuery('createPolicy', options);
 
 export default useCreatePolicy;


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-12792.

This decouples the FinishedCreatePolicy component into REST/GraphQL components depending on the feature flag set on/off respectively. `updatePolicy` for the REST component performs several steps to create a new policy: creates a policy using selected profile, assigns systems, fetches newly created tailorings and assigns rules to every tailoring.

## How to test

Go to the policies page and open a modal by clicking Create new policy. Choose any major OS, select a profile. Follow the systems and rules selections steps (these ones are not changed anyhow with this PR). In the final step, check that the overview contains correct OS selected, the number of systems and other details. Submit the creation and verify that the policy is successfully created. You should also get a link to the new policy page with the success notification.

## Screenshots
<img width="1346" alt="image" src="https://github.com/user-attachments/assets/793e495c-06b4-478f-a3d4-f5b95af8c479">

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
