### PR TITLE
feat(CreatePolicy): RHINENG-19425 - Always allow policies without hosts

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -1,10 +1,9 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import { formValueSelector, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import { Wizard } from '@patternfly/react-core/deprecated';
-import usePolicies from 'Utilities/hooks/api/usePolicies';
 import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 import CreateSCAPPolicy from './CreateSCAPPolicy';
 import { default as EditPolicyRules } from './EditPolicyProfilesRules/EditPolicyProfilesRules';
@@ -30,7 +29,7 @@ export const CreatePolicyForm = ({
   systemIds,
   reset,
 }) => {
-  const enableHostless = useFeatureFlag('image-builder.compliance.enabled');
+  const allowNoSystems = useFeatureFlag('image-builder.compliance.enabled');
   const navigate = useNavigate();
   const [stepIdReached, setStepIdReached] = useState(1);
   const resetAnchor = () => {
@@ -50,15 +49,6 @@ export const CreatePolicyForm = ({
     reset();
     navigate('/scappolicies');
   };
-
-  const { data: policiesTotal } = usePolicies({
-    onlyTotal: true,
-  });
-
-  const allowNoSystems = useMemo(
-    () => enableHostless && policiesTotal === 0,
-    [policiesTotal, enableHostless],
-  );
 
   const steps = [
     {

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   propTypes as reduxFormPropTypes,
   reduxForm,
@@ -95,6 +95,19 @@ export const EditPolicySystems = ({
       `os_minor_version ^ (${osMinorVersions.join(' ')}) AND ` +
       `profile_ref_id !^ (${profile.ref_id})`
     : '';
+
+  useEffect(() => {
+    if (selectedSystems.length === 0) {
+      change('systems', []);
+      change(
+        'osMinorVersionCounts',
+        osMinorVersions.map((version) => ({
+          osMinorVersion: version,
+          count: 0,
+        })),
+      );
+    }
+  }, [selectedSystems, change, osMinorVersions]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
This will allow creating policies even if there are already policies existing.

**How to test:**

0) Ensure the `image-builder.compliance.enabled` is enabled
1) Create a policy
2) Do not select any systems
3) Verify the "Next" button is clickable and proceed to the rules
4) Verify all profiles for each minor version are loaded
5) Finish the wizard and verify the policy was created properly 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enable creation of policies without selected systems whenever the image-builder compliance feature flag is active, remove the previous restriction based on existing policy count, and adjust form state to properly handle empty system selections.

New Features:
- Support creating hostless policies when the image-builder.compliance.enabled feature flag is enabled regardless of existing policies.

Enhancements:
- Add effect in the systems selection step to clear selected systems and initialize OS minor version counts to zero when no systems are chosen.
- Remove policies total fetch and related logic and rename the feature flag variable for clarity.