### PR TITLE
fix(RHINENG-10399): Get edit rules button back

### DIFF
--- a/src/SmartComponents/PolicyDetails/PolicyMultiversionRules.js
+++ b/src/SmartComponents/PolicyDetails/PolicyMultiversionRules.js
@@ -40,7 +40,9 @@ const PolicyMultiversionRules = ({
           )}
           columns={[Columns.Name, Columns.Severity, Columns.Remediation]}
           level={1}
-          DedicatedAction={DedicatedAction}
+          options={{
+            dedicatedAction: DedicatedAction,
+          }}
           ouiaId="RHELVersions"
         />
       </PageSection>


### PR DESCRIPTION
Our automation caught a bug when EditRules button disappeared from policy details Rules tab. This PR returns it back

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
