### PR TITLE
fix(RHINENG-14132): PDF download GQL when BO is set

### DIFF
--- a/src/SmartComponents/ReportDownload/Components/ReportPDF.js
+++ b/src/SmartComponents/ReportDownload/Components/ReportPDF.js
@@ -70,7 +70,7 @@ const ReportPDF = ({ data, ssgFinder }) => {
               ['Policy type', policy.policyType],
               ['Operating system', `RHEL ${policy.osMajorVersion}`],
               ['Compliance threshold', `${policy.complianceThreshold}%`],
-              ['Business Objective', policy.businessObjective || '--'],
+              ['Business Objective', policy.businessObjective?.title || '--'],
             ]}
           />
         </Column>

--- a/src/constants.js
+++ b/src/constants.js
@@ -358,7 +358,7 @@ export const policiesDataMapper = {
 export const reportDataMap = {
   id: 'id',
   title: 'policy.name;name',
-  business_objective: 'businessObjective',
+  business_objective: ['businessObjective', 'businessObjective.title'],
   compliance_threshold: 'complianceThreshold',
   os_major_version: 'osMajorVersion',
   profile_title: 'policyType', // REST api does not return policyType. Thus, re-using profile_title


### PR DESCRIPTION
PDF download was failing because of incorrect type mapping for business objective. 
How to reproduce issue:

1. Have a reported policy
2. Set business objective for policy
3. Navigate to reports page and try to download PDF report using GQL API (use stage/prod stable where we don't have v2 enabled)
4. Observe that backend requests are made and notifications about suceeded download appear but no download happens

With this fix it works again. Checked with REST v2 & GQL

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
