### PR TITLE
fix(CreatePolicy): Set minor OS counts initially

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
@@ -55,7 +55,7 @@ const EditPolicyProfilesRules = ({
   } = useProfileRuleIds({
     profileRefId,
     osMajorVersion,
-    osMinorVersions: osMinorVersionCounts.map(
+    osMinorVersions: osMinorVersionCounts?.map(
       ({ osMinorVersion }) => osMinorVersion,
     ),
     skip: skipFetchingProfileRuleIds,

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -66,13 +66,13 @@ PrependComponent.propTypes = {
   osMajorVersion: propTypes.string,
 };
 
-const useOnSelect = (change, countOsMinorVersions) => {
+const useOnSelect = (change) => {
   const onSelect = useCallback(
     (newSelectedSystems) => {
       change('systems', newSelectedSystems);
       change('osMinorVersionCounts', countOsMinorVersions(newSelectedSystems));
     },
-    [change, countOsMinorVersions],
+    [change],
   );
 
   return onSelect;
@@ -82,23 +82,24 @@ export const EditPolicySystems = ({
   profile,
   change,
   osMajorVersion,
+  osMinorVersionCounts,
   selectedSystems = [],
   allowNoSystems,
 }) => {
-  const onSelect = useOnSelect(change, countOsMinorVersions);
-  const osMinorVersions = profile.supportedOsVersions.map(
-    (version) => version.split('.')[1],
-  );
+  const onSelect = useOnSelect(change);
 
-  const defaultFilter = osMajorVersion
-    ? `os_major_version = ${osMajorVersion} AND ` +
-      `os_minor_version ^ (${osMinorVersions.join(' ')}) AND ` +
-      `profile_ref_id !^ (${profile.ref_id})`
-    : '';
+  const defaultFilter =
+    osMajorVersion && osMinorVersionCounts
+      ? `os_major_version = ${osMajorVersion} AND ` +
+        `os_minor_version ^ (${osMinorVersionCounts.map(({ osMinorVersion }) => osMinorVersion).join(' ')}) AND ` +
+        `profile_ref_id !^ (${profile.ref_id})`
+      : '';
 
   useEffect(() => {
-    if (selectedSystems.length === 0) {
-      change('systems', []);
+    if (!osMinorVersionCounts) {
+      const osMinorVersions = profile.supportedOsVersions.map(
+        (version) => version.split('.')[1],
+      );
       change(
         'osMinorVersionCounts',
         osMinorVersions.map((version) => ({
@@ -107,7 +108,7 @@ export const EditPolicySystems = ({
         })),
       );
     }
-  }, [selectedSystems, change, osMinorVersions]);
+  }, [change, osMinorVersionCounts, profile]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
This ensures there is always a minor OS count and the "Next" button is activated.


**How to test**

1) Disable the `image-builder.compliance.enabled` feature flag
2) Create a new policy
3) Verify that when no systems are selected the "Next" button is disabled, until a system is selected.

4) Enable the `image-builder.compliance.enabled` feature flag
5) Create a new policy
6) Verify that even if no systems are selected the "Next" button is enabled


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
