### PR TITLE
chore: RHINENG-16640 - Upgrade to node v22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      CYPRESS_DEFAULT_BROWSER: chrome
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -18,7 +18,7 @@ COPY ./entrypoint.sh /
 # nvm environment variables
 ENV NVM_DIR /root/.nvm
 RUN mkdir -p $NVM_DIR
-ENV NODE_VERSION 16.13.0
+ENV NODE_VERSION 22
 
 # install nvm
 # https://github.com/creationix/nvm#install-script

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -7,7 +7,7 @@
 export IMAGE="quay.io/cloudservices/compliance-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=20
+export NODE_BUILD_VERSION=22
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 set -exv

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "test": "jest --passWithNoTests",
     "test:nocoverage": "jest --passWithNoTests --no-coverage",
     "test:snapshots": "jest -u --passWithNoTests --no-coverage",
-    "test:ct": "BABEL_ENV=componentTest cypress run --browser chrome --component",
+    "test:ct": "BABEL_ENV=componentTest cypress run --component",
     "test:openct": "BABEL_ENV=componentTest cypress open --component",
     "test:coverage": "curl -sSL 'https://raw.githubusercontent.com/RedHatInsights/insights-interact-tools/refs/heads/main/scripts/coverage.sh' | bash",
     "lint": "npm-run-all lint:*",

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,7 +7,7 @@
 export IMAGE="quay.io/cloudservices/compliance-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=18
+export NODE_BUILD_VERSION=22
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 set -exv


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Upgrade Node to v22 and streamline Cypress testing configuration

Build:
- Bump NODE_BUILD_VERSION to v22 in build and PR check scripts

CI:
- Set CYPRESS_DEFAULT_BROWSER=chrome in CI test workflow

Tests:
- Remove explicit Chrome flag from Cypress component test script