### PR TITLE
fix(RHINENG-17367): Define bulkSelect selectedIds before accessing it

### DIFF
--- a/src/Frameworks/AsyncTableTools/hooks/useBulkSelect/useBulkSelect.js
+++ b/src/Frameworks/AsyncTableTools/hooks/useBulkSelect/useBulkSelect.js
@@ -49,7 +49,7 @@ const useBulkSelect = ({
   const [loading, setLoading] = useState(false);
   const enableBulkSelect = !!onSelect;
   const {
-    selection: selectedIds,
+    selection: selectedIds = [],
     set,
     select,
     deselect,
@@ -116,12 +116,12 @@ const useBulkSelect = ({
         {
           ...firstRow,
           ...(!isTreeTable
-            ? { selected: selectedIds?.includes(item.itemId) }
+            ? { selected: selectedIds.includes(item.itemId) }
             : {}),
           props: {
             ...firstRow.props,
             ...(isTreeTable && !item.isTreeBranch
-              ? { isChecked: selectedIds?.includes(item.itemId) }
+              ? { isChecked: selectedIds.includes(item.itemId) }
               : {}),
           },
         },


### PR DESCRIPTION
PR fixes selection on System details page when we have 0 preselected items (`selectedIds` is undefined).

### How to test:

1. Navigate to System details page and ensure that single selection works
2. Check if bulk select works on System details too

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
