### PR TITLE
fix(RHINENG-14374): Put filter name in double quotes

### DIFF
--- a/src/Frameworks/AsyncTableTools/__fixtures__/filters.js
+++ b/src/Frameworks/AsyncTableTools/__fixtures__/filters.js
@@ -2,7 +2,7 @@ export const exampleFilters = [
   {
     type: 'text',
     label: 'Name',
-    filterString: (value) => `name ~ ${value}`,
+    filterString: (value) => `name ~ "${value}"`,
   },
   {
     type: 'checkbox',

--- a/src/SmartComponents/SystemsTable/SystemsTableRest.test.js
+++ b/src/SmartComponents/SystemsTable/SystemsTableRest.test.js
@@ -42,7 +42,7 @@ describe('SystemsTableRest', () => {
       expect(useSystemBulkSelect).toHaveBeenCalledWith(
         expect.objectContaining({
           fetchArguments: {
-            filter: '(someFilter ~ test) AND display_name ~ test-name',
+            filter: '(someFilter ~ test) AND display_name ~ "test-name"',
             tags: [],
           },
         })
@@ -52,7 +52,7 @@ describe('SystemsTableRest', () => {
     expect(useSystemsExport).toHaveBeenCalledWith(
       expect.objectContaining({
         fetchArguments: {
-          filter: '(someFilter ~ test) AND display_name ~ test-name',
+          filter: '(someFilter ~ test) AND display_name ~ "test-name"',
           tags: [],
         },
       })

--- a/src/SmartComponents/SystemsTable/constants.js
+++ b/src/SmartComponents/SystemsTable/constants.js
@@ -150,7 +150,7 @@ export const osFilterHandler = ({ osFilter }, ignoreOsMajorVersion) => {
 };
 
 export const nameFilterHandler = ({ hostnameOrId }) =>
-  hostnameOrId && `display_name ~ ${hostnameOrId}`;
+  hostnameOrId && `display_name ~ "${hostnameOrId}"`;
 
 export const applyInventoryFilters = (
   handlers,

--- a/src/constants.js
+++ b/src/constants.js
@@ -85,7 +85,7 @@ export const defaultSystemsFilterConfiguration = (
   {
     type: conditionalFilterType.text,
     label: 'Name',
-    filterString: (value) => `${filterKey} ~ ${value}`,
+    filterString: (value) => `${filterKey} ~ "${value}"`,
   },
 ];
 


### PR DESCRIPTION
if searching systems by name with the space - page fails because we are sending filter without quotes and backend thinks it's 2 parameters. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
