### PR TITLE
fix(RHINENG-14516): Display BO empty value correctly

### DIFF
--- a/src/PresentationalComponents/ReportDetailsDescription/ReportDetailsDescription.js
+++ b/src/PresentationalComponents/ReportDetailsDescription/ReportDetailsDescription.js
@@ -43,9 +43,7 @@ const PolicyDescription = ({ profile }) => (
         passed for a system to be labeled "Compliant"`}
       </Dd>
       <Dt>Business objective</Dt>
-      <Dd>
-        {profile.businessObjective ? profile.businessObjective.title : '--'}
-      </Dd>
+      <Dd>{profile.businessObjective?.title || '--'}</Dd>
     </TextList>
     <Link to={'/scappolicies/' + profile.id}>View policy</Link>
   </React.Fragment>


### PR DESCRIPTION
We should show "--" when having business objective null. It wasn't working with APIv2 properly.

To test:
navigate to Report details page and ensure that Business objective shows "--" in case if it's not set and if it's set it shows correct value.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
