### PR TITLE
fix(RHINENG-16777): Fix policy inline edit

### DIFF
--- a/src/PresentationalComponents/PolicyDetailsDescription/PolicyDetailsDescription.js
+++ b/src/PresentationalComponents/PolicyDetailsDescription/PolicyDetailsDescription.js
@@ -68,7 +68,7 @@ const PolicyDetailsDescription = ({ policy, refetch }) => {
               Component={TextArea}
               text={descriptionText}
               variant="description"
-              inlineClosedText={businessText}
+              inlineClosedText={descriptionText}
               label="Policy description"
               propertyName="description"
               className="pf-v5-c-form-control"

--- a/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
+++ b/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
@@ -33,6 +33,7 @@ const EditPolicyDetailsInline = ({
   typeOfInput,
   Component = TextInput,
   refetch,
+  style,
   ...props
 }) => {
   const copiedData = policy;
@@ -62,10 +63,15 @@ const EditPolicyDetailsInline = ({
     setValue(newText);
     // setDirty(!!e.target.value);
   };
+
+  const handleSaveEdit = () => {
+    setIsEditOpen(false);
+    refetch();
+  };
+
   const handleCloseEdit = () => {
     setIsEditOpen(false);
     // setDirty(false);
-    refetch();
   };
 
   const constructData =
@@ -77,7 +83,7 @@ const EditPolicyDetailsInline = ({
         };
 
   const [isSaving, onSave] = useOnSavePolicyDetails(policy, constructData, {
-    onSave: handleCloseEdit,
+    onSave: handleSaveEdit,
   });
 
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -115,7 +121,7 @@ const EditPolicyDetailsInline = ({
       <div className="pf-v5-c-inline-edit__group">
         {isEditOpen ? (
           <>
-            <div>
+            <div style={style}>
               <Component value={value} onChange={handleTextUpdate} {...props} />
               {showTextUnderInline && validThreshold ? (
                 <Text>{textUnderInline}</Text>
@@ -209,6 +215,7 @@ EditPolicyDetailsInline.propTypes = {
   typeOfInput: propTypes.string,
   Component: propTypes.node,
   refetch: propTypes.func,
+  style: propTypes.object,
 };
 
 export default EditPolicyDetailsInline;

--- a/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.test.js
+++ b/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.test.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EditPolicyDetailsInline from './EditPolicyDetailsInline';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import useUpdatePolicy from 'Utilities/hooks/api/useUpdatePolicy';
+import { dispatchAction } from 'Utilities/Dispatcher';
+import { TextArea } from '@patternfly/react-core';
+
+jest.mock('@redhat-cloud-services/frontend-components-utilities/RBACHook');
+jest.mock('Utilities/hooks/api/useUpdatePolicy');
+jest.mock('Utilities/Dispatcher');
+
+describe('EditPolicyDetailsInline', () => {
+  beforeEach(() => {
+    useUpdatePolicy.mockReturnValue({
+      fetch: jest.fn(() => Promise.resolve()),
+    });
+    dispatchAction.mockImplementation(() => {});
+    usePermissionsWithContext.mockImplementation(() => ({
+      hasAccess: true,
+      isLoading: false,
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockPolicy = { id: '123', name: 'Test Policy' };
+  const mockRefetch = jest.fn();
+
+  const defaultProps = {
+    text: 'Test Text',
+    policy: mockPolicy,
+    variant: 'threshold',
+    propertyName: 'complianceThreshold',
+    inlineClosedText: 'Test Text Closed',
+    label: 'Test Label',
+    refetch: mockRefetch,
+    id: 'policydetails-input-threshold',
+  };
+
+  it('Renders the component with default props', () => {
+    render(<EditPolicyDetailsInline {...defaultProps} />);
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('Test Text Closed')).toBeInTheDocument();
+  });
+
+  it('No pencil button when user does not have access', () => {
+    usePermissionsWithContext.mockImplementation(() => ({
+      hasAccess: false,
+      isLoading: false,
+    }));
+
+    render(<EditPolicyDetailsInline {...defaultProps} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('Open and save edits works', async () => {
+    render(<EditPolicyDetailsInline {...defaultProps} />);
+
+    const pencilButton = screen.getByRole('button');
+    fireEvent.click(pencilButton);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '77' } });
+
+    const saveButton = screen.getByRole('button', { name: /Save edits/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(mockRefetch).toHaveBeenCalled());
+  });
+
+  it('Cancels edits when the cancel button is clicked', async () => {
+    render(<EditPolicyDetailsInline {...defaultProps} />);
+
+    const pencilButton = screen.getByRole('button');
+    fireEvent.click(pencilButton);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '77' } });
+
+    const cancelButton = screen.getByRole('button', { name: /Cancel edits/i });
+    fireEvent.click(cancelButton);
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    await waitFor(() => expect(mockRefetch).not.toHaveBeenCalled());
+  });
+
+  it('Save button disabled on invalid threshold input', () => {
+    render(<EditPolicyDetailsInline {...defaultProps} />);
+    const pencilButton = screen.getByRole('button');
+    fireEvent.click(pencilButton);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Invalid Threshold' } });
+
+    const saveButton = screen.getByRole('button', { name: /Save edits/i });
+    expect(saveButton).toBeDisabled();
+    expect(
+      screen.getByText(/Threshold has to be a number between 0 and 100/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Threshold values can have a maximum of one decimal place/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('Description input displayed correctly', () => {
+    const props = {
+      ...defaultProps,
+      variant: 'description',
+      text: 'Test description',
+      id: '',
+      Component: TextArea,
+      label: 'Policy description',
+      propertyName: 'description',
+    };
+
+    render(<EditPolicyDetailsInline {...props} />);
+    expect(screen.getByText('Test description')).toBeInTheDocument();
+
+    const pencilButton = screen.getByRole('button');
+    fireEvent.click(pencilButton);
+
+    const textbox = screen.getByRole('textbox');
+    expect(textbox.tagName).toBe('TEXTAREA');
+  });
+});

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -157,7 +157,7 @@ const PolicyDetails = ({ route }) => {
 
   return (
     <PolicyDetailsBase
-      query={{ ...query, data }}
+      query={{ ...query, data, refetch: query.fetch }}
       route={route}
       saveToPolicy={saveValue}
       versionCounts={versionCounts}

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -157,7 +157,7 @@ const PolicyDetails = ({ route }) => {
 
   return (
     <PolicyDetailsBase
-      query={{ ...query, data, refetch: query.fetch }}
+      query={{ ...query, data }}
       route={route}
       saveToPolicy={saveValue}
       versionCounts={versionCounts}

--- a/src/Utilities/hooks/api/useComplianceQuery.js
+++ b/src/Utilities/hooks/api/useComplianceQuery.js
@@ -95,6 +95,7 @@ import useComplianceTableState from './useComplianceTableState';
     error: queryError,
     loading: queryLoading,
     fetch: queryFetch,
+    refetch: queryRefetch,
   } = useQuery(apiEndpoint, {
     skip: batched ? true : skip,
     ...options,
@@ -138,6 +139,7 @@ import useComplianceTableState from './useComplianceTableState';
     fetchBatched: batchedFetch,
     fetchAllIds,
     exporter,
+    refetch: queryRefetch,
   };
 };
 


### PR DESCRIPTION
#### This PR deals with a couple of things:
1. Error when updating policy data (because refetch wasn't passed correctly)
2. No more re-render and api request when edit is cancelled
3. Styling fix for textArea (now edit description area is a bit bigger)
4. Test coverage

### How to test:
1. Navigate to policy Details tab
2. Try to update threshold, business obj & description ( see that it works )
3. Try to start editing and then cancel edit (no re-rendering happens, no api request made)
