### PR TITLE
feat(CreatePolicy): RHINENG-15324 - Allow policies without hosts

### DIFF
--- a/src/PresentationalComponents/Tailorings/Tailorings.js
+++ b/src/PresentationalComponents/Tailorings/Tailorings.js
@@ -128,10 +128,11 @@ const Tailorings = ({
                         }}
                       />
                     </FlexItem>
-                    {selectedVersionCounts?.[tab.os_minor_version] && (
+                    {typeof selectedVersionCounts?.[tab.os_minor_version] !==
+                      'undefined' && (
                       <FlexItem>
                         <Badge isRead>
-                          {selectedVersionCounts[tab.os_minor_version]}
+                          {` ${selectedVersionCounts[tab.os_minor_version]} `}
                         </Badge>
                       </FlexItem>
                     )}

--- a/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
@@ -78,10 +78,11 @@ const EditPolicyProfilesRules = ({
   const additionalRules =
     profilesAndRuleIds &&
     selectedRuleRefIds?.reduce((additions, profileAndRules) => {
-      const originalRules = profilesAndRuleIds.find(
-        ({ osMinorVersion }) =>
-          osMinorVersion === profileAndRules.osMinorVersion
-      ).ruleIds;
+      const originalRules =
+        profilesAndRuleIds.find(
+          ({ osMinorVersion }) =>
+            osMinorVersion === profileAndRules.osMinorVersion
+        )?.ruleIds || [];
 
       return {
         ...additions,

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import {
   propTypes as reduxFormPropTypes,
   reduxForm,
@@ -86,7 +86,9 @@ export const EditPolicySystems = ({
   profile,
   change,
   osMajorVersion,
+  osMinorVersionCounts,
   selectedSystems = [],
+  allowNoSystems,
 }) => {
   const onSelect = useOnSelect(change, countOsMinorVersions);
   const osMinorVersions = profile.supportedOsVersions.map(
@@ -107,6 +109,18 @@ export const EditPolicySystems = ({
       };
     });
 
+  useEffect(() => {
+    if (!osMinorVersionCounts || !osMinorVersionCounts.length) {
+      change(
+        'osMinorVersionCounts',
+        profile.supportedOsVersions.map((version) => ({
+          osMinorVersion: version.split('.')[1],
+          count: 0,
+        }))
+      );
+    }
+  }, [profile, osMinorVersionCounts, change]);
+
   return (
     <React.Fragment>
       <TextContent className="pf-v5-u-mb-md">
@@ -117,7 +131,9 @@ export const EditPolicySystems = ({
           <SystemsTable
             showOsMinorVersionFilter={[osMajorVersion]}
             prependComponent={
-              <PrependComponent osMajorVersion={osMajorVersion} />
+              allowNoSystems ? undefined : (
+                <PrependComponent osMajorVersion={osMajorVersion} />
+              )
             }
             emptyStateComponent={<EmptyState osMajorVersion={osMajorVersion} />}
             columns={[
@@ -155,14 +171,17 @@ export const EditPolicySystems = ({
 EditPolicySystems.propTypes = {
   osMajorVersion: propTypes.string,
   profile: propTypes.object,
+  osMinorVersionCounts: propTypes.array,
   selectedSystems: propTypes.array,
   change: reduxFormPropTypes.change,
+  allowNoSystems: propTypes.bool,
 };
 
 const selector = formValueSelector('policyForm');
 const mapStateToProps = (state) => ({
   profile: selector(state, 'profile'),
   osMajorVersion: selector(state, 'osMajorVersion'),
+  osMinorVersionCounts: selector(state, 'osMinorVersionCounts'),
   selectedSystems: selector(state, 'systems'),
 });
 

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
@@ -59,10 +59,12 @@ export const useUpdatePolicy = () => {
 
       const { id: newPolicyId } = createPolicyResponse.data;
 
-      await assignSystems(
-        [newPolicyId, undefined, { ids: hosts.map(({ id }) => id) }],
-        false
-      );
+      if (hosts) {
+        await assignSystems(
+          [newPolicyId, undefined, { ids: hosts.map(({ id }) => id) }],
+          false
+        );
+      }
 
       dispatchProgress();
 

--- a/src/SmartComponents/CreatePolicy/validate.js
+++ b/src/SmartComponents/CreatePolicy/validate.js
@@ -31,10 +31,10 @@ export const validateDetailsPage = (name, refId, complianceThreshold) =>
 export const validateRulesPage = (selectedRuleRefIds) =>
   selectedRuleRefIds?.length > 0;
 
-export const validateSystemsPage = (systemIds) => {
-  if (systemIds) {
-    return systemIds.length > 0;
+export const validateSystemsPage = (systemIds, allowNoSystems) => {
+  if (allowNoSystems) {
+    return true;
   } else {
-    return false;
+    return systemIds?.length > 0;
   }
 };


### PR DESCRIPTION
This PR changes the behaviour of the "Create Policy" wizard to allow creating policies without initially assigning hosts and default to set up a policy with profiles for all available minor OS versions. 


https://github.com/user-attachments/assets/a73fa52a-062c-4f77-8e04-04b077d6e400




**How to test:**

1) Open the "Create policy" wizard
2) Choose a policy and proceed to the "Systems" step
3) Do NOT select any hosts and verify that it is possible to advance to the "Rules" step
4) Verify the "Rules" step loads all minor OS version profiles correctly and shows know assigned hosts.
5) Move forward to the finishing steps and verify the policy was correctly created


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
