### PR TITLE
feat: RHINENG-20187 - Implement Import Rules modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@tanstack/react-query": "^5.86.0",
         "@unleash/proxy-client-react": "^3.6.0",
         "axios": "^1.11.0",
-        "bastilian-tabletools": "^2.12.3",
+        "bastilian-tabletools": "^2.14.0",
         "linkify-html": "^4.3.2",
         "linkifyjs": "^4.3.2",
         "p-all": "^5.0.0",
@@ -9328,9 +9328,9 @@
       "license": "MIT"
     },
     "node_modules/bastilian-tabletools": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.12.3.tgz",
-      "integrity": "sha512-KYWm7GrH4ppl8M2N6Mha/H24SJCMPye6rU187WnVIHdbktM51t50JtDnXmEHwktVslXVzWBogiES2a9L0J0l+A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.14.0.tgz",
+      "integrity": "sha512-GyE9v/VdVeWY9+LQNcO+iCyFMuB/Ue5/RoydqEO95DynRR3LCMbbrvbqyKHWJkJdEuuIYggpuLHu3D92knCeNA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -9343,8 +9343,9 @@
         "@patternfly/react-table": "^6.0.0",
         "@redhat-cloud-services/frontend-components": ">= 6.1.0",
         "@redhat-cloud-services/frontend-components-utilities": ">= 6.1.0",
-        "@tanstack/react-pacer": "^0.16.1",
-        "@tanstack/react-query": "^5.83.0",
+        "@tanstack/react-pacer": ">= 0.15.0",
+        "@tanstack/react-query": ">= 5.83.0",
+        "p-all": ">= 4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "use-deep-compare": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@tanstack/react-query": "^5.86.0",
     "@unleash/proxy-client-react": "^3.6.0",
     "axios": "^1.11.0",
