### PR TITLE
fix(SystemsTable): RHINENG-13831 - Don't show N/A for 0 failed rules

### DIFF
--- a/src/SmartComponents/SystemsTable/Cells.js
+++ b/src/SmartComponents/SystemsTable/Cells.js
@@ -153,11 +153,7 @@ Policies.propTypes = {
 };
 
 export const FailedRules = ({ system_id, rulesFailed }) => {
-  return (
-    <SystemLink {...{ id: system_id }}>
-      {rulesFailed > 0 ? rulesFailed : 'N/A'}
-    </SystemLink>
-  );
+  return <SystemLink {...{ id: system_id }}>{rulesFailed}</SystemLink>;
 };
 
 FailedRules.propTypes = {

--- a/src/SmartComponents/SystemsTable/Cells.test.js
+++ b/src/SmartComponents/SystemsTable/Cells.test.js
@@ -63,7 +63,7 @@ describe('FailedRules', () => {
       </TestWrapper>
     );
 
-    expect(screen.getByText('N/A')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
This changes the failed rules column on ReportDetails to show `0` instead of `N/A`. 

**Before:**

![Screenshot 2025-03-25 at 11 50 30](https://github.com/user-attachments/assets/bcb3516f-7973-4a7c-a0e6-03f12f2d7fe1)



**After:** 

![Screenshot 2025-03-25 at 11 50 38](https://github.com/user-attachments/assets/6afa840d-8f80-4e28-8898-70e33418b6f7)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
