### PR TITLE
fix(RHINENG-14513): Fix filter behavior

### DIFF
--- a/src/Frameworks/AsyncTableTools/__fixtures__/filters.js
+++ b/src/Frameworks/AsyncTableTools/__fixtures__/filters.js
@@ -18,7 +18,7 @@ export const exampleFilters = [
     label: 'Systems meeting compliance',
     filterString: (value) => {
       const scoreRange = value.split('-');
-      return `compliance_score >= ${scoreRange[0]} and compliance_score <= ${scoreRange[1]}`;
+      return `(percent_compliant >= ${scoreRange[0]} AND percent_compliant <= ${scoreRange[1]})`;
     },
     items: [
       { label: '90 - 100%', value: '90-100' },

--- a/src/PresentationalComponents/ReportsTable/Filters.js
+++ b/src/PresentationalComponents/ReportsTable/Filters.js
@@ -52,12 +52,12 @@ export const policyComplianceFilter = [
     label: 'Systems meeting compliance',
     filterAttribute: 'percent_compliant',
     filterSerialiser: (_, values) =>
-      values
+      `(${values
         .map((value) => {
           const scoreRange = value.split('-');
           return `(percent_compliant >= ${scoreRange[0]} AND percent_compliant <= ${scoreRange[1]})`;
         })
-        .join(' OR '),
+        .join(' OR ')})`,
     filter: (profiles, values) =>
       profiles.filter(({ testResultHostCount, compliantHostCount }) => {
         const compliantHostsPercent = Math.round(

--- a/src/PresentationalComponents/RulesTable/Filters.js
+++ b/src/PresentationalComponents/RulesTable/Filters.js
@@ -75,9 +75,9 @@ const RULE_STATE_FILTER_CONFIG = {
     { label: 'Failed rules', value: 'failed' },
   ],
   filterSerialiser: (_filterConfig, values) =>
-    values
+    `(${values
       .map((value) => `result = ${RULE_STATE_REST_SERIALISER[value]}`)
-      .join(' OR '),
+      .join(' OR ')})`,
   filter: (rules, values) =>
     anyFilterApply(
       rules,
@@ -106,7 +106,9 @@ export const ANSIBLE_SUPPORT_FILTER_CONFIG = {
     { label: 'No Ansible remediation support', value: 'false' },
   ],
   filterSerialiser: (_filterConfig, values) =>
-    values.map((value) => `remediation_available = ${value}`).join(' OR '),
+    `(${values
+      .map((value) => `remediation_available = ${value}`)
+      .join(' OR ')})`,
   filter: (rules, values) =>
     anyFilterApply(
       rules,

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -249,6 +249,7 @@ const ReportDetailsBase = ({
                         Columns.LastScanned,
                       ]}
                       defaultFilter={'never_reported = true'}
+                      ignoreOsMajorVersion
                       showGroupsFilter
                       apiV2Enabled={true}
                       reportId={id}

--- a/src/SmartComponents/SystemsTable/SystemsTableRest.js
+++ b/src/SmartComponents/SystemsTable/SystemsTableRest.js
@@ -22,8 +22,10 @@ import {
 } from './hooks';
 import { useFetchSystemsV2 } from './hooks/useFetchSystems';
 import {
+  defaultSystemsFilterConfiguration,
   complianceReportTableAdditionalFilter,
   compliantSystemFilterRestConfiguration,
+  DEFAULT_SYSTEMS_FILTER_CONFIGURATION_REST,
 } from '../../constants';
 
 export const SystemsTable = ({
@@ -73,6 +75,9 @@ export const SystemsTable = ({
   } = useFilterConfig({
     filters: {
       filterConfig: [
+        ...defaultSystemsFilterConfiguration(
+          DEFAULT_SYSTEMS_FILTER_CONFIGURATION_REST
+        ),
         ...(compliantFilter ? compliantSystemFilterRestConfiguration() : []),
         ...(policies?.length > 0 ? policyFilter(policies, showOsFilter) : []),
         ...(ssgVersions ? ssgVersionFilter(ssgVersions) : []),
@@ -210,7 +215,6 @@ export const SystemsTable = ({
           getEntities={getEntities}
           hideFilters={{
             all: true,
-            name: false,
             operatingSystem: false,
             tags: false,
             hostGroupFilteronCustomSelect: !showGroupsFilter,

--- a/src/SmartComponents/SystemsTable/constants.js
+++ b/src/SmartComponents/SystemsTable/constants.js
@@ -131,25 +131,30 @@ export const groupFilterHandler = ({ hostGroupFilter }) => {
 
 export const osFilterHandler = ({ osFilter }, ignoreOsMajorVersion) => {
   if (osFilter !== undefined && isPlainObject(osFilter)) {
-    const filterString = [];
+    const versionList = [];
+    const filterName = ignoreOsMajorVersion ? 'os_minor_version' : 'os_version';
     Object.entries(osFilter).forEach(([, osVersionGroups]) => {
       const selectedOsVersions = Object.entries(osVersionGroups);
-      selectedOsVersions.shift(); //first entry contains only major version, thus ignored
+      selectedOsVersions.shift(); // first entry contains only major version, thus ignored
 
       selectedOsVersions.forEach(([version, isSelected]) => {
         const parsedSemverVersion = coerce(version.split('-').pop() || null);
 
         if (valid(parsedSemverVersion) && isSelected) {
-          filterString.push(
-            !ignoreOsMajorVersion
-              ? `(os_major_version=${parsedSemverVersion.major} AND os_minor_version=${parsedSemverVersion.minor})`
-              : `os_minor_version=${parsedSemverVersion.minor}`
-          );
+          if (ignoreOsMajorVersion) {
+            versionList.push(`${parsedSemverVersion.minor}`);
+          } else {
+            versionList.push(
+              `${parsedSemverVersion.major}.${parsedSemverVersion.minor}`
+            );
+          }
         }
       });
     });
 
-    return filterString.join(' OR ');
+    return versionList.length > 0
+      ? `${filterName} ^ (${versionList.join(' ')})`
+      : '';
   }
 };
 

--- a/src/SmartComponents/SystemsTable/hooks.test.js
+++ b/src/SmartComponents/SystemsTable/hooks.test.js
@@ -214,7 +214,7 @@ describe('useGetEntities', () => {
         },
       });
       expect(mockFetch).toHaveBeenCalledWith(10, 1, {
-        filter: '(os_major_version=8 AND os_minor_version=4)',
+        filter: 'os_version ^ (8.4)',
         sortBy: ['nameAttribute:ASC'],
       });
     });
@@ -245,8 +245,7 @@ describe('useGetEntities', () => {
         },
       });
       expect(mockFetch).toHaveBeenCalledWith(10, 1, {
-        filter:
-          '(group_name = "test-group") AND (os_major_version=8 AND os_minor_version=4)',
+        filter: '(group_name = "test-group") AND os_version ^ (8.4)',
         sortBy: ['nameAttribute:ASC'],
       });
     });

--- a/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterBuilder.js
+++ b/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterBuilder.js
@@ -35,8 +35,11 @@ class FilterBuilder {
     const moreThanTwo =
       filterStringArray.map((f) => f.length).filter((fl) => fl > 0).length >= 2;
     return filterStringArray
-      .map((fs) => fs.join(' or '))
-      .join(moreThanTwo ? ' and ' : '');
+      .map((fs) => {
+        // Wrap `OR` groups in parentheses
+        return fs.length > 1 ? `(${fs.join(' OR ')})` : fs[0];
+      })
+      .join(moreThanTwo ? ' AND ' : '');
   };
 
   buildFilterString = (filters) => {

--- a/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterBuilder.test.js
+++ b/src/Utilities/hooks/useTableTools/FilterConfigBuilder/FilterBuilder.test.js
@@ -70,7 +70,7 @@ describe('buildFilterString', () => {
           compliancescore: ['0-50', '50-70'],
         })
       ).toEqual(
-        '(compliance_score >= 0 and compliance_score < 50) or (compliance_score >= 50 and compliance_score < 70)'
+        '((compliance_score >= 0 and compliance_score < 50) OR (compliance_score >= 50 and compliance_score < 70))'
       );
 
       expect(
@@ -79,7 +79,7 @@ describe('buildFilterString', () => {
           compliance: ['compliant=true'],
         })
       ).toEqual(
-        'compliant=true and (compliance_score >= 90 and compliance_score < 101) or (compliance_score >= 70 and compliance_score < 90)'
+        'compliant=true AND ((compliance_score >= 90 and compliance_score < 101) OR (compliance_score >= 70 and compliance_score < 90))'
       );
     });
 
@@ -92,7 +92,9 @@ describe('buildFilterString', () => {
         builder.buildFilterString({
           compliancescore: ['0-50', '50-70'],
         })
-      ).toEqual('(score >= 0 and score < 50) or (score >= 50 and score < 70)');
+      ).toEqual(
+        '((score >= 0 and score < 50) OR (score >= 50 and score < 70))'
+      );
 
       expect(
         builder.buildFilterString({
@@ -100,7 +102,7 @@ describe('buildFilterString', () => {
           compliance: ['compliant=true'],
         })
       ).toEqual(
-        'compliant=true and (score >= 90 and score < 101) or (score >= 70 and score < 90)'
+        'compliant=true AND ((score >= 90 and score < 101) OR (score >= 70 and score < 90))'
       );
     });
   });

--- a/src/Utilities/hooks/useTableTools/FilterConfigBuilder/__snapshots__/FilterBuilder.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/FilterConfigBuilder/__snapshots__/FilterBuilder.test.js.snap
@@ -4,6 +4,6 @@ exports[`buildFilterString filter building returns a base filter for name when s
 
 exports[`buildFilterString filter building returns a filter for compliant 1`] = `"compliant = true"`;
 
-exports[`buildFilterString filter building returns a filter for scores 1`] = `"compliance_score >= 0 and compliance_score <= 49 or compliance_score >= 50 and compliance_score <= 69"`;
+exports[`buildFilterString filter building returns a filter for scores 1`] = `"(compliance_score >= 0 and compliance_score <= 49 OR compliance_score >= 50 and compliance_score <= 69)"`;
 
-exports[`buildFilterString returns a filterstring 1`] = `"name ~ Name and compliant = true"`;
+exports[`buildFilterString returns a filterstring 1`] = `"name ~ Name AND compliant = true"`;

--- a/src/constants.js
+++ b/src/constants.js
@@ -148,7 +148,7 @@ const emptyFilterDropDownItem = {
 
 export const systemsOsMinorFilterConfiguration = (osMajorVersions) => {
   const filterString = (value) => [
-    Object.keys(value)
+    `(${Object.keys(value)
       .flatMap((majorVersion) =>
         Object.keys(value[majorVersion]).map(
           (minorVersion) =>
@@ -157,7 +157,7 @@ export const systemsOsMinorFilterConfiguration = (osMajorVersions) => {
         )
       )
       .filter((v) => !!v)
-      .join(' OR '),
+      .join(' OR ')})`,
   ];
   const osVersions = sortBy(Object.keys(osMajorVersions).map(Number)).reverse();
 
@@ -275,7 +275,7 @@ export const complianceReportTableAdditionalFilter = (
   {
     type: conditionalFilterType.checkbox,
     label: 'Failed rule severity',
-    filterString: (value) => `${filterKey} ^ (${value})`,
+    filterString: (value) => `${filterKey} = ${value}`,
     items: [
       { label: HIGH_SEVERITY, value: 'high' },
       { label: MEDIUM_SEVERITY, value: 'medium' },


### PR DESCRIPTION
This PR does couple things:

1. Set 'Name' filter as default for system table (before you could see different filters)
2. Wraps checkbox filter items in brackets when filter is selected. For example, `filter=display_name ~ "fdsf" AND (policies = ... OR policies=....)` so filter order doesn't affect sorting and it applied correctly
3. `os_version` filtering is used. So instead of sending request with `filter=(os_major_version=7 AND os_minor_version=8) OR (os_major_version=7 AND os_minor_version=9)` we will send `filter=os_version ^ (7.8 7.9)`
4. Fixed os_version filtering on Report details page for Not reported systems tab



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
