### PR TITLE
fix(RulesTable): prevent error on rule expand

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTableRest.js
+++ b/src/PresentationalComponents/RulesTable/RulesTableRest.js
@@ -82,7 +82,8 @@ const RulesTable = ({
       };
 
       return valueDefinitions === undefined ||
-        valueDefinitions.loading === true ? (
+        valueDefinitions.loading === true ||
+        valueDefinitions.data === undefined ? (
         <List />
       ) : (
         <RuleDetailsRow

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -94,7 +94,7 @@ export const checkForNonDefaultValues = (values, valueDefinitions) =>
   Object.entries(values || {}).some(([valueId, value]) => {
     const valueDefinition = valueDefinitions.find(
       (valueDefinition) =>
-        valueDefinition?.refId === valueId || valueDefinition?.id === valueId
+        valueDefinition.refId === valueId || valueDefinition.id === valueId
     );
 
     return value !== valueDefinition?.defaultValue;

--- a/src/PresentationalComponents/RulesTable/helpers.js
+++ b/src/PresentationalComponents/RulesTable/helpers.js
@@ -94,7 +94,7 @@ export const checkForNonDefaultValues = (values, valueDefinitions) =>
   Object.entries(values || {}).some(([valueId, value]) => {
     const valueDefinition = valueDefinitions.find(
       (valueDefinition) =>
-        valueDefinition.refId === valueId || valueDefinition.id === valueId
+        valueDefinition?.refId === valueId || valueDefinition?.id === valueId
     );
 
     return value !== valueDefinition?.defaultValue;


### PR DESCRIPTION
**Haven't created JIRA for this one as it's super small fix**

If you navigate to policy details Rules tab and expand rule that has some value firstly - page will throw an error as values are not loaded yet. Fix will prevent error and expanded rule will wait for API response

Before:
```
TypeError: Cannot read properties of undefined (reading 'refId')
    at 193.ecdabd904c06366681c1.js:142:18386
    at Array.find (<anonymous>)
    at 193.ecdabd904c06366681c1.js:142:18375
    at Array.some (<anonymous>)
    at m (193.ecdabd904c06366681c1.js:142:18349)
    at 193.ecdabd904c06366681c1.js:142:7125
    at rl (chrome-root.d6ec82adcca2f232.js:2:230321)
    at _s (chrome-root.d6ec82adcca2f232.js:2:250451)
    at chrome-root.d6ec82adcca2f232.js:2:249193
    at Es (chrome-root.d6ec82adcca2f232.js:2:249258)
```


https://github.com/user-attachments/assets/769ea999-67bb-42e2-accc-4095db5d0ad2



After:


https://github.com/user-attachments/assets/beb34a8d-7fb9-4196-9f07-6d302d92db8d



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
