### PR TITLE
fix(RHINENG-3019): Fix backend app name

### DIFF
--- a/src/SmartComponents/ExportPDF/ReportPDFBuild.js
+++ b/src/SmartComponents/ExportPDF/ReportPDFBuild.js
@@ -38,7 +38,7 @@ export const fetchData = async (createAsyncRequest, options) => {
   let refId = null;
 
   // Report details
-  const rawReportResponse = await createAsyncRequest('compliance-backend', {
+  const rawReportResponse = await createAsyncRequest('compliance', {
     method: 'GET',
     url: `${API_BASE_URL}/reports/${reportId}`,
   });
@@ -51,7 +51,7 @@ export const fetchData = async (createAsyncRequest, options) => {
   // Top 10 failed rules
   if (options.exportSettings.topTenFailedRules) {
     try {
-      const response = await createAsyncRequest('compliance-backend', {
+      const response = await createAsyncRequest('compliance', {
         method: 'GET',
         url: `${API_BASE_URL}/reports/${reportId}/stats`,
       });

--- a/src/SmartComponents/ExportPDF/ReportPDFBuild.test.js
+++ b/src/SmartComponents/ExportPDF/ReportPDFBuild.test.js
@@ -82,11 +82,11 @@ describe('fetchData', () => {
     const result = await fetchData(createAsyncRequest, options);
 
     expect(createAsyncRequest).toHaveBeenCalledTimes(2); // reportDetails & top failed rules
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${mockReportId}`,
     });
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${mockReportId}/stats`,
     });
@@ -167,7 +167,7 @@ describe('fetchData', () => {
     const result = await fetchData(createAsyncRequest, options);
 
     expect(createAsyncRequest).toHaveBeenCalledTimes(1);
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${mockReportId}`,
     });

--- a/src/SmartComponents/ExportPDF/helpers.js
+++ b/src/SmartComponents/ExportPDF/helpers.js
@@ -11,7 +11,7 @@ export const fetchPaginatedList = async (
   let allItems = [];
 
   const fetchPage = async (limit, offset) => {
-    return await createAsyncRequest('compliance-backend', {
+    return await createAsyncRequest('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${reportId}${endpointPath}`,
       params: { limit, offset, filter },
@@ -80,7 +80,7 @@ export const fetchUnsupportedSystemsWithExpectedSSG = async (
     const securityGuidePromises = Array.from(uniqueOsMinorVersions).map(
       async (osMinorVersion) => {
         try {
-          const response = await createAsyncRequest('compliance-backend', {
+          const response = await createAsyncRequest('compliance', {
             method: 'GET',
             url: `${API_BASE_URL}/security_guides`,
             params: {

--- a/src/SmartComponents/ExportPDF/helpers.test.js
+++ b/src/SmartComponents/ExportPDF/helpers.test.js
@@ -43,7 +43,7 @@ describe('fetchPaginatedList', () => {
     );
 
     expect(createAsyncRequest).toHaveBeenCalledTimes(1);
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${reportId}${endpointPath}`,
       params: { limit: batchSize, offset: 0, filter },
@@ -83,17 +83,17 @@ describe('fetchPaginatedList', () => {
 
     expect(createAsyncRequest).toHaveBeenCalledTimes(3);
 
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${reportId}${endpointPath}`,
       params: { limit: batchSize, offset: 0, filter },
     });
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${reportId}${endpointPath}`,
       params: { limit: batchSize, offset: batchSize, filter },
     });
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${reportId}${endpointPath}`,
       params: { limit: batchSize, offset: 4, filter },
@@ -224,7 +224,7 @@ describe('fetchUnsupportedSystemsWithExpectedSSG', () => {
     );
 
     expect(createAsyncRequest).toHaveBeenCalledTimes(3);
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/reports/${reportId}/test_results`,
       params: {
@@ -233,7 +233,7 @@ describe('fetchUnsupportedSystemsWithExpectedSSG', () => {
         offset: 0,
       },
     });
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/security_guides`,
       params: {
@@ -242,7 +242,7 @@ describe('fetchUnsupportedSystemsWithExpectedSSG', () => {
         sort_by: `version:desc`,
       },
     });
-    expect(createAsyncRequest).toHaveBeenCalledWith('compliance-backend', {
+    expect(createAsyncRequest).toHaveBeenCalledWith('compliance', {
       method: 'GET',
       url: `${API_BASE_URL}/security_guides`,
       params: {


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Correct the backend service identifier for PDF export requests by replacing 'compliance-backend' with 'compliance' across helper and build modules

Bug Fixes:
- Use 'compliance' instead of 'compliance-backend' for createAsyncRequest calls in PDF export helpers
- Update corresponding tests to expect the renamed backend app identifier