### PR TITLE
fix(RHINENG-13541): Make sorting work for Table with radioSelect

### DIFF
--- a/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useAsyncTableTools.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useAsyncTableTools/useAsyncTableTools.js
@@ -97,7 +97,10 @@ const useAsyncTableTools = (items, columns, options = {}) => {
 
   const { tableProps: sortableTableProps } = useTableSort(managedColumns, {
     ...options,
-    onSelect: bulkSelectTableProps?.onSelect || tablePropsOption?.onSelect,
+    onSelect:
+      bulkSelectTableProps?.onSelect ||
+      radioSelectTableProps?.onSelect ||
+      tablePropsOption?.onSelect,
   });
 
   const exportConfig = withExport({


### PR DESCRIPTION
Respect radio select when sorting by columns

How to test:

1. Navigate to create policy wizard
2. Select any OS major version
3. Check Policy types table if it's sorted by policy name by default and sorting works as expected

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
