### PR TITLE
fix(RHINENG-15810): Make export work when no selection made

### DIFF
--- a/src/SmartComponents/SystemsTable/Columns.js
+++ b/src/SmartComponents/SystemsTable/Columns.js
@@ -88,7 +88,7 @@ export const Policies = {
   transforms: [nowrap],
   key: 'policies',
   exportKey: 'policies',
-  renderExport: (policies) => policies.map(({ title }) => title).join(', '),
+  renderExport: (policies) => policies.map(({ name }) => name).join(', '),
   props: {
     width: 40,
     ...disableSorting,

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -169,6 +169,7 @@ export const SystemsTable = ({
     columns,
     selectedItems,
     total,
+    fetchSystems,
   });
 
   const handleOperatingSystemsFetch = useCallback(

--- a/src/SmartComponents/SystemsTable/hooks.js
+++ b/src/SmartComponents/SystemsTable/hooks.js
@@ -183,8 +183,21 @@ export const useInventoryUtilities = (
   }, [activeFilters]);
 };
 
-export const useSystemsExport = ({ columns, selectedItems, total }) => {
-  const exporter = async () => selectedItems;
+export const useSystemsExport = ({
+  columns,
+  selectedItems,
+  total,
+  fetchSystems,
+}) => {
+  const { fetchBatched } = useFetchBatched();
+  const exporter = async () => {
+    if (selectedItems && selectedItems.length > 0) {
+      return selectedItems;
+    } else {
+      const fetchedItems = await fetchBatched(fetchSystems, total);
+      return fetchedItems.flatMap((result) => result.entities);
+    }
+  };
 
   const {
     toolbarProps: { exportConfig },


### PR DESCRIPTION
This PR fixes the issue when you have 0 systems selected and try to export all systems + exported data will have policies column populated instead of being empty.

### How to test:
1. Navigate to Compliance systems page
2. Try to export entities without selection
3. Check if all systems have been exported
4. Try to export entities with selection
5. Check if only selected systems have been exported
6. Check if both exports have policies column populated

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