-    "bastilian-tabletools": "^2.12.3",
+    "bastilian-tabletools": "^2.14.0",
     "linkify-html": "^4.3.2",
     "linkifyjs": "^4.3.2",
     "p-all": "^5.0.0",

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -110,6 +110,19 @@ const policiesRoutes = [
     modal: true,
   },
   {
+    path: 'scappolicies/:policy_id/import-rules',
+    title: `$entityTitle - ${defaultPoliciesTitle}`,
+    defaultTitle: defaultPoliciesTitle,
+    requiredPermissions: [...defaultPermissions, 'compliance:policy:update'],
+    component: lazy(
+      () =>
+        import(
+          /* webpackChunkName: "ImportRules" */ 'SmartComponents/ImportRules/ImportRules'
+        ),
+    ),
+    modal: true,
+  },
+  {
     path: 'scappolicies/:policy_id/delete',
     title: `Delete policy - ${defaultPoliciesTitle}`,
     requiredPermissions: [...defaultPermissions, 'compliance:policy:delete'],

--- a/src/SmartComponents/ImportRules/ImportRules.js
+++ b/src/SmartComponents/ImportRules/ImportRules.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+import {
+  Content,
+  ContentVariants,
+  Skeleton,
+  Spinner,
+  Bullseye,
+} from '@patternfly/react-core';
+
+import VersionSelector from './components/VersionSelector';
+import RuleComparison from './components/RuleComparison';
+import ImportRulesModal from './components/ImportRulesModal';
+import useImportRulesData from './hooks/useImportRulesData';
+import useComparisonConditions from './hooks/useComparisonConditions';
+import useTailoringRuleSelection from './hooks/useTailoringRuleSelection';
+import useSaveTailoring from './hooks/useSaveTailoring';
+
+const ImportRules = () => {
+  const { policy_id: policyId } = useParams();
+
+  const {
+    loading: importRulesDataLoading,
+    error: importRulesDataError,
+    data: { tailorings, securityGuideProfile, policy } = {},
+  } = useImportRulesData({ policyId });
+
+  const {
+    comparisonConditions: { tailoringId, osMinorVersion },
+    tailoring: tailoringToCompare,
+    sourceVersion,
+    targetVersion,
+    onComparisonSettingsChange,
+  } = useComparisonConditions({ tailorings, securityGuideProfile });
+
+  const {
+    loading: initialSelectionLoading,
+    initialSelection,
+    selection,
+    onSelect,
+    error: initialSelectionError,
+  } = useTailoringRuleSelection({ tailoringId, policyId, osMinorVersion });
+
+  const onSave = useSaveTailoring({
+    policyId,
+    selection,
+  });
+  const isSaveDisabled = !selection || !osMinorVersion;
+
+  const loading = importRulesDataLoading;
+  const error = importRulesDataError || initialSelectionError;
+  const data = !!tailorings && !!securityGuideProfile && !!policy;
+
+  return (
+    <ImportRulesModal
+      policyId={policyId}
+      title={
+        importRulesDataLoading ? (
+          <Skeleton />
+        ) : (
+          'Import rules for ' + policy.title
+        )
+      }
+      stateValues={{
+        error,
+        loading,
+        data,
+      }}
+      isSaveDisabled={isSaveDisabled}
+      onSave={onSave}
+    >
+      <Content component={ContentVariants.p}>
+        Select which minor RHEL version you would like to import the tailored
+        rules from.
+      </Content>
+
+      <VersionSelector
+        tailorings={tailorings}
+        securityGuideProfile={securityGuideProfile}
+        values={{ tailoringId, osMinorVersion }}
+        onChange={onComparisonSettingsChange}
+      />
+
+      {policy && tailoringToCompare && osMinorVersion && (
+        <>
+          <Content component={ContentVariants.hr} />
+          {initialSelectionLoading || !initialSelection || !selection ? (
+            <Bullseye>
+              <Spinner />
+            </Bullseye>
+          ) : (
+            <RuleComparison
+              policy={policy}
+              tailoring={tailoringToCompare}
+              sourceVersion={sourceVersion}
+              targetVersion={targetVersion}
+              securityGuideProfile={securityGuideProfile}
+              osMinorVersionToCompare={osMinorVersion}
+              initialSelection={initialSelection}
+              selection={selection}
+              onSelect={onSelect}
+            />
+          )}
+        </>
+      )}
+    </ImportRulesModal>
+  );
+};
+
+ImportRules.propTypes = {
+  policy: propTypes.object,
+  securityGuideProfile: propTypes.object,
+};
+
+export default ImportRules;

--- a/src/SmartComponents/ImportRules/components/ImportRulesModal.js
+++ b/src/SmartComponents/ImportRules/components/ImportRulesModal.js
@@ -1,0 +1,74 @@
+import React, { useCallback } from 'react';
+import propTypes from 'prop-types';
+import { Button, Bullseye, Spinner } from '@patternfly/react-core';
+import { ModalVariant } from '@patternfly/react-core/deprecated';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+
+import {
+  ComplianceModal,
+  StateViewWithError,
+  StateViewPart,
+} from 'PresentationalComponents';
+
+const ImportRulesModal = ({
+  policyId,
+  stateValues,
+  children,
+  onSave,
+  onCancel,
+  isSaveDisabled,
+  ...modalProps
+}) => {
+  const navigate = useInsightsNavigate();
+  const navigateToPolicyRules = useCallback(() => {
+    navigate(`/scappolicies/${policyId}#rules`);
+  }, [policyId, navigate]);
+
+  return (
+    <ComplianceModal
+      isOpen
+      variant={ModalVariant.medium}
+      actions={[
+        <Button
+          key="save"
+          ouiaId="SaveImportButton"
+          aria-label="save"
+          onClick={() => onSave?.()}
+          isDisabled={isSaveDisabled}
+        >
+          Save
+        </Button>,
+        <Button
+          key="cancel"
+          ouiaId="DeleteReportCancelButton"
+          variant="secondary"
+          onClick={navigateToPolicyRules}
+        >
+          Cancel
+        </Button>,
+      ]}
+      onClose={navigateToPolicyRules}
+      {...modalProps}
+    >
+      <StateViewWithError stateValues={stateValues}>
+        <StateViewPart stateKey="loading">
+          <Bullseye>
+            <Spinner />
+          </Bullseye>
+        </StateViewPart>
+        <StateViewPart stateKey="data">{children}</StateViewPart>
+      </StateViewWithError>
+    </ComplianceModal>
+  );
+};
+
+ImportRulesModal.propTypes = {
+  policyId: propTypes.string,
+  stateValues: propTypes.object,
+  children: propTypes.node,
+  onSave: propTypes.func,
+  onCancel: propTypes.func,
+  isSaveDisabled: propTypes.bool,
+};
+
+export default ImportRulesModal;

--- a/src/SmartComponents/ImportRules/components/RuleComparison/RuleComparison.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/RuleComparison.js
@@ -1,0 +1,90 @@
+import React, { useMemo } from 'react';
+import propTypes from 'prop-types';
+import { faker } from '@faker-js/faker';
+
+import { Content, ContentVariants } from '@patternfly/react-core';
+import { TableStateProvider } from 'bastilian-tabletools';
+
+import ComparisonTable from './components/ComparisonTable/ComparisonTable';
+import useFakeCompareData from './hooks/useFakeCompareData';
+
+// TODO Add PDF link
+const RuleComparison = ({
+  policy,
+  tailoring,
+  sourceVersion,
+  targetVersion,
+  onSelect,
+  selection,
+  initialSelection,
+  osMinorVersionToCompare,
+}) => {
+  const { id: policyId } = policy;
+  const { id: tailoringId } = tailoring;
+
+  // Should we need to built the initial selection with taking the target versions into account
+  // this hook and the TableStateProvider should/can be moved to the ImportRules component
+  const {
+    loading,
+    data: { data: rules, meta: { total } = {} } = {},
+    error,
+  } = useFakeCompareData({
+    tailoringId,
+    policyId,
+    targetOsMinorVersion: osMinorVersionToCompare,
+    // TODO remove if not needed
+    sourceVersion,
+    targetVersion,
+  });
+
+  const items = useMemo(
+    () =>
+      rules?.map((rule) => ({
+        ...rule,
+        isInInitialSelection: initialSelection?.includes(rule.ref_id),
+        isSelected: selection?.includes(rule.ref_id),
+        // TODO remove when switching to actual endpoint
+        available_in_version: faker.helpers.arrayElements([
+          sourceVersion.ssg_version,
+          targetVersion.ssg_version,
+        ]),
+      })),
+    [rules, sourceVersion, targetVersion, selection, initialSelection],
+  );
+
+  return (
+    <>
+      <Content component={ContentVariants.h2}>Rule comparison</Content>
+      <ComparisonTable
+        sourceVersion={sourceVersion}
+        targetVersion={targetVersion}
+        onSelect={onSelect}
+        selection={selection}
+        initialSelection={initialSelection}
+        loading={loading}
+        items={items}
+        total={total}
+        error={error}
+      />
+    </>
+  );
+};
+
+RuleComparison.propTypes = {
+  policy: propTypes.object,
+  tailoring: propTypes.object,
+  sourceVersion: propTypes.object,
+  targetVersion: propTypes.object,
+  osMinorVersionToCompare: propTypes.string,
+  initialSelection: propTypes.array,
+  selection: propTypes.array,
+  onSelect: propTypes.func,
+};
+
+const RuleComparisonWithTableStateProvider = (props) => (
+  <TableStateProvider>
+    <RuleComparison {...props} />
+  </TableStateProvider>
+);
+
+export default RuleComparisonWithTableStateProvider;

--- a/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/ComparisonTable.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/ComparisonTable.js
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react';
+import propTypes from 'prop-types';
+
+import { ComplianceTable } from 'PresentationalComponents';
+
+import DifferingOnlyToggle from './components/DifferingOnlyToggle';
+import RuleRow from './components/RuleRow';
+import defaultColumns, { profileVersion } from './columns';
+import filters from './filters';
+
+const ComparisonTable = ({
+  sourceVersion,
+  targetVersion,
+  initialSelection,
+  selection,
+  onSelect,
+  ...props
+}) => {
+  const columns = useMemo(
+    () => [
+      ...defaultColumns,
+      profileVersion(sourceVersion, targetVersion, {
+        isDisabled: true,
+        selectedProp: 'isInInitialSelection',
+      }),
+      profileVersion(targetVersion, targetVersion, {
+        selectedProp: 'isSelected',
+        onSelect,
+      }),
+    ],
+    [sourceVersion, targetVersion, onSelect],
+  );
+
+  const rowWrapper = useMemo(
+    // eslint-disable-next-line react/display-name
+    () => (props) => (
+      <RuleRow
+        {...props}
+        sourceVersion={sourceVersion}
+        targetVersion={targetVersion}
+      />
+    ),
+    [targetVersion, sourceVersion],
+  );
+
+  return (
+    <ComplianceTable
+      {...props}
+      variant="compact"
+      columns={columns}
+      filters={{
+        filterConfig: filters,
+      }}
+      options={{
+        debug: true,
+        dedicatedAction: DifferingOnlyToggle,
+      }}
+      rowWrapper={rowWrapper}
+    />
+  );
+};
+
+ComparisonTable.propTypes = {
+  sourceVersion: propTypes.object,
+  targetVersion: propTypes.object,
+  initialSelection: propTypes.array,
+  selection: propTypes.array,
+  onSelect: propTypes.func,
+};
+
+export default ComparisonTable;

--- a/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/columns.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/columns.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { nowrap } from '@patternfly/react-table';
+
+import RuleCell from './components/RuleCell';
+import ProfileVersionCell from './components/ProfileVersionCell';
+
+const rule = {
+  title: <strong>Rule</strong>,
+  Component: RuleCell,
+};
+
+export const profileVersion = (version, targetVersion, additionalProps) => ({
+  dataLabel: `RHEL ${version.os_major_version}.${version.os_minor_version} -  SSG version ${version.ssg_version}`,
+  title: (
+    <>
+      <strong>
+        RHEL {version.os_major_version}.{version.os_minor_version}
+      </strong>
+      <br />
+      SSG version {version.ssg_version}
+    </>
+  ),
+  Component: (props) => (
+    <ProfileVersionCell
+      {...{
+        version,
+        targetVersion,
+        ...props,
+        ...additionalProps,
+      }}
+    />
+  ),
+  transforms: [nowrap],
+});
+
+export default [rule];

--- a/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/DifferingOnlyToggle.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/DifferingOnlyToggle.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+
+import { useTableState } from 'bastilian-tabletools';
+
+const DifferingOnlyToggle = () => {
+  const [differingOnly, setDifferingOnly] = useTableState('diffOnly', false);
+
+  return (
+    <ToggleGroup aria-label="Default with single selectable">
+      <ToggleGroupItem
+        text="All"
+        isSelected={!differingOnly}
+        onChange={() => setDifferingOnly(false)}
+      />
+      <ToggleGroupItem
+        text="Differing only"
+        isSelected={differingOnly}
+        onChange={() => setDifferingOnly(true)}
+      />
+    </ToggleGroup>
+  );
+};
+
+export default DifferingOnlyToggle;

--- a/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/ProfileVersionCell.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/ProfileVersionCell.js
@@ -1,0 +1,46 @@
+import React, { useId, useCallback } from 'react';
+import propTypes from 'prop-types';
+
+import { Checkbox } from '@patternfly/react-core';
+
+const ProfileVersionCell = ({
+  version,
+  targetVersion,
+  isDisabled,
+  available_in_version,
+  ref_id,
+  selectedProp,
+
+  onSelect,
+  ...props
+}) => {
+  const id = useId();
+  const onChange = useCallback(() => onSelect?.(ref_id), [onSelect, ref_id]);
+
+  return (
+    <>
+      {available_in_version.includes(version.ssg_version) && (
+        <Checkbox
+          id={id}
+          isChecked={props[selectedProp] || false}
+          isDisabled={isDisabled}
+          onChange={onChange}
+        />
+      )}
+    </>
+  );
+};
+
+ProfileVersionCell.propTypes = {
+  sourceVersion: propTypes.object,
+  targetVersion: propTypes.object,
+  version: propTypes.string,
+  targetVersion: propTypes.object,
+  isDisabled: propTypes.bool,
+  available_in_version: propTypes.array,
+  ref_id: propTypes.string,
+  selectedProp: propTypes.string,
+  onSelect: propTypes.func,
+};
+
+export default ProfileVersionCell;

--- a/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/RuleCell.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/RuleCell.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import propTypes from 'prop-types';
+
+const RuleCell = ({ title, identifier: { label } }) => (
+  <>
+    {label}: {title}
+  </>
+);
+
+RuleCell.propTypes = {
+  title: propTypes.string,
+  identifier: propTypes.object,
+};
+
+export default RuleCell;

--- a/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/RuleRow.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/RuleRow.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Tr } from '@patternfly/react-table';
+
+const RuleRow = ({
+  children,
+  targetVersion,
+  sourceVersion,
+  row: { item: { available_in_version } = {} },
+  rowProps: _rowProps,
+  ...props
+}) => (
+  <Tr
+    {...props}
+    style={{
+      ...(available_in_version &&
+      !available_in_version.includes(targetVersion.ssg_version) &&
+      available_in_version.includes(sourceVersion.ssg_version)
+        ? { backgroundColor: 'var(--pf-v5-global--palette--black-150)' }
+        : {}),
+      ...(available_in_version &&
+      available_in_version?.includes(targetVersion.ssg_version) &&
+      !available_in_version?.includes(sourceVersion.ssg_version)
+        ? { backgroundColor: 'var(--pf-v5-global--palette--blue-50)' }
+        : {}),
+    }}
+  >
+    {children}
+  </Tr>
+);
+
+RuleRow.propTypes = {
+  children: propTypes.node,
+  sourceVersion: propTypes.object,
+  targetVersion: propTypes.object,
+  row: propTypes.object,
+  rowProps: propTypes.object,
+};
+
+export default RuleRow;

