### PR TITLE
Add export defaul rules page

### DIFF
--- a/src/SmartComponents/PolicyRules/PolicyRules.js
+++ b/src/SmartComponents/PolicyRules/PolicyRules.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import * as Columns from '@/PresentationalComponents/RulesTable/Columns';
 import RulesTable from '@/PresentationalComponents/RulesTable/RulesTableRest';
@@ -9,6 +9,8 @@ import { policyRulesSkips } from './helpers';
 import TableStateProvider from '@/Frameworks/AsyncTableTools/components/TableStateProvider';
 import useSecurityGuide from 'Utilities/hooks/api/useSecurityGuide';
 import useProfile from 'Utilities/hooks/api/useProfile';
+import useExporter from '@/Frameworks/AsyncTableTools/hooks/useExporter';
+
 
 const PolicyDefaultRules = () => {
   const tableState = useFullTableState();
@@ -44,7 +46,7 @@ const PolicyDefaultRules = () => {
     },
   });
 
-  const { data, loading /*fetchRules*/ } = usePolicyRulesList({
+  const { data, loading, fetchRules } = usePolicyRulesList({
     profileId,
     securityGuideId,
     tableState,
@@ -54,8 +56,7 @@ const PolicyDefaultRules = () => {
 
   const { rules, builtTree } = data;
 
-  //TODO: Disabled for now. Bring back during polishing.
-  // const rulesExporter = useRulesExporter(fetchRules);
+  const ruleResultsExporter = useExporter(fetchRules);
 
   return (
     <>
@@ -75,6 +76,10 @@ const PolicyDefaultRules = () => {
           ruleValues={{}}
           loading={loading}
           ruleTree={builtTree}
+          options={{
+            exporter: async () =>
+              await ruleResultsExporter(),
+          }}
         />
       </div>
     </>

--- a/src/SmartComponents/PolicyRules/PolicyRules.js
+++ b/src/SmartComponents/PolicyRules/PolicyRules.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import * as Columns from '@/PresentationalComponents/RulesTable/Columns';
 import RulesTable from '@/PresentationalComponents/RulesTable/RulesTableRest';
@@ -10,7 +10,6 @@ import TableStateProvider from '@/Frameworks/AsyncTableTools/components/TableSta
 import useSecurityGuide from 'Utilities/hooks/api/useSecurityGuide';
 import useProfile from 'Utilities/hooks/api/useProfile';
 import useExporter from '@/Frameworks/AsyncTableTools/hooks/useExporter';
-
 
 const PolicyDefaultRules = () => {
   const tableState = useFullTableState();
@@ -76,9 +75,9 @@ const PolicyDefaultRules = () => {
           ruleValues={{}}
           loading={loading}
           ruleTree={builtTree}
+          skipValueDefinitions={true}
           options={{
-            exporter: async () =>
-              await ruleResultsExporter(),
+            exporter: async () => await ruleResultsExporter(),
           }}
         />
       </div>


### PR DESCRIPTION
While poking around, I found out that we don't have export on Default profile rules page. So I'm bringing it back here. + making rules list expand work by ignoring rule values (as it was before migration)

**How to test:**
1. Open Edit policy modal rules tab
2. Use view default rules link to navigate to Default profile rules page
3. Try to export CSV/JSON
4. Click on list table
5. Try to expand rules

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
