### PR TITLE
fix(sentry): Update sentry flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,15 @@
-name: sentryConfig
+name: sentryInit
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       commit_hash:
         description: 'The commit hash (or branch/tag) to build'
-        required: true
-        default: 'master'
+        required: false
+        default: ''
 
 jobs:
   createSentryRelease:
@@ -15,17 +18,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.commit_hash }}
+          ref: ${{ github.event.inputs.commit_hash || 'refs/heads/master' }}
 
       - name: Install dependencies
-        env:
-          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash }}
         run: npm ci
 
       - name: Build
         env:
-          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          ENABLE_SENTRY:  ${{ secrets.ENABLE_SENTRY }}
+          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash && github.event.inputs.commit_hash }}
+          SENTRY_AUTH_TOKEN: ${{ github.event.inputs.commit_hash && secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: npm run build --if-present

--- a/fec.config.js
+++ b/fec.config.js
@@ -20,11 +20,12 @@ module.exports = {
   useProxy: process.env.PROXY === 'true',
   devtool: 'hidden-source-map',
   plugins: [
-    // Put the Sentry Webpack plugin after all other plugins
-    ...(process.env.SENTRY_AUTH_TOKEN
+    ...(process.env.ENABLE_SENTRY
       ? [
           sentryWebpackPlugin({
-            authToken: process.env.SENTRY_AUTH_TOKEN,
+            ...(process.env.SENTRY_AUTH_TOKEN && {
+              authToken: process.env.SENTRY_AUTH_TOKEN,
+            }),
             org: 'red-hat-it',
             project: 'compliance-rhel',
             moduleMetadata: ({ release }) => ({
@@ -35,19 +36,7 @@ module.exports = {
             }),
           }),
         ]
-      : [
-          //Just injects debugIDs
-          sentryWebpackPlugin({
-            org: 'red-hat-it',
-            project: 'compliance-rhel',
-            moduleMetadata: ({ release }) => ({
-              dsn: `https://6410c806f0ac7b638105bb4e15eb3399@o490301.ingest.us.sentry.io/4508083145408512`,
-              org: 'red-hat-it',
-              project: 'compliance-rhel',
-              release,
-            }),
-          }),
-        ]),
+      : []),
   ],
   moduleFederation: {
     shared: [


### PR DESCRIPTION
This also removes the issue where the plugin is initialized locally and sends up debugIDs for local env on every build
**Workflow Behavior:**

**Locally (without variables):**
The Sentry plugin won't build as SENTRY_AUTH_TOKEN is not defined.

**GitHub push to master (automatic trigger):**
The plugin won't include the authToken because commit_hash is not provided in push events.

**Manually triggered with commit_hash:**
The plugin includes the authToken and tracks the build with Sentry.