--- a/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/filters.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/filters.js
@@ -1,0 +1,10 @@
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+
+const rule = {
+  type: conditionalFilterType.text,
+  label: 'Rule',
+  filterSerialiser: (_, value) =>
+    `(title ~ "${value}" OR identifier_label ~ "${value}")`,
+};
+
+export default [rule];

--- a/src/SmartComponents/ImportRules/components/RuleComparison/hooks/useFakeCompareData.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/hooks/useFakeCompareData.js
@@ -1,0 +1,26 @@
+// import { useFullTableState } from 'bastilian-tabletools';
+import useTailoringRules from 'Utilities/hooks/api/useTailoringRules';
+
+const useFakeCompareData = ({ tailoringId, policyId }) => {
+  // const fullTableState = useFullTableState();
+  // const { tableState: { diffOnly } = {} } = fullTableState || {};
+
+  // TODO Replace with actual comparison endpoint(s)
+  const { data, error, loading } = useTailoringRules({
+    params: {
+      tailoringId,
+      policyId,
+      // diffOnly
+    },
+    useTableState: true,
+    skip: !tailoringId || !policyId,
+  });
+
+  return {
+    loading,
+    data,
+    error,
+  };
+};
+
+export default useFakeCompareData;

--- a/src/SmartComponents/ImportRules/components/RuleComparison/index.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/index.js
@@ -1,0 +1,1 @@
+export { default } from './RuleComparison';

