### PR TITLE
fix(RHINENG-16323): Respect value selection on multiple profile select

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -81,6 +81,7 @@ const EditPolicy = ({ route }) => {
           ...prev?.tailoringValueOverrides,
           [osMinorVersion]: {
             ...tailoring?.value_overrides,
+            ...prev?.tailoringValueOverrides?.[osMinorVersion],
             [valueDefinition.id]: newValue,
           },
         },

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -83,8 +83,9 @@ export const EditPolicyRulesTab = ({
             [Number(profile.osMinorVersion)]: profile.ruleIds,
           };
         }, {}),
-        tailoringValueOverrides: tailoringsData?.reduce(
-          (overrides, tailoring) => {
+        tailoringValueOverrides: {
+          ...prev?.tailoringValueOverrides,
+          ...tailoringsData?.reduce((overrides, tailoring) => {
             return {
               ...overrides,
               [tailoring.os_minor_version]: {
@@ -92,9 +93,8 @@ export const EditPolicyRulesTab = ({
                 ...prev?.tailoringValueOverrides?.[tailoring.os_minor_version],
               },
             };
-          },
-          {}
-        ),
+          }, {}),
+        },
       };
     });
 


### PR DESCRIPTION
Follow up PR:

this one will take care of: 

1. saving value state on multiple profile selection. 
2. saving values correctly on multiple value edit for 1 profile/tailoring

How to test:

1. Have Pre-created policy with minor ver X
3. Open edit policy modal rules tab
4. Edit 2 values for X
5. Switch to systems tab and select minor ver Y
6.  Edit 2 values for Y
7. Switch to systems tab and select minor ver Q
8. Edit 2 values for Q
9. Check if values you edited for X, Y and Q are still there.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
