### PR TITLE
fix(ReportDetails): os filtering use minor ver only

### DIFF
--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -206,7 +206,8 @@ const ReportDetailsBase = ({
                         Columns.ComplianceScore(true),
                         Columns.LastScanned,
                       ]}
-                      // showOsMinorVersionFilter={[profile.osMajorVersion]}
+                      showOsMinorVersionFilter={[profile.osMajorVersion]}
+                      ignoreOsMajorVersion
                       // ssgVersions={ssgVersions}
                       compliantFilter
                       ruleSeverityFilter


### PR DESCRIPTION
Before applying os_version filter we used major and minor versions and we get `["Invalid parameter: Field 'os_major_version' not recognized for searching!"]` because major ver filtering is not supported under reports/id/test_results as major version is constant.


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
