### PR TITLE
fix(RHINENG-9785): Fix empty state icon size & spacing

### DIFF
--- a/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.js
+++ b/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.js
@@ -47,7 +47,12 @@ const ComplianceEmptyState = ({ title, mainButton, client }) => {
   const haveWord = policiesCount > 1 ? 'have' : 'has';
 
   return (
-    <EmptyState>
+    <EmptyState
+      style={{
+        '--pf-v5-c-empty-state__icon--FontSize':
+          'var(--pf-v5-c-empty-state--m-xl__icon--FontSize)',
+      }}
+    >
       <EmptyStateHeader
         titleText={<>{title}</>}
         icon={
@@ -56,8 +61,6 @@ const ComplianceEmptyState = ({ title, mainButton, client }) => {
               fontWeight: '500',
               color: 'var(--pf-v5-global--primary-color--100)',
             }}
-            size="xl"
-            title="Compliance"
             icon={CloudSecurityIcon}
           />
         }

--- a/src/SmartComponents/SystemDetails/NoReportsState.js
+++ b/src/SmartComponents/SystemDetails/NoReportsState.js
@@ -7,19 +7,21 @@ import {
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStateHeader,
-  EmptyStateFooter,
 } from '@patternfly/react-core';
 
 const NoReportsState = ({ system }) => (
   <Bullseye>
-    <EmptyState>
+    <EmptyState
+      style={{
+        '--pf-v5-c-empty-state__icon--FontSize':
+          'var(--pf-v5-c-empty-state--m-xl__icon--FontSize)',
+      }}
+    >
       <EmptyStateHeader
         titleText="No results reported"
         icon={
           <EmptyStateIcon
             icon={CloudSecurityIcon}
-            title="Compliance"
-            size="xl"
             style={{
               fontWeight: '500',
               color: 'var(--pf-v5-global--primary-color--100)',
@@ -33,12 +35,10 @@ const NoReportsState = ({ system }) => (
         {system?.policies?.length > 1 ? ' policies' : ' policy'}, but has not
         returned any results.
       </EmptyStateBody>
-      <EmptyStateFooter>
-        <EmptyStateBody>
-          Reports are returned when the system checks into Insights. By default,
-          systems check in every 24 hours.
-        </EmptyStateBody>
-      </EmptyStateFooter>
+      <EmptyStateBody>
+        Reports are returned when the system checks into Insights. By default,
+        systems check in every 24 hours.
+      </EmptyStateBody>
     </EmptyState>
   </Bullseye>
 );


### PR DESCRIPTION
PR fixes 2 things related to empty state:

1. Icon size - since Compliance had different icon size for some empty states I had to set it directly using `style` as it's not PF5 default size
2. Fixed spacing between empty state bodies

Before:
![image](https://github.com/user-attachments/assets/b0fd9fce-0718-4f8d-bb7f-a9f084005fd3)

After:
![image](https://github.com/user-attachments/assets/72311b37-acfa-41e4-bd90-dfc35a0983bd)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
