### PR TITLE
fix(RHINENG-14376): filter systems correctly on Wizard

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -99,7 +99,7 @@ export const EditPolicySystems = ({
     ? apiV2Enabled
       ? `os_major_version = ${osMajorVersion} AND os_minor_version ^ (${osMinorVersions.join(
           ' '
-        )})`
+        )}) AND profile_ref_id !^ (${policy.refId})`
       : `os_major_version = ${osMajorVersion} AND os_minor_version ^ (${osMinorVersions.join(
           ','
         )})`


### PR DESCRIPTION
We need to have this additional filter that will prevent already assigned systems (to same policy) appear in system list. This is something new as with APIv2 we introduce ability to create duplicated policies. We don't want 1 system being assigned to 2-N same policies

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
