### PR TITLE
fix(RHINENG-14124): Make some queries work again v2

### DIFF
--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -85,7 +85,9 @@ CompliancePoliciesBase.propTypes = {
 };
 
 const CompliancePoliciesV2 = () => {
-  const query = usePolicies();
+  const query = usePolicies({
+    params: [undefined, 100],
+  });
 
   const data = query.data?.data
     ? {

--- a/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.js
+++ b/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.js
@@ -12,14 +12,19 @@ import { useParams } from 'react-router-dom';
 
 const SystemPolicyCard = ({ policy }) => {
   const { inventoryId } = useParams();
-  const { data, loading } = useReportTestResults({
-    params: {
-      reportId: policy.id,
-      filter: `system_id=${inventoryId}`,
-    },
+  const { data } = useReportTestResults({
+    params: [
+      policy.id,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `system_id=${inventoryId}`,
+    ],
   });
 
-  return loading ? (
+  return data === undefined ? (
     <LoadingPolicyCards count={1} />
   ) : data.meta.total === 0 ? (
     <React.Fragment />
@@ -42,10 +47,7 @@ SystemPolicyCard.propTypes = {
 export const SystemPolicyCards = () => {
   const { inventoryId } = useParams();
   const { data, loading } = useSystemReports({
-    params: {
-      systemId: inventoryId,
-      limit: 100,
-    },
+    params: [inventoryId, null, 100],
   });
 
   return (

--- a/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.test.js
+++ b/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.test.js
@@ -38,8 +38,7 @@ describe('SystemPolicyCards', () => {
       loading: false,
     }));
     useReportTestResults.mockImplementation(() => ({
-      data: null,
-      loading: true,
+      data: undefined, // indicates loading state
     }));
     render(<SystemPolicyCards />);
 
@@ -55,7 +54,6 @@ describe('SystemPolicyCards', () => {
     }));
     useReportTestResults.mockImplementation(() => ({
       data: { data: testResultsData, meta: { total: 1 } },
-      loading: false,
     }));
     render(<SystemPolicyCards />);
 
@@ -86,7 +84,7 @@ describe('SystemPolicyCards', () => {
     render(<SystemPolicyCards />);
 
     expect(useSystemReports).toBeCalledWith({
-      params: { limit: 100, systemId: 'abc' },
+      params: ['abc', null, 100],
     });
   });
 
@@ -96,16 +94,20 @@ describe('SystemPolicyCards', () => {
       loading: false,
     }));
     useReportTestResults.mockImplementation(() => ({
-      data: null,
-      loading: true,
+      data: undefined, // indicates loading state
     }));
     render(<SystemPolicyCards />);
 
     expect(useReportTestResults).toBeCalledWith({
-      params: {
-        filter: 'system_id=abc',
-        reportId: systemReportsData[0].id,
-      },
+      params: [
+        systemReportsData[0].id,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'system_id=abc',
+      ],
     });
   });
 
@@ -116,7 +118,6 @@ describe('SystemPolicyCards', () => {
     }));
     useReportTestResults.mockImplementation(() => ({
       data: { data: [], meta: { total: 0 } },
-      loading: false,
     }));
     render(<SystemPolicyCards />);
 


### PR DESCRIPTION
Some endponts broke after one of PRs as they do not support the keyword params.
No need to rely on loading parameter but we need to rely on data, discussed it with @bastilian 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
