### PR TITLE
feat(RHIENG-16658): Change Remediate button label to Plan remediation

### DIFF
--- a/src/PresentationalComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
+++ b/src/PresentationalComponents/ComplianceRemediationButton/ComplianceRemediationButton.js
@@ -32,7 +32,7 @@ const ComplianceRemediationButton = ({
       fallback={<FallbackButton />}
       {...buttonProps}
     >
-      Remediate
+      Plan remediation
     </RemediationRemediationButton>
   );
 };

--- a/src/PresentationalComponents/ComplianceRemediationButton/components/FallBackButton.js
+++ b/src/PresentationalComponents/ComplianceRemediationButton/components/FallBackButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
 
-const FallbackButton = ({ text = 'Remediate' }) => (
+const FallbackButton = ({ text = 'Plan remediation' }) => (
   <Button variant="primary" isDisabled>
     {text}
   </Button>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-16658
In accordance with the above ticket, this changes the text on the remediations button to say 'plan remediation' instead of 'remediate'

In compliance the button can be found in report details page 