--- a/src/SmartComponents/ImportRules/components/VersionSelector/VersionSelector.js
+++ b/src/SmartComponents/ImportRules/components/VersionSelector/VersionSelector.js
@@ -1,0 +1,77 @@
+import React, { useMemo } from 'react';
+import propTypes from 'prop-types';
+import { Form, Flex, FlexItem } from '@patternfly/react-core';
+
+import VersionSelect from './components/VersionSelect';
+import {
+  optionsFromTailorings,
+  optionsFromSecurityGuideProfileVersions,
+} from './helpers';
+
+const VersionSelector = ({
+  tailorings,
+  securityGuideProfile,
+  values: { tailoringId, osMinorVersion },
+  onChange,
+}) => {
+  const versionsToCopy = useMemo(
+    () => optionsFromTailorings(tailorings),
+    [tailorings],
+  );
+  const selectedOsMinorVersion = tailorings?.find(
+    ({ id }) => id === tailoringId,
+  )?.os_minor_version;
+
+  const versionsToApply = useMemo(
+    () =>
+      optionsFromSecurityGuideProfileVersions(
+        securityGuideProfile,
+        selectedOsMinorVersion,
+      ),
+    [securityGuideProfile, selectedOsMinorVersion],
+  );
+
+  return (
+    <Form>
+      <Flex>
+        <Flex flex={{ default: 'flex_1' }}>
+          <FlexItem>
+            <VersionSelect
+              label="Copy and import rules from"
+              aria-label="Import version selection"
+              placeholder="Choose version to import rules from"
+              options={versionsToCopy}
+              value={tailoringId}
+              onChange={(tailoringId) => onChange?.('tailoringId', tailoringId)}
+            />
+          </FlexItem>
+        </Flex>
+        <Flex flex={{ default: 'flex_1' }}>
+          <FlexItem>
+            <VersionSelect
+              isDisabled={!tailoringId}
+              label="Paste and apply rules to"
+              aria-label="Apply version selection"
+              placeholder="Choose version to apply rules to"
+              value={osMinorVersion}
+              onChange={(osMinorVersion) =>
+                onChange?.('osMinorVersion', osMinorVersion)
+              }
+              options={versionsToApply}
+            />
+          </FlexItem>
+        </Flex>
+      </Flex>
+    </Form>
+  );
+};
+
+VersionSelector.propTypes = {
+  securityGuideProfile: propTypes.object,
+  tailorings: propTypes.array,
+  canSelectVersionToApply: propTypes.bool,
+  values: propTypes.object,
+  onChange: propTypes.func,
+};
+
+export default VersionSelector;

