### PR TITLE
fix(useColumnManager): hide unmanageable columns from column manager

### DIFF
--- a/src/Frameworks/AsyncTableTools/__fixtures__/columns.js
+++ b/src/Frameworks/AsyncTableTools/__fixtures__/columns.js
@@ -44,10 +44,8 @@ export default [
   {
     title: 'Download button',
     key: 'download',
-    sortByProperty: 'severity',
-    sortByArray: severityLevels,
-    exportKey: 'severity',
     manageable: false,
-    renderFunc: () => <a href="#">Download</a>,
+    export: false,
+    renderFunc: () => 'download link',
   },
 ];

--- a/src/Frameworks/AsyncTableTools/__fixtures__/columns.js
+++ b/src/Frameworks/AsyncTableTools/__fixtures__/columns.js
@@ -41,4 +41,13 @@ export default [
     exportKey: 'severity',
     renderFunc: (_a, _b, item) => item.severity,
   },
+  {
+    title: 'Download button',
+    key: 'download',
+    sortByProperty: 'severity',
+    sortByArray: severityLevels,
+    exportKey: 'severity',
+    manageable: false,
+    renderFunc: () => <a href="#">Download</a>,
+  },
 ];

--- a/src/Frameworks/AsyncTableTools/__fixtures__/filters.js
+++ b/src/Frameworks/AsyncTableTools/__fixtures__/filters.js
@@ -1,0 +1,97 @@
+export const exampleFilters = [
+  {
+    type: 'text',
+    label: 'Name',
+    filterString: (value) => `name ~ ${value}`,
+  },
+  {
+    type: 'checkbox',
+    label: 'Compliance',
+    filterString: (value) => `compliant = ${value}`,
+    items: [
+      { label: 'Compliant', value: 'true' },
+      { label: 'Non-compliant', value: 'false' },
+    ],
+  },
+  {
+    type: 'checkbox',
+    label: 'Systems meeting compliance',
+    filterString: (value) => {
+      const scoreRange = value.split('-');
+      return `compliance_score >= ${scoreRange[0]} and compliance_score <= ${scoreRange[1]}`;
+    },
+    items: [
+      { label: '90 - 100%', value: '90-100' },
+      { label: '70 - 89%', value: '70-89' },
+      { label: '50 - 69%', value: '50-69' },
+      { label: 'Less than 50%', value: '0-49' },
+    ],
+  },
+];
+
+export default [
+  {
+    type: 'text',
+    label: 'Name',
+    filterAttribute: 'name',
+    filter: (items, value) =>
+      items.filter((item) => item?.name.includes(value)),
+  },
+  {
+    type: 'hidden',
+    label: 'Hidden filter',
+    filter: (items) => items,
+  },
+  {
+    type: 'checkbox',
+    label: 'Checkbox Filter',
+    filterAttribute: 'checkbox',
+    items: ['OPTION 1', 'OPTION 2', 'OPTION 3'].map((option) => ({
+      label: option,
+      value: `${option}-value`,
+    })),
+    filter: (items) => items,
+  },
+  {
+    type: 'radio',
+    label: 'Radio Filter',
+    filterAttribute: 'radio',
+    items: ['OPTION 1', 'OPTION 2', 'OPTION 3'].map((option) => ({
+      label: option,
+      value: `${option}-value`,
+    })),
+    filter: (items) => items,
+  },
+  {
+    type: 'UNKNOWNTYPE',
+    label: 'Invalid Filter',
+    items: ['OPTION 1', 'OPTION 2', 'OPTION 3'].map((option) => ({
+      label: option,
+      value: `${option}-value`,
+    })),
+    filter: (items) => items,
+  },
+  {
+    type: 'group',
+    label: 'Filter group',
+    items: [
+      {
+        label: 'Parent 1',
+        value: 1,
+        items: [
+          { label: 'Child 1', value: 1 },
+          { label: 'Child 2', value: 2 },
+        ],
+      },
+      {
+        label: 'Parent 2',
+        value: 2,
+        items: [
+          { label: 'Parent 2 Child 1', value: 1 },
+          { label: 'Parent 2 Child 2', value: 2 },
+        ],
+      },
+    ],
+    filter: () => [],
+  },
+];

