### PR TITLE
fix(rulesTable): Allow rules table to open multiple rule

### DIFF
--- a/src/PresentationalComponents/RulesTable/components/InlineValueEdit.js
+++ b/src/PresentationalComponents/RulesTable/components/InlineValueEdit.js
@@ -5,10 +5,10 @@ import { validatorFor, disableEdit } from '../helpers';
 
 const InlineValueEdit = ({ value, valueDefinition, ...props }) => (
   <p>
-    {valueDefinition.title}:{' '}
+    {valueDefinition?.title}:{' '}
     <InlineEdit
-      isDisabled={disableEdit(value || valueDefinition.defaultValue)}
-      defaultValue={valueDefinition.defaultValue}
+      isDisabled={disableEdit(value || valueDefinition?.defaultValue)}
+      defaultValue={valueDefinition?.defaultValue}
       validate={validatorFor(valueDefinition)}
       {...{ ...props, value }}
     />

--- a/src/PresentationalComponents/RulesTable/components/RuleValueEdit.js
+++ b/src/PresentationalComponents/RulesTable/components/RuleValueEdit.js
@@ -66,8 +66,8 @@ const RuleValueEdit = ({ rule, onValueChange, onRuleValueReset }) => {
             key={`rule-value-${idx}`}
             isOpen={editValues}
             value={
-              ruleValues?.[valueDefinition.id] ||
-              ruleValues?.[valueDefinition.refId]
+              ruleValues?.[valueDefinition?.id] ||
+              ruleValues?.[valueDefinition?.refId]
             }
             valueDefinition={valueDefinition}
             onSave={onValueSave(valueDefinition)}

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -107,6 +107,6 @@ const validators = {
 };
 
 export const validatorFor = (valueDefinition) =>
-  validators[valueDefinition.type] || (() => true);
+  validators[valueDefinition?.type] || (() => true);
 
 export const disableEdit = (value) => /(\n|\r|\\n|\\r)/.test(value);

--- a/src/SmartComponents/PolicyRules/PolicyRules.js
+++ b/src/SmartComponents/PolicyRules/PolicyRules.js
@@ -73,7 +73,6 @@ const PolicyRulesGraphQL = () => {
   );
 };
 
-//TODO: Data is currently hardcoded, once modals are migrated we can pass in IDs in TabHeader
 const PolicyRulesRest = () => {
   const tableState = useFullTableState();
   // const { policy_id: policyId, security_guide_id: securityGuideId } = useParams();


### PR DESCRIPTION
Rules Table was unable to open more than 2-4 rows without crashing. This just adds little checks and prevents the table from crashing. 

To test:
navigate to any rules table, rows view and open up multiple.
Rules table in policy details 
Rules table in default_ruleset reached from creatPolicy->rules step-> default rules link