### PR TITLE
fix(RHINENG-14893): Fix bug with OR and improve tests

### DIFF
--- a/src/SmartComponents/SystemDetails/EmptyState.js
+++ b/src/SmartComponents/SystemDetails/EmptyState.js
@@ -12,7 +12,7 @@ const EmptyState = ({ inventoryId, system }) => {
     params: [inventoryId],
     skip: system,
   });
-  const policiesCount = system?.policies.length || data?.policies.length;
+  const policiesCount = system?.policies.length ?? data?.policies.length;
   const insightsId = system?.insights_id || data?.insights_id;
 
   if (!system && !data) {

--- a/src/SmartComponents/SystemDetails/EmptyState.test.js
+++ b/src/SmartComponents/SystemDetails/EmptyState.test.js
@@ -39,11 +39,11 @@ describe('EmptyState for systemDetails', () => {
     );
 
     expect(
-      screen.getByText('This system isn’t connected to Insights yet')
+      screen.getByText(`This system isn't connected to Insights yet`)
     ).toBeInTheDocument();
   });
 
-  it('expect to render NoPoliciesState component', () => {
+  it('expect to render NoPoliciesState component for Inventory', () => {
     useSystem.mockImplementation(() => ({
       data: { data: { display_name: 'foo', policies: [], insights_id: '123' } },
       error: undefined,
@@ -54,6 +54,30 @@ describe('EmptyState for systemDetails', () => {
         <EmptyState inventoryId={'123'} />
       </TestWrapper>
     );
+
+    expect(
+      screen.getByText(
+        'This system is not part of any SCAP policies defined within Compliance.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it.only('expect to render NoPoliciesState component for Compliance SystemDetails', () => {
+    useSystem.mockImplementation(() => ({}));
+
+    render(
+      <TestWrapper>
+        <EmptyState
+          inventoryId={'123'}
+          system={{ insights_id: '123', policies: [] }}
+        />
+      </TestWrapper>
+    );
+
+    expect(useSystem).toHaveBeenCalledWith({
+      params: ['123'],
+      skip: { insights_id: '123', policies: [] }, // Ensure correct 'skip' value
+    });
 
     expect(
       screen.getByText(
@@ -85,6 +109,8 @@ describe('EmptyState for systemDetails', () => {
   });
 
   it('expect to render NoReportsState component', () => {
+    useSystem.mockImplementation(() => ({}));
+
     render(
       <TestWrapper>
         <EmptyState


### PR DESCRIPTION
Can't use OR when 0 value can be returned as 0 || undefined will return us undefined and as the result empty state is not shown correctly. Also covered this case by test

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