--- a/src/SmartComponents/ImportRules/components/VersionSelector/components/VersionSelect.js
+++ b/src/SmartComponents/ImportRules/components/VersionSelector/components/VersionSelect.js
@@ -1,0 +1,72 @@
+import React, { useCallback } from 'react';
+import propTypes from 'prop-types';
+import {
+  Content,
+  ContentVariants,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+} from '@patternfly/react-core';
+
+const VersionSelect = ({
+  label,
+  ariaLabel,
+  placeholder,
+  options,
+  value,
+  onChange,
+  isDisabled = false,
+}) => {
+  const ssgVersion =
+    value &&
+    options.find(
+      ({ value: optionValue }) => String(optionValue) === String(value),
+    )?.ssgVersion;
+
+  const onChangeSelect = useCallback(
+    (_event, optionValue) => onChange?.(optionValue),
+    [onChange],
+  );
+
+  return (
+    <FormGroup label={label}>
+      <FormSelect
+        className="pf-v6-u-mb-sm"
+        isDisabled={isDisabled}
+        aria-label={ariaLabel}
+        onChange={onChangeSelect}
+        value={value}
+      >
+        {placeholder && (
+          <FormSelectOption
+            isPlaceholder
+            key={-1}
+            label={placeholder || 'Select options'}
+          />
+        )}
+
+        {options.map(({ label, value }) => (
+          <FormSelectOption key={label} value={value} label={label} />
+        ))}
+      </FormSelect>
+
+      {ssgVersion && (
+        <Content component={ContentVariants.p} className="pf-v6-u-mb-sm">
+          <strong>SSG version</strong> {ssgVersion}
+        </Content>
+      )}
+    </FormGroup>
+  );
+};
+
+VersionSelect.propTypes = {
+  label: propTypes.string,
+  ariaLabel: propTypes.string,
+  placeholder: propTypes.string,
+  options: propTypes.object,
+  value: propTypes.string,
+  onChange: propTypes.func,
+  isDisabled: propTypes.bool,
+};
+
+export default VersionSelect;

