### PR TITLE
fix(RHINENG-14334): System detail shows empty GridItem

### DIFF
--- a/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.js
+++ b/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.js
@@ -24,15 +24,19 @@ const SystemPolicyCard = ({ policy }) => {
     ],
   });
 
-  return data === undefined ? (
-    <LoadingPolicyCards count={1} />
-  ) : data.meta.total === 0 ? (
-    <React.Fragment />
-  ) : (
-    <SystemPolicyCardPresentational
-      policy={dataSerialiser({ ...data.data[0], ...policy }, dataMap)}
-      style={{ height: '100%' }}
-    />
+  return (
+    data?.meta.total === 0 || (
+      <GridItem sm={12} md={12} lg={6} xl={4}>
+        {data === undefined ? (
+          <LoadingPolicyCards count={1} />
+        ) : (
+          <SystemPolicyCardPresentational
+            policy={dataSerialiser({ ...data.data[0], ...policy }, dataMap)}
+            style={{ height: '100%' }}
+          />
+        )}
+      </GridItem>
+    )
   );
 };
 
@@ -55,11 +59,15 @@ export const SystemPolicyCards = () => {
       {loading ? (
         <LoadingPolicyCards />
       ) : (
-        (data?.data || []).map((policy) => (
-          <GridItem sm={12} md={12} lg={6} xl={4} key={policy.id}>
-            <SystemPolicyCard policy={policy} inventoryId={inventoryId} />
-          </GridItem>
-        ))
+        (data?.data || []).map((policy) => {
+          return (
+            <SystemPolicyCard
+              policy={policy}
+              inventoryId={inventoryId}
+              key={policy.id}
+            />
+          );
+        })
       )}
     </Grid>
   );


### PR DESCRIPTION
There is the case when you have your system assigned to multiple policies but it's not reported against each policy - we will still try to show a card (you can see an GridItem - we show there an empty component). This is happening because we have multiple reports returned but some of them have 0 test results ( as system is never reported)

To repro:
- Go to Compliance -> Systems
- Find a system with multiple policies but at least one policy with 0   test results (data.meta.total === 0)

Before, the GridItem would render, but with no card.

![image](https://github.com/user-attachments/assets/1f17ed15-75e9-4975-a945-4e8d57474170)

Now, the GridItem has been moved into the child component and will only display the GridItem if the meta.total > 0.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
