### PR TITLE
fix(RHINENG-15635): Set system minVer correctly on search&select

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicyFormRest.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyFormRest.js
@@ -42,7 +42,11 @@ const EditPolicyForm = ({
   const handleSystemSelect = useCallback(
     (newSelectedSystems) => {
       const newOsMinorVersions = [
-        ...new Set(newSelectedSystems.map((system) => system.osMinorVersion)), // get unique values
+        ...new Set(
+          newSelectedSystems.map(
+            (system) => system.os_minor_version ?? system.osMinorVersion
+          )
+        ), // get unique values
       ];
 
       const hasNewOsMinorVersions =
@@ -57,7 +61,11 @@ const EditPolicyForm = ({
       setNewRulesAlert(hasNewOsMinorVersions);
       setSelectedOsMinorVersions(newOsMinorVersions);
       setSelectedVersionCounts(
-        getCounts(newSelectedSystems.map((system) => system.osMinorVersion))
+        getCounts(
+          newSelectedSystems.map(
+            (system) => system.osMinorVersion ?? system.os_minor_version
+          )
+        )
       );
       setSelectedSystems(newSelectedSystems.map((system) => system.id));
     },


### PR DESCRIPTION
I was looking into Sentry issues and found out that it's possible that when system is selected on Edit policy modal - minor version is `undefined` and as result we get non-working rules tab. I also found minor issue with count labels.

To test:
1. Have Policy with minor version X assigned (let's say RHEL8 policy with system 8.6)
2. Go to edit policy modal and open systems tab
3. Search system by name with minor version Y (let's say you have system test.foo 8.4)
4. Select system
5. Open Rules tab and observe that there are 2 tabs: 8.6 & 8.4 and labels are set correctly

Before:
we see error in console `TypeError: Cannot read properties of undefined (reading 'id')` and v2 request is sent with undefined minor version:
`/api/compliance/v2/security_guides?limit=1&ids_only=true&sort_by=version:desc&filter=os_major_version=8 AND supported_profile=xccdf_org.ssgproject.content_profile_cis_server_l1:undefined`


https://github.com/user-attachments/assets/a2439223-7ad0-46c4-872e-e0bddbf5ccfc



After: 
everything works as it should 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
