### PR TITLE
fix(SystemDetails): Fetch rule_id for bulk selection

### DIFF
--- a/src/SmartComponents/SystemDetails/RuleResults.js
+++ b/src/SmartComponents/SystemDetails/RuleResults.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import propTypes from 'prop-types';
 import TableStateProvider from '@/Frameworks/AsyncTableTools/components/TableStateProvider';
 import useReportRuleResults from 'Utilities/hooks/api/useReportRuleResults';
@@ -17,7 +17,7 @@ const RuleResults = ({ reportTestResult }) => {
   const {
     data: ruleResults,
     exporter,
-    fetchAllIds,
+    fetchBatched,
   } = useReportRuleResults({
     params: {
       testResultId,
@@ -25,6 +25,12 @@ const RuleResults = ({ reportTestResult }) => {
     },
     useTableState: true,
   });
+
+  const fetchAllIds = useCallback(
+    async (...args) =>
+      (await fetchBatched(...args)).data.map(({ rule_id }) => rule_id),
+    [fetchBatched],
+  );
 
   const transformRules = (ruleResults, reportTestResult) => {
     return ruleResults !== undefined

--- a/src/SmartComponents/SystemDetails/RuleResults.test.js
+++ b/src/SmartComponents/SystemDetails/RuleResults.test.js
@@ -7,8 +7,6 @@ import { buildTestResults } from '@/__factories__/ruleResults';
 
 jest.mock('Utilities/hooks/api/useReportRuleResults', () => jest.fn());
 
-const fetchAllIds = jest.fn();
-
 describe('RuleResults', () => {
   const reportTestResult = {
     id: 'test-id',
@@ -31,6 +29,10 @@ describe('RuleResults', () => {
   it('renders Select all in bulk select dropdown', async () => {
     const testResults = buildTestResults(11);
 
+    const fetchAllIds = jest.fn(() => ({
+      data: testResults.map(({ id }) => id),
+    }));
+
     useReportRuleResults.mockImplementation(() => ({
       data: {
         data: testResults.slice(0, 10),
@@ -38,7 +40,7 @@ describe('RuleResults', () => {
       },
       loading: false,
       error: null,
-      fetchAllIds,
+      fetchBatched: fetchAllIds,
     }));
     render(<RuleResultsWrapper reportTestResult={reportTestResult} />);
 


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Use fetchBatched to retrieve and map rule_id for table bulk selection in RuleResults.

Bug Fixes:
- Fix bulk selection in SystemDetails by correctly fetching rule_id values

Enhancements:
- Replace hook-provided fetchAllIds with a custom useCallback that maps rule_id from fetchBatched