### PR TITLE
fix(RHINENG-16323): Make value update work EditPolicy

### DIFF
--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
@@ -109,18 +109,11 @@ export const useUpdatePolicy = () => {
         ) {
           continue;
         }
-
-        await updateTailoring(
-          [
-            newPolicyId,
-            tailoring.id,
-            undefined,
-            {
-              value_overrides: tailoringValueOverrides,
-            },
-          ],
-          false
-        );
+        await updateTailoring({
+          policyId: newPolicyId,
+          tailoringId: tailoring.id,
+          valuesUpdate: { value_overrides: tailoringValueOverrides },
+        });
 
         dispatchProgress();
       }

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.test.js
@@ -156,15 +156,11 @@ describe('useUpdatePolicy', () => {
       onProgress
     );
 
-    expect(updateTailoring).toBeCalledWith(
-      [
-        createdPolicyId,
-        createdTailoringId,
-        undefined,
-        { value_overrides: { test_id_1: 'test_value_1' } },
-      ],
-      false
-    );
+    expect(updateTailoring).toBeCalledWith({
+      policyId: createdPolicyId,
+      tailoringId: createdTailoringId,
+      valuesUpdate: { value_overrides: { test_id_1: 'test_value_1' } },
+    });
   });
 
   it('updates progress', async () => {

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -75,7 +75,7 @@ const EditPolicy = ({ route }) => {
     setUpdatedPolicy((prev) => ({
       ...prev,
       value: {
-        ...prev.value,
+        ...prev?.value,
         [tailoring.id]: {
           ...tailoring.value_overrides,
           [valueDefinition.id]: newValue,

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -72,16 +72,18 @@ const EditPolicy = ({ route }) => {
     newValue,
     closeInlineEdit
   ) => {
-    setUpdatedPolicy((prev) => ({
-      ...prev,
-      value: {
-        ...prev?.value,
-        [tailoring.id]: {
-          ...tailoring.value_overrides,
-          [valueDefinition.id]: newValue,
+    setUpdatedPolicy((prev) => {
+      return {
+        ...prev,
+        tailoringValueOverrides: {
+          ...prev?.tailoringValueOverrides,
+          [tailoring.id]: {
+            ...tailoring.value_overrides,
+            [valueDefinition.id]: newValue,
+          },
         },
-      },
-    }));
+      };
+    });
 
     closeInlineEdit();
   };

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -72,13 +72,15 @@ const EditPolicy = ({ route }) => {
     newValue,
     closeInlineEdit
   ) => {
+    // tailoring might be an object or just a number (minor version for profile tab)
+    const osMinorVersion = tailoring?.os_minor_version ?? tailoring;
     setUpdatedPolicy((prev) => {
       return {
         ...prev,
         tailoringValueOverrides: {
           ...prev?.tailoringValueOverrides,
-          [tailoring.id]: {
-            ...tailoring.value_overrides,
+          [osMinorVersion]: {
+            ...tailoring?.value_overrides,
             [valueDefinition.id]: newValue,
           },
         },

--- a/src/SmartComponents/EditPolicy/EditPolicy.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.test.js
@@ -8,6 +8,7 @@ import useAssignRules from 'Utilities/hooks/api/useAssignRules';
 import useAssignedRules from './hooks/useAssignedRules';
 import useAssignSystems from 'Utilities/hooks/api/useAssignSystems';
 import useTailorings from 'Utilities/hooks/api/useTailorings';
+import useUpdateTailoring from 'Utilities/hooks/api/useUpdateTailoring';
 import TestWrapper from '@redhat-cloud-services/frontend-components-utilities/TestingUtils/JestUtils/TestWrapper';
 import userEvent from '@testing-library/user-event';
 import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
@@ -21,6 +22,7 @@ jest.mock('Utilities/hooks/api/useAssignSystems');
 jest.mock('Utilities/hooks/api/usePolicy');
 jest.mock('Utilities/hooks/api/useTailorings');
 jest.mock('Utilities/hooks/api/useUpdatePolicy');
+jest.mock('Utilities/hooks/api/useUpdateTailoring');
 jest.mock('./hooks/useAssignedRules');
 jest.mock('Utilities/Dispatcher', () => ({ dispatchNotification: jest.fn() }));
 
@@ -81,7 +83,12 @@ describe('EditPolicy', () => {
       assignedRulesLoading: false,
     }));
 
-    [useAssignRules, useAssignSystems, useSupportedProfiles].forEach((hook) => {
+    [
+      useAssignRules,
+      useAssignSystems,
+      useSupportedProfiles,
+      useUpdateTailoring,
+    ].forEach((hook) => {
       hook.mockImplementation(() => ({
         data: { data: [{ id: 'test-id' }] },
         loading: false,
@@ -188,6 +195,15 @@ describe('EditPolicy', () => {
         assignRulesRequest: { ids: ['rule-1', 'rule-2'] },
       })
     );
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith({
+        policyId: 'test-id',
+        tailoringId: 'tailoring-id',
+        valuesUpdate: { value_overrides: { 'value-id': 'changed-value' } },
+      })
+    );
+
     await waitFor(() =>
       expect(dispatchNotification).toHaveBeenCalledWith({
         autoDismiss: true,

--- a/src/SmartComponents/EditPolicy/EditPolicy.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.test.js
@@ -104,7 +104,9 @@ describe('EditPolicy', () => {
             8: ['rule-1', 'rule-2'],
           },
           hosts: ['system-1'],
-          tailoringValueOverrides: { 'tailoring-id': { 'value-id': 'changed-value' } },
+          tailoringValueOverrides: {
+            8: { 'value-id': 'changed-value' },
+          },
         });
       }, []);
 
@@ -199,7 +201,7 @@ describe('EditPolicy', () => {
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith({
         policyId: 'test-id',
-        tailoringId: 'tailoring-id',
+        tailoringId: 'tailoring-id-1',
         valuesUpdate: { value_overrides: { 'value-id': 'changed-value' } },
       })
     );

--- a/src/SmartComponents/EditPolicy/EditPolicy.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.test.js
@@ -104,7 +104,7 @@ describe('EditPolicy', () => {
             8: ['rule-1', 'rule-2'],
           },
           hosts: ['system-1'],
-          value: { 'tailoring-id': { 'value-id': 'changed-value' } },
+          tailoringValueOverrides: { 'tailoring-id': { 'value-id': 'changed-value' } },
         });
       }, []);
 

--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -19,6 +19,7 @@ const getCounts = (arr) =>
 const EditPolicyForm = ({
   policy,
   setUpdatedPolicy,
+  updatedPolicy,
   assignedRuleIds,
   assignedSystems,
   setRuleValues,
@@ -87,6 +88,7 @@ const EditPolicyForm = ({
             selectedOsMinorVersions={selectedOsMinorVersions}
             selectedVersionCounts={selectedVersionCounts}
             setUpdatedPolicy={setUpdatedPolicy}
+            updatedPolicy={updatedPolicy}
           />
         </Tab>
         <Tab

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -85,14 +85,13 @@ export const EditPolicyRulesTab = ({
         }, {}),
         tailoringValueOverrides: tailoringsData?.reduce(
           (overrides, tailoring) => {
-            const foo = {
+            return {
               ...overrides,
-              [tailoring.id]: {
+              [tailoring.os_minor_version]: {
                 ...tailoring.value_overrides,
-                ...prev?.tailoringValueOverrides?.[tailoring.id],
+                ...prev?.tailoringValueOverrides?.[tailoring.os_minor_version],
               },
             };
-            return foo;
           },
           {}
         ),

--- a/src/SmartComponents/EditPolicy/hooks.js
+++ b/src/SmartComponents/EditPolicy/hooks.js
@@ -55,10 +55,13 @@ const useUpdatePolicyRest = (policy, updatedPolicyHostsAndRules) => {
       if (tailoringValueOverrides) {
         for (const entry of Object.entries(tailoringValueOverrides)) {
           // patch rule values
-          const [tailoringId, valueOverrides] = entry;
+          const [osMinorVersion, valueOverrides] = entry;
           await updateTailoring({
             policyId,
-            tailoringId,
+            tailoringId: tailoringsUpdated.find(
+              ({ os_minor_version }) =>
+                os_minor_version === Number(osMinorVersion)
+            ).id,
             valuesUpdate: { value_overrides: valueOverrides },
           });
         }

--- a/src/SmartComponents/EditPolicy/hooks.js
+++ b/src/SmartComponents/EditPolicy/hooks.js
@@ -13,7 +13,7 @@ const useUpdatePolicyRest = (policy, updatedPolicyHostsAndRules) => {
     description,
     businessObjective,
     complianceThreshold,
-    value: valuesPerTailoringId,
+    tailoringValueOverrides,
   } = updatedPolicyHostsAndRules || {};
 
   const { fetch: assignRules } = useAssignRules({ skip: true });
@@ -29,7 +29,7 @@ const useUpdatePolicyRest = (policy, updatedPolicyHostsAndRules) => {
       await assignSystems({ policyId, assignSystemsRequest: { ids: hosts } });
     }
 
-    if (tailoringRules || valuesPerTailoringId) {
+    if (tailoringRules || tailoringValueOverrides) {
       const tailoringsResponse = await fetchTailorings(
         {
           policyId,
@@ -52,8 +52,8 @@ const useUpdatePolicyRest = (policy, updatedPolicyHostsAndRules) => {
           });
         }
       }
-      if (valuesPerTailoringId) {
-        for (const entry of Object.entries(valuesPerTailoringId)) {
+      if (tailoringValueOverrides) {
+        for (const entry of Object.entries(tailoringValueOverrides)) {
           // patch rule values
           const [tailoringId, valueOverrides] = entry;
           await updateTailoring({

--- a/src/SmartComponents/PolicyDetails/hooks/useSaveValueOverrides.js
+++ b/src/SmartComponents/PolicyDetails/hooks/useSaveValueOverrides.js
@@ -14,9 +14,12 @@ const useSaveValueOverrides = () => {
           [valueDefintion.id]: newValue,
         },
       };
-      const params = [policyId, tailoringId, undefined, tailoringData];
 
-      return await submit(params, false);
+      return await submit({
+        policyId,
+        tailoringId,
+        valuesUpdate: tailoringData,
+      });
     },
     [submit]
   );

--- a/src/Utilities/hooks/api/useUpdateTailoring.js
+++ b/src/Utilities/hooks/api/useUpdateTailoring.js
@@ -1,6 +1,25 @@
 import useComplianceQuery from './useComplianceQuery';
 
+const convertToArray = (params) => {
+  if (Array.isArray(params)) {
+    return params;
+  } else {
+    const { policyId, tailoringId, valuesUpdate } = params;
+
+    return [
+      policyId,
+      tailoringId,
+      undefined, // xRHIDENTITY,
+      valuesUpdate,
+    ];
+  }
+};
+
 const useUpdateTailoring = (options) =>
-  useComplianceQuery('updateTailoring', { skip: true, ...options });
+  useComplianceQuery('updateTailoring', {
+    skip: true,
+    ...options,
+    convertToArray,
+  });
 
 export default useUpdateTailoring;


### PR DESCRIPTION
This PR fixes rule values update on EditPolicy modal.

**Before the fix:**
If you try to update value - page reloads and on second try page is going to crash

**After the fix:**
Value changes are respected and on Save button click PATCH request is sent for tailoring.

**How to test:**

1. Have freshly created policy with 1 assigned host with minor version X
2. Navigate to Edit policy rules tab
3. Find any rule that has value to edit (hint: search for "selinux" or "passord")
4. Use inline edit to update a value to something that you will remember (like classic "foo")
5. Do not save changes, open systems tab and add 1 more system but with minor version Y (different from first one)
6. Open rules tab back and observe 2 minor version tabs
7. Check if tab with X still has value that you set
8. Try to change a value for tab Y for any rule
9. Save policy
10. Navigate to policy details and check if each tab has rule with patched value

**Since I refactored a bit other calls ensure value update also works from:**

1. Create policy wizard
11. Policy details Rules tab

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
