### PR TITLE
fix(RHINENG-13839): Tooltip content misalignment never reported

### DIFF
--- a/src/SmartComponents/SystemsTable/Cells.js
+++ b/src/SmartComponents/SystemsTable/Cells.js
@@ -186,10 +186,10 @@ const NeverScanned = () => (
       </Fragment>
     }
   >
-    <div>
+    <span>
       <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
       {' ' + NEVER}
-    </div>
+    </span>
   </Tooltip>
 );
 


### PR DESCRIPTION
Before:

<img width="896" alt="Screenshot 2025-04-17 at 14 08 43" src="https://github.com/user-attachments/assets/e29edddf-2b64-4273-80cc-0b335700cfde" />

After:

<img width="896" alt="Screenshot 2025-04-17 at 14 08 06" src="https://github.com/user-attachments/assets/786a7bd3-f77f-4302-9495-e611851d7646" />
