### PR TITLE
 fix(sentry): Avoid sentry plugin install on dev set up

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -21,33 +21,26 @@ module.exports = {
   devtool: 'hidden-source-map',
   plugins: [
     // Put the Sentry Webpack plugin after all other plugins
-    ...(process.env.SENTRY_AUTH_TOKEN
+    ...(process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG
       ? [
           sentryWebpackPlugin({
-            authToken: process.env.SENTRY_AUTH_TOKEN,
             org: 'red-hat-it',
             project: 'compliance-rhel',
+            ...(process.env.SENTRY_AUTH_TOKEN && {
+              authToken: process.env.SENTRY_AUTH_TOKEN,
+            }),
             moduleMetadata: ({ release }) => ({
+              ...(process.env.SENTRY_AUTH_TOKEN && {
+                authToken: process.env.SENTRY_AUTH_TOKEN,
+              }),
+              release,
               dsn: `https://6410c806f0ac7b638105bb4e15eb3399@o490301.ingest.us.sentry.io/4508083145408512`,
               org: 'red-hat-it',
               project: 'compliance-rhel',
-              release,
             }),
           }),
         ]
-      : [
-          //Just injects debugIDs
-          sentryWebpackPlugin({
-            org: 'red-hat-it',
-            project: 'compliance-rhel',
-            moduleMetadata: ({ release }) => ({
-              dsn: `https://6410c806f0ac7b638105bb4e15eb3399@o490301.ingest.us.sentry.io/4508083145408512`,
-              org: 'red-hat-it',
-              project: 'compliance-rhel',
-              release,
-            }),
-          }),
-        ]),
+      : []),
   ],
   moduleFederation: {
     shared: [


### PR DESCRIPTION
Whenever you run compliance locally, the plugin uploads debugIds, this doesnt affect functionality but is unnecessary and prolongs start up time locally. These variables are always available to master branch as secrets, so the plugin will load in every time master is built, as well as pass in the auth token when its defined