### PR TITLE
fix(RHINENG-14588): Fix the selection handling in edit systems

### DIFF
--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -99,7 +99,11 @@ SystemDetailsGraphQL.propTypes = {
 
 const SystemDetailsRest = ({ route }) => {
   const { inventoryId } = useParams();
-  let { data: { data } = {}, error, loading } = useSystem(inventoryId);
+  let {
+    data: { data } = {},
+    error,
+    loading,
+  } = useSystem({ params: [inventoryId] });
   const systemName = data?.display_name || inventoryId;
 
   useTitleEntity(route, systemName);

--- a/src/SmartComponents/SystemsTable/SystemsTableRest.js
+++ b/src/SmartComponents/SystemsTable/SystemsTableRest.js
@@ -60,7 +60,7 @@ export const SystemsTable = ({
   const inventory = useRef(null);
   const [isEmpty, setIsEmpty] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [items, setItems] = useState([]);
+  const [items, setItems] = useState();
   const [total, setTotal] = useState(0);
   const navigateToInventory = useNavigate('inventory');
   const [error, setError] = useState(errorProp);
@@ -110,6 +110,7 @@ export const SystemsTable = ({
     currentPageItems: items,
     fetchApi,
     apiV2Enabled: true,
+    tableLoaded: isLoaded,
   });
 
   useInventoryUtilities(inventory, selectedIds, activeFilterValues);

--- a/src/SmartComponents/SystemsTable/hooks/useLoadedItems.js
+++ b/src/SmartComponents/SystemsTable/hooks/useLoadedItems.js
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import unionBy from '../../../Utilities/unionBy';
-import debounce from '@redhat-cloud-services/frontend-components-utilities/debounce';
 
 const useLoadedItems = (currentPageItems, total, key = 'id') => {
-  const [loadedItems, setLoadedItems] = useState(currentPageItems);
+  const [loadedItems, setLoadedItems] = useState(currentPageItems || []);
   const [allLoaded, setAllLoaded] = useState(false); // to avoid unnecessary requests
 
   const addToLoadedItems = useCallback(
@@ -13,24 +12,15 @@ const useLoadedItems = (currentPageItems, total, key = 'id') => {
     [key]
   );
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const resetLoadedItems = useCallback(
-    debounce((newItems = []) => {
-      setLoadedItems(newItems);
-      setAllLoaded(total <= newItems.length);
-    }, 200),
-    []
-  );
-
   useEffect(() => {
     setAllLoaded(total <= loadedItems.length);
   }, [total, loadedItems]);
 
   useEffect(() => {
-    addToLoadedItems(currentPageItems);
+    addToLoadedItems(currentPageItems || []);
   }, [currentPageItems, addToLoadedItems]);
 
-  return { loadedItems, addToLoadedItems, resetLoadedItems, allLoaded };
+  return { loadedItems, addToLoadedItems, allLoaded };
 };
 
 export default useLoadedItems;

--- a/src/SmartComponents/SystemsTable/hooks/useLoadedItems.test.js
+++ b/src/SmartComponents/SystemsTable/hooks/useLoadedItems.test.js
@@ -10,7 +10,6 @@ describe('useLoadedItems', () => {
     expect(result.current).toStrictEqual({
       loadedItems: [],
       addToLoadedItems: expect.anything(),
-      resetLoadedItems: expect.anything(),
       allLoaded: false,
     });
   });
@@ -22,7 +21,6 @@ describe('useLoadedItems', () => {
     expect(result.current).toStrictEqual({
       loadedItems: [{ id: 'abc' }],
       addToLoadedItems: expect.anything(),
-      resetLoadedItems: expect.anything(),
       allLoaded: false,
     });
   });
@@ -39,7 +37,6 @@ describe('useLoadedItems', () => {
       expect(result.current).toStrictEqual({
         loadedItems: [{ id: 'test' }, { id: 'abc' }],
         addToLoadedItems: expect.anything(),
-        resetLoadedItems: expect.anything(),
         allLoaded: false,
       });
     });
@@ -60,29 +57,6 @@ describe('useLoadedItems', () => {
 
     await waitFor(() => {
       expect(result.current.allLoaded).toBe(false);
-    });
-  });
-
-  it('can reset loaded items', async () => {
-    loadedItems = [{ id: 'abc' }];
-    const { result } = renderHook(() => useLoadedItems(loadedItems, 1));
-
-    const {
-      loadedItems: resultLoadedItems,
-      resetLoadedItems,
-      allLoaded,
-    } = result.current;
-
-    expect(allLoaded).toBe(true);
-    expect(resultLoadedItems).toStrictEqual(loadedItems);
-    resetLoadedItems();
-
-    await waitFor(() => {
-      expect(result.current.allLoaded).toBe(false);
-    });
-
-    await waitFor(() => {
-      expect(result.current.loadedItems).toStrictEqual([]);
     });
   });
 });

--- a/src/Utilities/hooks/api/useSystem.js
+++ b/src/Utilities/hooks/api/useSystem.js
@@ -1,6 +1,5 @@
 import useComplianceQuery from './useComplianceQuery';
 
-const useSystem = (systemId, options) =>
-  useComplianceQuery('system', { params: [systemId], ...options });
+const useSystem = (options) => useComplianceQuery('system', options);
 
 export default useSystem;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-14588.

This addresses one of the bugs found in the edit policy modal, the systems tab. The problem was that the selection remembered only the items preselected on the first page.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