--- a/src/SmartComponents/ImportRules/components/VersionSelector/helpers.js
+++ b/src/SmartComponents/ImportRules/components/VersionSelector/helpers.js
@@ -1,0 +1,18 @@
+export const optionsFromTailorings = (tailorings) =>
+  tailorings.map((tailoring) => ({
+    label: `RHEL ${tailoring.os_major_version}.${tailoring.os_minor_version}`,
+    value: tailoring.id,
+    ssgVersion: tailoring.security_guide_version,
+  }));
+
+export const optionsFromSecurityGuideProfileVersions = (
+  securityGuideProfile,
+  selectedVersion,
+) =>
+  securityGuideProfile?.os_minor_versions
+    .filter((version) => version !== selectedVersion)
+    .map((osMinorVersion) => ({
+      label: `RHEL ${securityGuideProfile.os_major_version}.${osMinorVersion}`,
+      value: osMinorVersion,
+      ssgVersion: securityGuideProfile.security_guide_version,
+    }));

--- a/src/SmartComponents/ImportRules/components/VersionSelector/index.js
+++ b/src/SmartComponents/ImportRules/components/VersionSelector/index.js
@@ -1,0 +1,1 @@
+export { default } from './VersionSelector';

--- a/src/SmartComponents/ImportRules/hooks/useComparisonConditions.js
+++ b/src/SmartComponents/ImportRules/hooks/useComparisonConditions.js
@@ -1,0 +1,51 @@
+import { useCallback, useMemo, useState } from 'react';
+
+const useComparisonConditions = ({ tailorings, securityGuideProfile }) => {
+  const [comparisonConditions, setComparisonConditions] = useState({});
+
+  const onComparisonSettingsChange = useCallback((setting, value) => {
+    setComparisonConditions((currentComparisonConditions) => ({
+      ...(setting !== 'tailoringId' ? currentComparisonConditions : {}),
+      [setting]: value,
+    }));
+  }, []);
+
+  const tailoring = tailorings?.find(
+    ({ id }) => id === comparisonConditions?.tailoringId,
+  );
+
+  const sourceVersion = useMemo(
+    () =>
+      tailoring && {
+        os_major_version: tailoring.os_major_version,
+        os_minor_version: tailoring.os_minor_version,
+        ssg_version: tailoring.security_guide_version,
+      },
+    [tailoring],
+  );
+
+  const targetVersion = useMemo(
+    () =>
+      securityGuideProfile &&
+      comparisonConditions.osMinorVersion && {
+        os_major_version: securityGuideProfile.os_major_version,
+        os_minor_version: comparisonConditions.osMinorVersion,
+        ssg_version: securityGuideProfile.security_guide_version,
+      },
+    [securityGuideProfile, comparisonConditions.osMinorVersion],
+  );
+
+  return {
+    comparisonConditions,
+    onComparisonSettingsChange,
+    ...(tailoring
+      ? {
+          tailoring,
+        }
+      : {}),
+    ...(sourceVersion ? { sourceVersion } : {}),
+    ...(targetVersion ? { targetVersion } : {}),
+  };
+};
+
+export default useComparisonConditions;

--- a/src/SmartComponents/ImportRules/hooks/useImportRulesData.js
+++ b/src/SmartComponents/ImportRules/hooks/useImportRulesData.js
@@ -1,0 +1,53 @@
+import useTailorings from 'Utilities/hooks/api/useTailorings';
+import usePolicy from 'Utilities/hooks/api/usePolicy';
+import useSupportedProfiles from 'Utilities/hooks/api/useSupportedProfiles';
+
+const useImportRulesData = ({ policyId }) => {
+  const {
+    data: { data: policy } = {},
+    loading: policyLoading,
+    error: policyError,
+  } = usePolicy({ params: { policyId }, skip: !policyId });
+
+  const {
+    data: { data: supportedProfiles } = {},
+    error: supportedProfilesError,
+    loading: supportedProfilesLoading,
+  } = useSupportedProfiles({
+    params: {
+      filter: `os_major_version=${policy?.os_major_version}`,
+    },
+    batched: true,
+    skip: !policy,
+  });
+
+  const securityGuideProfile = supportedProfiles?.find(
+    (profile) => profile.ref_id === policy?.ref_id,
+  );
+
+  const {
+    data: { data: tailorings } = {},
+    error: tailoringsError,
+    loading: tailoringsLoading,
+  } = useTailorings({
+    params: {
+      policyId,
+      filter: 'NOT(null? os_minor_version)',
+      skip: !policy,
+    },
+  });
+
+  const data = {
+    ...(policy ? { policy } : {}),
+    ...(securityGuideProfile ? { securityGuideProfile } : {}),
+    ...(tailorings ? { tailorings } : {}),
+  };
+
+  return {
+    loading: policyLoading || supportedProfilesLoading || tailoringsLoading,
+    error: policyError || supportedProfilesError || tailoringsError,
+    ...(policy && tailorings && securityGuideProfile ? { data } : {}),
+  };
+};
+
+export default useImportRulesData;

