### PR TITLE
fix(RHINENG-14371): fix tabs ordering and 0 value

### DIFF
--- a/src/PresentationalComponents/TabbedRules/OsVersionText.js
+++ b/src/PresentationalComponents/TabbedRules/OsVersionText.js
@@ -1,6 +1,6 @@
 const OsVersionText = ({ profile, newOsMinorVersion }) =>
   `RHEL${'\u00A0'}${profile.osMajorVersion}.${
-    profile.osMinorVersion || newOsMinorVersion
+    profile.osMinorVersion != null ? profile.osMinorVersion : newOsMinorVersion
   }`;
 
 export default OsVersionText;

--- a/src/PresentationalComponents/Tailorings/Tailorings.js
+++ b/src/PresentationalComponents/Tailorings/Tailorings.js
@@ -111,7 +111,7 @@ const Tailorings = ({
       undefined,
       undefined,
       undefined,
-      undefined,
+      'os_minor_version:desc',
       'NOT(null? os_minor_version)',
     ],
     skip: !policy,


### PR DESCRIPTION
This one fixes rules tab ordering and treats `0` minor version correctly.
Before if you had minor version`0` you would see this:

![image](https://github.com/user-attachments/assets/dd1fb13e-118a-4688-8d14-7094044de2ef)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