--- a/src/Frameworks/AsyncTableTools/__fixtures__/items.js
+++ b/src/Frameworks/AsyncTableTools/__fixtures__/items.js
@@ -1,0 +1,16 @@
+export const severityLevels = ['high', 'medium', 'low', 'unknown'];
+
+export default (count) => {
+  let currentCount = 0;
+  return [...new Array(count > 0 ? count : 1)]
+    .map(() => {
+      currentCount++;
+      return {
+        id: currentCount,
+        severity: severityLevels[currentCount % 4],
+        name: 'TEST ITEM #' + currentCount,
+        description: 'DESCRIPTION',
+      };
+    })
+    .sort();
+};

--- a/src/Frameworks/AsyncTableTools/__fixtures__/tableTree.js
+++ b/src/Frameworks/AsyncTableTools/__fixtures__/tableTree.js
@@ -1,0 +1,59 @@
+import items from './items';
+
+export const exampleItems = items(30).map((item) => ({
+  ...item,
+  itemId: 'item-' + item.id,
+}));
+
+const item = (idx) => exampleItems[idx - 1].itemId;
+
+export default [
+  {
+    title: '1st Branch',
+    itemId: '1st-branch',
+    twigs: [
+      {
+        itemId: '1st-twig',
+        title: '1st Twig',
+        leaves: [item(1)],
+      },
+      {
+        itemId: '2nd-twig',
+        title: '2nd Twig',
+        leaves: [item(2), item(3)],
+      },
+    ],
+  },
+  {
+    title: '2nd Branch',
+    itemId: '2nd-branch',
+    twigs: [
+      {
+        itemId: '2nd-branch-1st-twig',
+        title: '2nd Branch 1st Twig',
+        leaves: [item(4)],
+      },
+      {
+        itemId: '2nd-branch-2nd-twig',
+        title: '2nd Branch 2nd Twig',
+        twigs: [
+          {
+            itemId: '2nd-branch-2nd-twig-1st-twig',
+            title: '2nd Branch 2nd Twig 1st Twig',
+            leaves: [item(5), item(6)],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: '3rd Branch',
+    itemId: '3rd-branch',
+    leaf: item(7),
+  },
+  {
+    title: '4th Branch',
+    itemId: '4th-branch',
+    leaves: [item(8)],
+  },
+];

--- a/src/Frameworks/AsyncTableTools/components/AsyncTableToolsTable/AsyncTableToolsTable.test.js
+++ b/src/Frameworks/AsyncTableTools/components/AsyncTableToolsTable/AsyncTableToolsTable.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import items from 'Utilities/hooks/useTableTools/__fixtures__/items';
+import items from '../../__fixtures__/items';
 
 import TableStateProvider from '../TableStateProvider';
 import AsyncTableToolsTable from './AsyncTableToolsTable';

--- a/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useAsyncTableTools.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useAsyncTableTools.test.js
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { DEFAULT_RENDER_OPTIONS } from '../../utils/testHelpers';
-import items from 'Utilities/hooks/useTableTools/__fixtures__/items';
-import columns from 'Utilities/hooks/useTableTools/__fixtures__/columns';
+import items from '../../__fixtures__/items';
+import columns from '../../__fixtures__/columns';
 
 import useAsyncTableTools from './useAsyncTableTools';
 

--- a/src/Frameworks/AsyncTableTools/hooks/useColumnManager/helper.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useColumnManager/helper.js
@@ -1,12 +1,8 @@
-export const getManagableColumns = (columns = []) =>
-  columns
-    .map((column) =>
-      column.manageable === undefined ? { ...column, manageable: true } : column
-    )
-    .filter((column) => column.manageable === true)
-    .map((column, idx) => ({
-      isUntoggleable: idx === 0,
-      isShownByDefault: true,
-      isShown: true,
-      ...column,
-    }));
+export const getFixedColumns = (columns = []) =>
+  columns.map((column, idx) => ({
+    manageable: column.manageable === undefined ? true : column.manageable,
+    isUntoggleable: idx === 0,
+    isShownByDefault: true,
+    isShown: true,
+    ...column,
+  }));

--- a/src/Frameworks/AsyncTableTools/hooks/useColumnManager/useColumnManager.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useColumnManager/useColumnManager.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, useMemo } from 'react';
 import { ColumnManagementModal } from '@patternfly/react-component-groups';
-import { getManagableColumns } from './helper';
+import { getFixedColumns } from './helper';
 
 /**
  *  @typedef {object} useColumnManagerReturn
@@ -30,11 +30,12 @@ const useColumnManager = (columns = [], options = {}) => {
     manageColumns: enableColumnManager,
     manageColumnLabel = 'Manage columns',
   } = options;
-  const managableColumns = useMemo(
-    () => getManagableColumns(columns),
-    [columns]
+  const fixedColumns = useMemo(() => getFixedColumns(columns), [columns]);
+  const manageableColumns = fixedColumns.filter(({ manageable }) => manageable);
+  const unManagableColumns = fixedColumns.filter(
+    ({ manageable }) => !manageable
   );
-  const [selectedColumns, setSelectedColumns] = useState(managableColumns);
+  const [selectedColumns, setSelectedColumns] = useState(manageableColumns);
   const [isManagerOpen, setIsManagerOpen] = useState(false);
 
   const onClick = useCallback(function innerClick() {
@@ -47,8 +48,11 @@ const useColumnManager = (columns = [], options = {}) => {
   }, []);
 
   const columnsToShow = useMemo(
-    () => selectedColumns.filter(({ isShown }) => isShown),
-    [selectedColumns]
+    () => [
+      ...selectedColumns.filter(({ isShown }) => isShown),
+      ...unManagableColumns,
+    ],
+    [selectedColumns, unManagableColumns]
   );
 
   const ColumnManager = useMemo(
@@ -74,6 +78,7 @@ const useColumnManager = (columns = [], options = {}) => {
           onClick,
         },
         ColumnManager,
+        applyColumns,
       }
     : { columns };
 };

--- a/src/Frameworks/AsyncTableTools/hooks/useColumnManager/useColumnManager.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useColumnManager/useColumnManager.test.js
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
-import columns from 'Utilities/hooks/useTableTools/__fixtures__/columns';
+import columns from '../../__fixtures__/columns';
+
 import useColumnManager from './useColumnManager';
 
 describe('useColumnManager', () => {

--- a/src/Frameworks/AsyncTableTools/hooks/useColumnManager/useColumnManager.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useColumnManager/useColumnManager.test.js
@@ -16,16 +16,24 @@ describe('useColumnManager', () => {
     expect(result.current.ColumnManager).toBeDefined();
   });
 
-  it.skip('applies columns', () => {
+  it('applies columns', () => {
     const { result } = renderHook(() => useColumnManager(...defaultArguments));
     const columnsToSelect = result.current.columns.filter(
       ({ key }) => key === 'desc'
     );
 
+    // Unmanageable columns are always visible in the table
+    const unManageableColumns = columns
+      .filter((col) => !col.manageable)
+      .map((col) => col.id);
+
     act(() => {
       result.current.applyColumns(columnsToSelect);
     });
 
-    expect(result.current.columns).toEqual(columnsToSelect);
+    const appliedIds = columnsToSelect.map((col) => col.id);
+    const resultIds = result.current.columns.map((col) => col.id);
+
+    expect(resultIds).toEqual([...appliedIds, ...unManageableColumns]);
   });
 });

--- a/src/Frameworks/AsyncTableTools/hooks/useFilterConfig/filterChipHelpers.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useFilterConfig/filterChipHelpers.test.js
@@ -1,4 +1,4 @@
-import filters from 'Utilities/hooks/useTableTools/__fixtures__/filters';
+import filters from '../../__fixtures__/filters';
 import { toDeselectValue, toFilterChips } from './filterChipHelpers';
 
 describe('toFilterChips', () => {

--- a/src/Frameworks/AsyncTableTools/hooks/useFilterConfig/useFilterConfig.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useFilterConfig/useFilterConfig.test.js
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { DEFAULT_RENDER_OPTIONS } from '../../utils/testHelpers';
-import filterConfig from 'Utilities/hooks/useTableTools/__fixtures__/filters';
+import filterConfig from '../../__fixtures__/filters';
 
 import useFilterConfig from './useFilterConfig';
 

--- a/src/Frameworks/AsyncTableTools/hooks/useItems/useItems.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useItems/useItems.test.js
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { DEFAULT_RENDER_OPTIONS } from '../../utils/testHelpers';
-import items from 'Utilities/hooks/useTableTools/__fixtures__/items';
+import items from '../../__fixtures__/items';
 
 import useItems from './useItems';
 

--- a/src/Frameworks/AsyncTableTools/hooks/useTableSort/useTableSort.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableSort/useTableSort.test.js
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { DEFAULT_RENDER_OPTIONS } from '../../utils/testHelpers';
-import columns from 'Utilities/hooks/useTableTools/__fixtures__/columns';
+import columns from '../../__fixtures__/columns';
 import { useSerialisedTableState } from '../useTableState';
 import useTableSort from './useTableSort';
 

--- a/src/Frameworks/AsyncTableTools/hooks/useTableView/useTableView.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableView/useTableView.test.js
@@ -2,9 +2,9 @@ import { renderHook, waitFor } from '@testing-library/react';
 import NoResultsTable from 'Utilities/hooks/useTableTools/Components/NoResultsTable';
 import { Spinner } from '@patternfly/react-core';
 
-import items from 'Utilities/hooks/useTableTools/__fixtures__/items';
-import columns from 'Utilities/hooks/useTableTools/__fixtures__/columns';
-import tableTree from 'Utilities/hooks/useTableTools/__fixtures__/tableTree';
+import items from '../../__fixtures__/items';
+import columns from '../../__fixtures__/columns';
+import tableTree from '../../__fixtures__/tableTree';
 
 import { DEFAULT_RENDER_OPTIONS } from '../../utils/testHelpers';
 import useItems from '../useItems';

--- a/src/Frameworks/AsyncTableTools/hooks/useTableView/views/treeChopper.test.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useTableView/views/treeChopper.test.js
@@ -1,6 +1,4 @@
-import tableTree, {
-  exampleItems,
-} from 'Utilities/hooks/useTableTools/__fixtures__/tableTree';
+import tableTree, { exampleItems } from '../../../__fixtures__/tableTree';
 
 import treeChopper from './treeChopper';
 

--- a/src/Frameworks/AsyncTableTools/utils/withExport/helpers.test.js
+++ b/src/Frameworks/AsyncTableTools/utils/withExport/helpers.test.js
@@ -1,14 +1,16 @@
-import items from '../../../../Utilities/hooks/useTableTools/__fixtures__/items';
-import columns from '../../../../Utilities/hooks/useTableTools/__fixtures__/columns';
+import items from '../../__fixtures__/items';
+import columns from '../../__fixtures__/columns';
 
-import { csvForItems, jsonForItems } from './helpers';
+import { csvForItems, exportableColumns, jsonForItems } from './helpers';
 
 const exampleItems = items(25);
+
+const filteredColumns = exportableColumns(columns);
 
 describe('jsonForItems', () => {
   it('returns an json export of items', () => {
     const result = jsonForItems({
-      columns,
+      columns: filteredColumns,
       items: exampleItems,
     });
 
@@ -19,7 +21,7 @@ describe('jsonForItems', () => {
 describe('csvForItems', () => {
   it('returns an csv export of items', () => {
     const result = csvForItems({
-      columns,
+      columns: filteredColumns,
       items: exampleItems,
     });
 

--- a/src/Frameworks/AsyncTableTools/utils/withExport/withExport.test.js
+++ b/src/Frameworks/AsyncTableTools/utils/withExport/withExport.test.js
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import withExport from './withExport';
-import items from '../../../../Utilities/hooks/useTableTools/__fixtures__/items';
-import columns from '../../../../Utilities/hooks/useTableTools/__fixtures__/columns';
+import items from '../../__fixtures__/items';
+import columns from '../../__fixtures__/columns';
 
 const exampleItems = items(25);
 

--- a/src/PresentationalComponents/ReportsTable/Columns.js
+++ b/src/PresentationalComponents/ReportsTable/Columns.js
@@ -53,7 +53,7 @@ export const CompliantSystems = {
 export const PDFExportDownload = {
   title: '',
   renderFunc: renderComponent(PDFExportDownloadCell),
-  managable: false,
+  manageable: false,
 };
 
 const PolicyType = {

--- a/src/Utilities/hooks/useTableTools/__fixtures__/columns.js
+++ b/src/Utilities/hooks/useTableTools/__fixtures__/columns.js
@@ -6,7 +6,7 @@ export default [
     sortByProperty: 'id',
     exportKey: 'id',
     key: 'id',
-    managable: false,
+    manageable: false,
   },
   {
     title: 'Name',
@@ -40,5 +40,14 @@ export default [
     sortByArray: severityLevels,
     exportKey: 'severity',
     renderFunc: (_a, _b, item) => item.severity,
+  },
+  {
+    title: 'Download button',
+    key: 'download',
+    sortByProperty: 'severity',
+    sortByArray: severityLevels,
+    exportKey: 'severity',
+    manageable: false,
+    renderFunc: () => <a href="#">Download</a>,
   },
 ];

--- a/src/Utilities/hooks/useTableTools/__snapshots__/useTableSort.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__snapshots__/useTableSort.test.js.snap
@@ -9,7 +9,7 @@ exports[`useTableSort returns a table sort configuration 1`] = `
         {
           "exportKey": "id",
           "key": "id",
-          "managable": false,
+          "manageable": false,
           "sortByProperty": "id",
           "title": "ID",
         },

--- a/src/Utilities/hooks/useTableTools/useColumnManager.js
+++ b/src/Utilities/hooks/useTableTools/useColumnManager.js
@@ -5,11 +5,13 @@ const filterColumnsBySelected = (columns, selected) =>
   columns.filter((column) => selected.includes(column.title));
 
 const useColumnManager = (columns = [], options = {}) => {
-  const managableColumns = columns
+  const manageableColumns = columns
     .map((column) =>
-      column?.managable === undefined ? { ...column, managable: true } : column
+      column?.manageable === undefined
+        ? { ...column, manageable: true }
+        : column
     )
-    .filter((column) => column.managable === true);
+    .filter((column) => column.manageable === true);
   const [selectedColumns, setSelectedColumns] = useState(
     columns.map(({ hiddenByDefault, title }) => !hiddenByDefault && title)
   );
@@ -33,7 +35,7 @@ const useColumnManager = (columns = [], options = {}) => {
         },
         ColumnManager: () => (
           <ColumnManager
-            columns={managableColumns}
+            columns={manageableColumns}
             isOpen={isManagerOpen}
             onClose={() => setIsManagerOpen(false)}
             selectedColumns={selectedColumns}


### PR DESCRIPTION
[RHINENG-14286](https://issues.redhat.com/browse/RHINENG-14286)

On the migrated Reports page in column manager, there is an additional field (its the download button)
![image](https://github.com/user-attachments/assets/7152bb68-4690-4062-aaa6-3f2f4ee32c18)

This PR removes it. The key stuff is in `useColumnManager.js` in `AsyncTableTools`.

Since there can be a difference in tests and the download button works **differently** there. I've copied fixtures to `AsyncTableTools` and all the tests use these ones instead the `TableTools` fixtures. Open for discussion, but it breaks the tabletools tests.

It's covered by tests.

## How to test:
1. Enable API V2 and Async Tables in local storage
Set `insights:compliance:apiv2` to `true`
Set `insights:compliance:asynctables` to `true`

2. Go to reports page
3. Check the column manager that the additional column isn't there
4. Verify the download button is in the table
5. Verify the download button **isn't** in the export
6. Play with the column manager
7. Do the same for GraphQL (just to be sure)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
