### PR TITLE
fix(RHINENG-15136): Make default rules page work from EditPolicy

### DIFF
--- a/src/PresentationalComponents/Tailorings/components/TailoringTab.js
+++ b/src/PresentationalComponents/Tailorings/components/TailoringTab.js
@@ -122,7 +122,7 @@ const TailoringTab = ({
                 osMinorVersion,
               }
             }
-            profileId={profileId}
+            profileId={profileId || tailoring.profile_id}
             rulesPageLink={rulesPageLink}
             resetLink={resetLink}
             systemCount={systemCount}


### PR DESCRIPTION
profileId hasn't been passed through defaultRules link to default rules page and as the result page is crashing.

**To test:**

1. Navigate to Edit policy modal
2. Click on Rules tab
3. Use "View policy rules" link to navigate to default rules page
4. See that page doesn't crash and shows correct data

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