--- a/src/SmartComponents/ImportRules/hooks/useSaveTailoring.js
+++ b/src/SmartComponents/ImportRules/hooks/useSaveTailoring.js
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import useCreateTailoring from 'Utilities/hooks/api/useCreateTailoring';
+import useAssignRules from 'Utilities/hooks/api/useAssignRules';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+
+const useSaveTailoring = ({
+  policyId,
+  osMinorVersion: os_minor_version,
+  selection,
+}) => {
+  const navigate = useInsightsNavigate();
+
+  const { fetch: assignRules } = useAssignRules({
+    params: { policyId },
+    skip: true,
+  });
+  const { fetch: createTailorings } = useCreateTailoring({
+    params: { policyId },
+  });
+
+  const onSave = useCallback(async () => {
+    const tailoring = await createTailorings({
+      tailoringCreate: { os_minor_version },
+    });
+
+    await assignRules({
+      tailoringId: tailoring.id,
+      // TODO Doublecheck what happens when submitting refIds that have been removed from the target profile
+      assignRulesRequest: { ids: selection },
+    });
+
+    navigate(`/scappolicies/${policyId}#rules`);
+  }, [
+    policyId,
+    createTailorings,
+    assignRules,
+    os_minor_version,
+    selection,
+    navigate,
+  ]);
+
+  return onSave;
+};
+
+export default useSaveTailoring;

--- a/src/SmartComponents/ImportRules/hooks/useTailoringRuleSelection.js
+++ b/src/SmartComponents/ImportRules/hooks/useTailoringRuleSelection.js
@@ -1,0 +1,62 @@
+import { useEffect, useCallback, useMemo, useState } from 'react';
+
+import useTailoringRules from 'Utilities/hooks/api/useTailoringRules';
+
+const useTailoringRuleSelection = ({
+  tailoringId,
+  policyId,
+  osMinorVersion,
+}) => {
+  const [selection, setSelection] = useState();
+
+  const {
+    loading,
+    data: { data: tailoringRules } = {},
+    error,
+  } = useTailoringRules({
+    params: { policyId, tailoringId },
+    batched: true,
+    skip: !policyId || !tailoringId,
+  });
+  const initialSelection = useMemo(
+    () => tailoringRules?.map(({ ref_id }) => ref_id),
+    [tailoringRules],
+  );
+
+  const onSelect = useCallback(
+    (ruleRefId) => {
+      setSelection((currentSelection) => {
+        if (currentSelection.includes(ruleRefId)) {
+          return currentSelection.filter(
+            (selectedRefId) => ruleRefId !== selectedRefId,
+          );
+        } else {
+          return [...currentSelection, ruleRefId];
+        }
+      });
+    },
+    [setSelection],
+  );
+
+  useEffect(() => {
+    if (typeof osMinorVersion === 'undefined' || osMinorVersion === '') {
+      setSelection(initialSelection);
+    }
+  }, [setSelection, osMinorVersion, initialSelection]);
+
+  useEffect(() => {
+    if (tailoringRules) {
+      setSelection(tailoringRules.map(({ ref_id }) => ref_id));
+    }
+  }, [tailoringRules]);
+
+  return {
+    loading,
+    initialSelection,
+    error,
+    selection,
+    onSelect,
+  };
+};
+
+export default useTailoringRuleSelection;

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -1,18 +1,19 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
+  Flex,
   Grid,
   GridItem,
   Tab,
   PageSection,
