### PR TITLE
fix(RHINENG-15120): Fix rule patching in policies

### DIFF
--- a/src/PresentationalComponents/RulesTable/components/RuleValueEdit.js
+++ b/src/PresentationalComponents/RulesTable/components/RuleValueEdit.js
@@ -71,6 +71,7 @@ const RuleValueEdit = ({ rule, onValueChange, onRuleValueReset }) => {
             key={`rule-value-${idx}`}
             isOpen={isOpen}
             value={
+              valueDefinition.value ||
               ruleValues?.[valueDefinition?.id] ||
               ruleValues?.[valueDefinition?.refId]
             }

--- a/src/PresentationalComponents/Tailorings/Tailorings.js
+++ b/src/PresentationalComponents/Tailorings/Tailorings.js
@@ -33,6 +33,7 @@ import NoTailorings from './NoTailorings';
  *  @param                        [props.rulesPageLink]
  *
  *  @param   {object}             props.selectedVersionCounts            An object containing minor version as a key and count as a value. Helps to render the system count badge in tab headers.
+ *  @param                        props.valueOverrides
  *  @returns {React.ReactElement}
  *
  *  @category Compliance
@@ -147,6 +148,7 @@ import NoTailorings from './NoTailorings';
   preselected,
   enableSecurityGuideRulesToggle,
   selectedVersionCounts,
+  valueOverrides,
   ...rulesTableProps
 }) => {
   const {
@@ -240,6 +242,7 @@ import NoTailorings from './NoTailorings';
                       preselected?.[tab.id] ||
                       preselected?.[tab.os_minor_version],
                     rulesPageLink: rulesPageLink,
+                    valueOverrides,
                   }}
                 />
               </Tab>
@@ -273,6 +276,7 @@ Tailorings.propTypes = {
   preselected: propTypes.object,
   enableSecurityGuideRulesToggle: propTypes.bool,
   selectedVersionCounts: propTypes.object,
+  valueOverrides: propTypes.object,
 };
 
 export default Tailorings;

--- a/src/PresentationalComponents/Tailorings/components/TailoringTab.js
+++ b/src/PresentationalComponents/Tailorings/components/TailoringTab.js
@@ -28,6 +28,7 @@ const TailoringTab = ({
   onSelect,
   preselected,
   enableSecurityGuideRulesToggle,
+  valueOverrides,
 }) => {
   const tableState = useFullTableState();
   const openRuleGroups = tableState?.tableState?.['open-items'];
@@ -150,6 +151,7 @@ const TailoringTab = ({
             shouldSkip.securityGuide.valueDefinitions === false &&
             valueDefinitions === undefined,
         }}
+        valueOverrides={valueOverrides}
         onRuleValueReset={onRuleValueReset}
         onValueOverrideSave={onValueSave}
         onSelect={onSelect ? onSelectRule : undefined}
@@ -189,6 +191,7 @@ TailoringTab.propTypes = {
   onValueOverrideSave: propTypes.func,
   preselected: propTypes.object,
   enableSecurityGuideRulesToggle: propTypes.bool,
+  valueOverrides: propTypes.object,
 };
 
 const TailoringTabProvider = (props) => (

--- a/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRulesRest.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRulesRest.js
@@ -187,6 +187,7 @@ export const EditPolicyProfilesRulesRest = ({
             preselected={preselected}
             enableSecurityGuideRulesToggle
             rulesPageLink={true}
+            valueOverrides={valueOverrides}
             onValueOverrideSave={onValueOverrideSave}
             selectedVersionCounts={osMinorVersionCounts.reduce(
               (prev, cur) => ({


### PR DESCRIPTION
There is an issue when altering the value of a rule, where 1, it does not save, and 2, when updating one and opening another, the first gets reset.

To reproduce: 

- Navigate to Create policy wizard
- Go to Rules step
- Find any rule that has value (search for "password" or "ssh" and most of these rules have values)
- Expand rule and patch value
- Expand rule that goes after patched one
- **Old Behavior** Observe that value of patched rule has been changed to default one (we still store patched values and will apply them, so bug is only visual)
- **New Behavior** Observe that the value is saved. Note that when alter rules, many times the valueCheckIds for the rules are the same, so alter one may alter all the following rules.

Observe everywhere that the value is correct for the rule.
The policy needs to be monitored in 3 places. Create Policy Wizard, Policy Details in the rules Tab, and edit policy in system details.

