### PR TITLE
fix(CreatePolicy): RHINENG-15324 - Explicitly create tailorings when no hosts

### DIFF
--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.test.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.test.js
@@ -103,16 +103,13 @@ describe('useUpdatePolicy', () => {
 
     await result.current(undefined, policyDataToSubmit, onProgress);
 
-    expect(assignSystems).toBeCalledWith(
-      [
-        createdPolicyId,
-        undefined, // X-RH identity
-        {
-          ids: policyDataToSubmit.hosts.map(({ id }) => id),
-        },
-      ],
-      false // to return response data
-    );
+    expect(assignSystems).toBeCalledWith([
+      createdPolicyId,
+      undefined, // X-RH identity
+      {
+        ids: policyDataToSubmit.hosts.map(({ id }) => id),
+      },
+    ]);
   });
 
   it('fetches tailorings and adds rules to these tailorings', async () => {

--- a/src/Utilities/hooks/api/useCreateTailoring.js
+++ b/src/Utilities/hooks/api/useCreateTailoring.js
@@ -1,0 +1,12 @@
+import { useComplianceMutation } from '../useComplianceQuery';
+
+const convertToArray = ({ policyId, tailoringCreate }) => [
+  policyId,
+  undefined, // xRHIDENTITY
+  tailoringCreate,
+];
+
+const useCreatePolicy = (options) =>
+  useComplianceMutation('createTailoring', { ...options, convertToArray });
+
+export default useCreatePolicy;

--- a/src/Utilities/hooks/useComplianceQuery/index.js
+++ b/src/Utilities/hooks/useComplianceQuery/index.js
@@ -1,1 +1,2 @@
 export { default } from './useComplianceQuery';
+export { default as useComplianceMutation } from './useComplianceMutation';

--- a/src/Utilities/hooks/useComplianceQuery/useComplianceMutation.js
+++ b/src/Utilities/hooks/useComplianceQuery/useComplianceMutation.js
@@ -1,0 +1,6 @@
+import useComplianceQuery from '../useComplianceQuery';
+
+const useComplianceMutation = (endpoint, options) =>
+  useComplianceQuery(endpoint, { ...options, skip: true });
+
+export default useComplianceMutation;


### PR DESCRIPTION
This is a followup to https://github.com/RedHatInsights/compliance-frontend/pull/2487
and adds explicitly creating the tailorings if no hosts were selected.


**How to test:**

1) Follow the steps described in https://github.com/RedHatInsights/compliance-frontend/pull/2487
2) Open the policy and ensure that it does have tailorings on the "Rules" tab


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