+  Spinner,
 } from '@patternfly/react-core';
 import PageHeader, {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 import {
   PolicyDetailsDescription,
   PolicyDetailsContentLoader,
@@ -23,8 +24,10 @@ import {
   RoutedTabs,
   BreadcrumbLinkItem,
   Tailorings,
+  LinkButton,
 } from 'PresentationalComponents';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
+
 import '@/Charts.scss';
 import PolicySystemsTab from './PolicySystemsTab';
 import './PolicyDetails.scss';
@@ -48,6 +51,8 @@ const dataMap = {
 };
 
 export const PolicyDetails = ({ route }) => {
+  // TODO Replace with actual feature flag;
+  const enableImportRules = false;
   const defaultTab = 'details';
   const { policy_id: policyId } = useParams();
   const {
@@ -75,7 +80,23 @@ export const PolicyDetails = ({ route }) => {
   const policy = data?.profile;
 
   useTitleEntity(route, policy?.name);
-  const DedicatedAction = () => <EditRulesButtonToolbarItem policy={policy} />;
+  const DedicatedAction = useMemo(
+    // eslint-disable-next-line react/display-name
+    () => () => (
+      <Flex columnGap={{ default: 'columnGapSm' }}>
+        <EditRulesButtonToolbarItem policy={policy} />
+        {enableImportRules && (
+          <LinkButton
+            to={`/scappolicies/${policyId}/import-rules`}
+            variant="secondary"
+          >
+            Import rules
+          </LinkButton>
+        )}
+      </Flex>
+    ),
+    [enableImportRules, policy, policyId],
+  );
 
   return (
     <StateViewWithError

--- a/src/Utilities/hooks/api/useAssignRules.js
+++ b/src/Utilities/hooks/api/useAssignRules.js
@@ -1,19 +1,11 @@
 import useComplianceQuery from '../useComplianceQuery';
 
-const convertToArray = (params) => {
-  if (Array.isArray(params)) {
-    return params;
-  } else {
-    const { policyId, tailoringId, assignRulesRequest } = params;
-
-    return [
-      policyId,
-      tailoringId,
-      undefined, // xRHIDENTITY,
-      assignRulesRequest,
-    ];
-  }
-};
+const convertToArray = ({ policyId, tailoringId, assignRulesRequest }) => [
+  policyId,
+  tailoringId,
+  undefined, // xRHIDENTITY,
+  assignRulesRequest,
+];
 
 const useAssignRules = (options) =>
   useComplianceQuery('assignRules', { ...options, skip: true, convertToArray });

--- a/src/Utilities/hooks/api/useTailoringRules.js
+++ b/src/Utilities/hooks/api/useTailoringRules.js
@@ -1,24 +1,23 @@
 import useComplianceQuery from '../useComplianceQuery';
 
-const convertToArray = (params) => {
-  if (Array.isArray(params)) {
-    return params;
-  } else {
-    const { policyId, tailoringId, limit, offset, idsOnly, sortBy, filter } =
-      params;
-
-    return [
-      policyId,
-      tailoringId,
-      undefined, // xRHIDENTITY
-      limit,
-      offset,
-      idsOnly,
-      sortBy,
-      filter,
-    ];
-  }
-};
+const convertToArray = ({
+  policyId,
+  tailoringId,
+  limit,
+  offset,
+  idsOnly,
+  sortBy,
+  filter,
+}) => [
+  policyId,
+  tailoringId,
+  undefined, // xRHIDENTITY
+  limit,
+  offset,
+  idsOnly,
+  sortBy,
+  filter,
+];
 
 // TODO investigate why this endpoint requires direct arguments and does not recognise the params object.
 const useTailoringRules = (options) =>

--- a/src/Utilities/hooks/useComplianceQuery/useComplianceQuery.js
+++ b/src/Utilities/hooks/useComplianceQuery/useComplianceQuery.js
@@ -123,6 +123,7 @@ const useComplianceQuery = (
     queryFn: (_queryContext, ...args) => fetchApi(...args),
     enabled: !(batched ? true : skip),
     refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
     ...useQueryOptions,
   });
 


### PR DESCRIPTION
This adds base for the modal for the Import Rules feature, currently hidden behind a static feature flag.

**How to test:**

1) Change the "feature flag" in PolicyDetails[0]
2) Open a Compliance policy
3) Verify the "Import rules" button is visible
4) Open the modal and test its functionality. 


[0] https://github.com/RedHatInsights/compliance-frontend/pull/2591/files#diff-7629357b316f8bcd1281bacb3848b4334512e818c1732d6b20c688fa9174a006R55


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Implement an ‘Import Rules’ workflow by adding a new modal, route, UI components, and hooks to allow users to copy tailoring rules between policy versions, while refactoring API parameter handling and updating query options and dependencies.

New Features:
- Add 'Import Rules' modal with version selector and rule comparison UI for policy tailoring
- Introduce new route, components, and hooks to fetch, select, compare, and save imported tailoring rules
- Add 'Import rules' button to PolicyDetails toolbar to open the modal

Enhancements:
- Refactor convertToArray implementations in useTailoringRules and useAssignRules hooks
- Disable refetchOnReconnect in useComplianceQuery for query stability
- Bump bastilian-tabletools dependency to ^2.14.0