### PR TITLE
feat(RHINENG-18226): Update RemediationCell values

### DIFF
--- a/src/PresentationalComponents/RemediationCell/RemediationCell.js
+++ b/src/PresentationalComponents/RemediationCell/RemediationCell.js
@@ -2,7 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 
 const RemediationCell = ({ hasPlaybook = false }) => (
-  <>{hasPlaybook ? ' Playbook' : ' Manual'}</>
+  <>{hasPlaybook ? ' Automated' : ' Manual'}</>
 );
 RemediationCell.propTypes = {
   hasPlaybook: propTypes.bool,

--- a/src/PresentationalComponents/RemediationCell/RemediationCell.test.js
+++ b/src/PresentationalComponents/RemediationCell/RemediationCell.test.js
@@ -9,9 +9,9 @@ describe('RemediationCell', () => {
     expect(screen.getByText('Manual')).toBeInTheDocument();
   });
 
-  it('expect to render "Palybook"', () => {
+  it('expect to render "Automated"', () => {
     render(<RemediationCell hasPlaybook={true} />);
 
-    expect(screen.getByText('Playbook')).toBeInTheDocument();
+    expect(screen.getByText('Automated')).toBeInTheDocument();
   });
 });

--- a/src/PresentationalComponents/RulesTable/Columns.js
+++ b/src/PresentationalComponents/RulesTable/Columns.js
@@ -41,7 +41,8 @@ export const Remediation = {
   title: 'Remediation type',
   transforms: [nowrap],
   sortable: 'remediation_available',
-  renderExport: (rule) => (rule?.remediation_available ? 'Playbook' : 'Manual'),
+  renderExport: (rule) =>
+    rule?.remediation_available ? 'Automated' : 'Manual',
   renderFunc: renderComponent(RemediationColumnCell),
 };
 

--- a/src/PresentationalComponents/Tailorings/Tailorings.cy.js
+++ b/src/PresentationalComponents/Tailorings/Tailorings.cy.js
@@ -403,7 +403,7 @@ describe('Tailorings - Tailorings on Policy details', () => {
             );
             cy.get('td[data-label="Remediation type"]').should(
               'contain',
-              foundRule.remediation_available ? 'Playbook' : 'Manual'
+              foundRule.remediation_available ? 'Automated' : 'Manual'
             );
             cy.get('div').find("span[class*='table__toggle']").click();
           });

--- a/src/SmartComponents/SystemDetails/Columns.js
+++ b/src/SmartComponents/SystemDetails/Columns.js
@@ -25,7 +25,7 @@ export const PassedSystemDetails = {
 export const RemediationSystemDetails = {
   ...Remediation,
   sortByFunction: (rule) => rule?.remediation_issue_id,
-  renderExport: (rule) => (rule?.remediation_issue_id ? 'Playbook' : 'Manual'),
+  renderExport: (rule) => (rule?.remediation_issue_id ? 'Automated' : 'Manual'),
   renderFunc: renderComponent(RemediationColumnCell),
 };
 


### PR DESCRIPTION
This simply updates all the remediation cell values from `Playbook` to `Automated`.
 As per https://issues.redhat.com/browse/RHINENG-18226

## Summary by Sourcery

Update remediation display to use 'Automated' instead of 'Playbook' across UI components and exports

Enhancements:
- Replace 'Playbook' label with 'Automated' in RemediationCell and table column export renderers for rules and system details

Tests:
- Update unit and Cypress tests to expect 'Automated' in place of 'Playbook' for remediation availability