### PR TITLE
fix(RHINENG-14527): Enable value editing when creating a SCAP policy

### DIFF
--- a/src/PresentationalComponents/InlineEdit/InlineEdit.js
+++ b/src/PresentationalComponents/InlineEdit/InlineEdit.js
@@ -43,16 +43,21 @@ const InlineEdit = ({
     }
   };
 
-  const handleCloseEdit = () => {
-    setValue(valueProp || defaultValue);
+  const onCloseEdit = async () => {
+    setSaving(true);
+    const value = valueProp || defaultValue;
+    setValue(value);
+    await onSaveProp?.(value);
     // setDirty(false);
     setOpen(false);
+    setSaving(false);
   };
 
-  const onSave = () => {
+  const onSave = async () => {
     setSaving(true);
     // setDirty(false);
-    onSaveProp?.(value);
+    await onSaveProp?.(value);
+    setSaving(false);
   };
 
   useEffect(() => {
@@ -123,7 +128,7 @@ const InlineEdit = ({
                   type="button"
                   aria-label="Cancel edits"
                   ouiaId="CancelEdits"
-                  onClick={handleCloseEdit}
+                  onClick={onCloseEdit}
                   style={{ 'margin-left': '5px' }}
                 >
                   <TimesIcon />

--- a/src/PresentationalComponents/InlineEdit/InlineEdit.js
+++ b/src/PresentationalComponents/InlineEdit/InlineEdit.js
@@ -57,6 +57,7 @@ const InlineEdit = ({
     setSaving(true);
     // setDirty(false);
     await onSaveProp?.(value);
+    setOpen(false);
     setSaving(false);
   };
 

--- a/src/PresentationalComponents/RulesTable/RulesTableRest.js
+++ b/src/PresentationalComponents/RulesTable/RulesTableRest.js
@@ -56,7 +56,7 @@ const RulesTable = ({
   );
 
   const DetailsRow = useMemo(() => {
-    const Row = (props) => {
+    function Row(props) {
       // eslint-disable-next-line react/prop-types
       const { itemId, valueDefinitions } = props?.item || {};
 
@@ -91,7 +91,7 @@ const RulesTable = ({
           item={item}
         />
       );
-    };
+    }
 
     return Row;
   }, [

--- a/src/PresentationalComponents/Tailorings/components/TailoringTab.js
+++ b/src/PresentationalComponents/Tailorings/components/TailoringTab.js
@@ -141,7 +141,12 @@ const TailoringTab = ({
         setRuleValues={setRuleValues}
         // TODO Doublecheck if we should set default profile value_override values when creating a policy
         ruleValues={tailoring?.value_overrides || {}}
-        valueDefinitions={valueDefinitions?.data}
+        valueDefinitions={{
+          data: valueDefinitions?.data,
+          loading:
+            shouldSkip.securityGuide.valueDefinitions === false &&
+            valueDefinitions === undefined,
+        }}
         onRuleValueReset={onRuleValueReset}
         onValueOverrideSave={onValueSave}
         onSelect={

--- a/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
@@ -39,6 +39,7 @@ EditPolicyProfilesRules.propTypes = {
   ),
   selectedRuleRefIds: propTypes.array,
   ruleValues: propTypes.array,
+  valueOverrides: propTypes.object,
 };
 
 const selector = formValueSelector('policyForm');
@@ -50,6 +51,7 @@ export default compose(
     osMinorVersionCounts: selector(state, 'osMinorVersionCounts'),
     selectedRuleRefIds: selector(state, 'selectedRuleRefIds'),
     ruleValues: selector(state, 'ruleValues'),
+    valueOverrides: selector(state, 'valueOverrides'),
   })),
   reduxForm({
     form: 'policyForm',

--- a/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRulesRest.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRulesRest.js
@@ -27,6 +27,7 @@ export const EditPolicyProfilesRulesRest = ({
   change,
   osMajorVersion,
   osMinorVersionCounts,
+  valueOverrides = {},
 }) => {
   const preselected =
     selectedRuleRefIds &&
@@ -104,6 +105,31 @@ export const EditPolicyProfilesRulesRest = ({
     }
   }, [change, osMinorVersionCounts, profilesAndRuleIds, selectedRuleRefIds]);
 
+  const onValueOverrideSave = (
+    _policy,
+    osMinorVersion,
+    valueDefinition,
+    valueOverrideValue,
+    closeInlineEdit
+  ) => {
+    let valueOverridesUpdated = structuredClone(valueOverrides);
+
+    if (valueOverrideValue === '' || valueOverrideValue === undefined) {
+      delete valueOverridesUpdated?.[osMinorVersion]?.[valueDefinition.id];
+    } else {
+      valueOverridesUpdated = {
+        ...valueOverrides,
+        [osMinorVersion]: {
+          ...valueOverrides[osMinorVersion],
+          [valueDefinition.id]: valueOverrideValue,
+        },
+      };
+    }
+
+    change('valueOverrides', valueOverridesUpdated);
+    closeInlineEdit();
+  };
+
   const noRuleSets =
     !preselectedRuleIdsError &&
     !preselectedRuleIdsLoading &&
@@ -162,6 +188,7 @@ export const EditPolicyProfilesRulesRest = ({
             enableSecurityGuideRulesToggle
             rulesPageLink={true}
             defaultTableView="rows"
+            onValueOverrideSave={onValueOverrideSave}
           />
         </StateViewPart>
       </StateViewWithError>
@@ -181,6 +208,7 @@ EditPolicyProfilesRulesRest.propTypes = {
   ),
   selectedRuleRefIds: propTypes.array,
   ruleValues: propTypes.array,
+  valueOverrides: propTypes.object,
 };
 
 export default EditPolicyProfilesRulesRest;

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyBase.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyBase.js
@@ -50,7 +50,7 @@ export const FinishedCreatePolicyBase = ({
   benchmarkId,
   systems,
   selectedRuleRefIds,
-  valueOverrides,
+  valueOverrides = {},
   updatePolicy,
 }) => {
   const [percent, setPercent] = useState(0);

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyBase.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyBase.js
@@ -50,7 +50,7 @@ export const FinishedCreatePolicyBase = ({
   benchmarkId,
   systems,
   selectedRuleRefIds,
-  ruleValues: values,
+  valueOverrides,
   updatePolicy,
 }) => {
   const [percent, setPercent] = useState(0);
@@ -73,7 +73,7 @@ export const FinishedCreatePolicyBase = ({
       benchmarkId,
       hosts: systems,
       selectedRuleRefIds,
-      values,
+      valueOverrides,
     };
 
     updatePolicy(null, newPolicy, onProgress)
@@ -156,7 +156,7 @@ FinishedCreatePolicyBase.propTypes = {
   complianceThreshold: propTypes.number,
   onWizardFinish: propTypes.func,
   selectedRuleRefIds: propTypes.arrayOf(propTypes.string).isRequired,
-  ruleValues: propTypes.object,
+  valueOverrides: propTypes.object,
   updatePolicy: propTypes.func.isRequired,
 };
 
@@ -175,7 +175,7 @@ export default compose(
         parseFloat(selector(state, 'complianceThreshold')) || 100.0,
       systems: selector(state, 'systems'),
       selectedRuleRefIds: selector(state, 'selectedRuleRefIds'),
-      ruleValues: selector(state, 'ruleValues'),
+      valueOverrides: selector(state, 'valueOverrides'),
     };
   }),
   reduxForm({

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyRest.js
@@ -78,7 +78,7 @@ export const useUpdatePolicy = () => {
 
       dispatchProgress();
 
-      tailorings.forEach(async (tailoring) => {
+      for (const tailoring of tailorings) {
         const rulesToAssign = selectedRuleRefIds.find(
           ({ osMinorVersion }) =>
             Number(osMinorVersion) === tailoring.os_minor_version
@@ -97,9 +97,9 @@ export const useUpdatePolicy = () => {
         );
 
         dispatchProgress();
-      });
+      }
 
-      tailorings.forEach(async (tailoring) => {
+      for (const tailoring of tailorings) {
         const tailoringValueOverrides =
           valueOverrides[tailoring.os_minor_version];
 
@@ -107,7 +107,7 @@ export const useUpdatePolicy = () => {
           tailoringValueOverrides === undefined ||
           Object.keys(tailoringValueOverrides).length === 0
         ) {
-          return;
+          continue;
         }
 
         await updateTailoring(
@@ -123,7 +123,7 @@ export const useUpdatePolicy = () => {
         );
 
         dispatchProgress();
-      });
+      }
 
       return { id: newPolicyId };
     },


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-14527.

This fixes the create policy wizard: when overriding at least one rule values, the wizard should call PATCH request additionally to update the value overrides.

## How to test

Try to create a policy and find the rules which has some value to override. Set any value and follow up to the finish step. When submitting the policy creation, make sure the policy creation is complete. Follow to the policy details page and verify that the rules has all the value overrides you set in the wizard.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
