### PR TITLE
fix(Tailorings): Follow up multiple fixes

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTableRest.js
+++ b/src/PresentationalComponents/RulesTable/RulesTableRest.js
@@ -148,6 +148,7 @@ const RulesTable = ({
         selectedFilter,
         dedicatedAction: DedicatedAction,
         ...(remediationsEnabled ? { dedicatedAction: remediationAction } : {}),
+        total,
       }}
       total={total}
       {...rulesTableProps}

--- a/src/PresentationalComponents/Tailorings/Tailorings.js
+++ b/src/PresentationalComponents/Tailorings/Tailorings.js
@@ -158,7 +158,7 @@ const Tailorings = ({
                       additionalRules?.[tab.id] ||
                       additionalRules?.[tab.os_minor_version],
                     rulesPageLink: rulesPageLink,
-                    valueOverrides,
+                    valueOverrides: valueOverrides?.[tab.os_minor_version],
                   }}
                 />
               </Tab>

--- a/src/PresentationalComponents/Tailorings/components/TailoringTab.js
+++ b/src/PresentationalComponents/Tailorings/components/TailoringTab.js
@@ -134,7 +134,7 @@ const TailoringTab = ({
         valueDefinitions,
         valueOverrides: {
           ...tailoring?.value_overrides,
-          ...valueOverrides?.[osMinorVersion],
+          ...valueOverrides,
         },
         ...(tableState?.tableState?.selectedRulesOnly
           ? { selected: preselected }

--- a/src/PresentationalComponents/Tailorings/components/TailoringTab.js
+++ b/src/PresentationalComponents/Tailorings/components/TailoringTab.js
@@ -132,10 +132,7 @@ const TailoringTab = ({
         profileRules,
         tailoringRules,
         valueDefinitions,
-        valueOverrides: {
-          ...tailoring?.value_overrides,
-          ...valueOverrides,
-        },
+        valueOverrides: { ...tailoring?.value_overrides, ...valueOverrides },
         ...(tableState?.tableState?.selectedRulesOnly
           ? { selected: preselected }
           : {}),

--- a/src/PresentationalComponents/Tailorings/components/TailoringTab.js
+++ b/src/PresentationalComponents/Tailorings/components/TailoringTab.js
@@ -132,7 +132,10 @@ const TailoringTab = ({
         profileRules,
         tailoringRules,
         valueDefinitions,
-        valueOverrides: { ...tailoring?.value_overrides, ...valueOverrides },
+        valueOverrides: {
+          ...tailoring?.value_overrides,
+          ...valueOverrides?.[osMinorVersion],
+        },
         ...(tableState?.tableState?.selectedRulesOnly
           ? { selected: preselected }
           : {}),

--- a/src/PresentationalComponents/Tailorings/helpers/skips.js
+++ b/src/PresentationalComponents/Tailorings/helpers/skips.js
@@ -73,7 +73,7 @@ const skipProfiles = ({
           skipValueDefinitions: hasNoOpenItems,
         },
         profile: {
-          skipRules: true,
+          skipRules: !profileId || selectedRulesOnlyDisabled,
           skipRuleTree: true,
         },
         tailoring: {
@@ -89,8 +89,8 @@ const skipProfiles = ({
           skipValueDefinitions: hasNoOpenItems,
         },
         profile: {
-          skipRules: true,
-          skipRuleTree: true,
+          skipRules: !profileId || selectedRulesOnlyDisabled || hasNoOpenItems,
+          skipRuleTree: !profileId || selectedRulesOnlyDisabled,
         },
         tailoring: {
           skipRules: !tailoring || selectedRulesOnlyDisabled || hasNoOpenItems,

--- a/src/PresentationalComponents/Tailorings/helpers/skips.test.js
+++ b/src/PresentationalComponents/Tailorings/helpers/skips.test.js
@@ -380,7 +380,7 @@ describe('skips', () => {
             skipValueDefinitions: true,
           },
           profile: {
-            skipRules: true,
+            skipRules: false,
             skipRuleTree: true,
           },
           tailoring: {
@@ -451,7 +451,7 @@ describe('skips', () => {
           },
           profile: {
             skipRules: true,
-            skipRuleTree: true,
+            skipRuleTree: false,
           },
           tailoring: {
             skipRules: true,
@@ -485,8 +485,8 @@ describe('skips', () => {
             skipValueDefinitions: false,
           },
           profile: {
-            skipRules: true,
-            skipRuleTree: true,
+            skipRules: false,
+            skipRuleTree: false,
           },
           tailoring: {
             skipRules: false,

--- a/src/Utilities/hooks/api/useComplianceTableState.js
+++ b/src/Utilities/hooks/api/useComplianceTableState.js
@@ -26,7 +26,7 @@ const useComplianceTableState = (useTableState, paramsOption) => {
             sortBy,
             ...(filter ? { filter } : {}),
           }
-        : paramsParam;
+        : paramsOption;
     } else {
       return paramsOption;
     }


### PR DESCRIPTION
There are fixes for some issues I found after https://github.com/RedHatInsights/compliance-frontend/pull/2388 

1. List rules view stoped showing checkboxes to select/unselect rules because `total` has been removed
2. Replaced `paramsParam` with `paramsOption` to respect also filters (found out that `filter` is not respected on EditPolicy systems table
3. When I was checking value editing on Create policy wizard I found out that valueOverrides are saved but UI still show default values so it's fixed now `...valueOverrides?.[osMinorVersion]`
4. Couple fixes for EditPolicy rules selection - Make `additionalRules` respect profiles and not only tailorings for showing tree correctly, make list rules show data on profiles if there are some selected (do not skip), use `setUpdatedPolicy` correctly for tailoringRules (fixes https://issues.redhat.com/browse/RHINENG-16357)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
