### PR TITLE
feat(RHINENG-14515): Use Report score value from backend resp

### DIFF
--- a/src/PresentationalComponents/ReportsTable/Cells.test.js
+++ b/src/PresentationalComponents/ReportsTable/Cells.test.js
@@ -55,6 +55,7 @@ describe('ReportsTable Cells', () => {
       reported_system_count: 7,
       unsupported_system_count: 2,
       compliant_system_count: 4,
+      percent_compliant: 40,
     };
 
     render(

--- a/src/SmartComponents/ReportDetails/Components/ReportChart.test.js
+++ b/src/SmartComponents/ReportDetails/Components/ReportChart.test.js
@@ -15,6 +15,7 @@ describe('ReportChart', () => {
       reported_system_count: 7,
       unsupported_system_count: 2,
       compliant_system_count: 4,
+      percent_compliant: 40,
     };
 
     const component = <ReportChart report={reportData} />;
@@ -29,6 +30,7 @@ describe('ReportChart', () => {
       reported_system_count: 5,
       unsupported_system_count: 0,
       compliant_system_count: 4,
+      percent_compliant: 80,
     };
 
     const component = <ReportChart report={reportData} />;

--- a/src/SmartComponents/ReportDetails/Components/hooks/useDonutChart.js
+++ b/src/SmartComponents/ReportDetails/Components/hooks/useDonutChart.js
@@ -48,11 +48,10 @@ const useDonutChart = (report) => {
     reported_system_count: testResultSystemCount = 0,
     unsupported_system_count: unsupportedSystemCount = 0,
     assigned_system_count: totalSystemCount = 0,
+    percent_compliant: compliancePercentage = 0,
   } = report;
 
   const notReportingSystemCount = totalSystemCount - testResultSystemCount;
-  // TODO: This is not always true as unsupported.
-  // Deal with it after RHINENG-14550
   const nonCompliantSystemCount =
     testResultSystemCount - compliantSystemCount - unsupportedSystemCount;
 
@@ -74,12 +73,6 @@ const useDonutChart = (report) => {
   const flyoutValues = [150, 180, 170, 170];
   const legendData = useLegendData(donutValues);
 
-  const compliancePercentage = fixedPercentage(
-    totalSystemCount > 0
-      ? Math.floor(100 * (compliantSystemCount / totalSystemCount))
-      : 0
-  );
-
   return {
     chartProps: {
       data: donutValues,
@@ -96,7 +89,7 @@ const useDonutChart = (report) => {
         />
       ),
       identifier: donutId,
-      title: compliancePercentage,
+      title: fixedPercentage(compliancePercentage),
       subTitle: 'Compliant',
       themeVariant: ChartThemeColor.light,
       colorScale: chartColorScale,

--- a/src/__factories__/reports.js
+++ b/src/__factories__/reports.js
@@ -22,7 +22,6 @@ export const buildReports = (length) =>
       min: 0,
       max: max_number_unsupported_systems,
     });
-    // TODO: we will probably need to fix it after https://issues.redhat.com/browse/RHINENG-14550
     return {
       id: faker.string.uuid(),
       title,


### PR DESCRIPTION
Counting score has been fixed on backend side so we can directly use it from response instead of calculating it by ourself.

### How to test:

1. Have reported systems (you can use compliance script to upload it or just account that has some reported systems)
2. Navigate to Reports/Report details pages
3. Check if score inside donut chart shows correct value (compliant_systems / assigned_systems) * 100%

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
