### PR TITLE
fix(SystemDetails): Properly pass remediationsEnabled prop

### DIFF
--- a/src/PresentationalComponents/RulesTable/RulesTable.js
+++ b/src/PresentationalComponents/RulesTable/RulesTable.js
@@ -50,7 +50,7 @@ const RulesTable = ({
   policyId,
   policyName,
   columns = defaultColumns,
-  remediationsEnabled = true,
+  remediationsEnabled,
   ansibleSupportFilter = false,
   selectedFilter = false, // TODO this is potentially obsolete.
   selectedRules: selectedRulesProp = [],

--- a/src/SmartComponents/SystemDetails/RuleResults.js
+++ b/src/SmartComponents/SystemDetails/RuleResults.js
@@ -5,7 +5,7 @@ import useReportRuleResults from 'Utilities/hooks/api/useReportRuleResults';
 import { RulesTable } from 'PresentationalComponents';
 import columns from './Columns';
 
-const RuleResults = ({ reportTestResult }) => {
+const RuleResults = ({ reportTestResult, remediationsEnabled }) => {
   // Enable default filter
   const activeFilters = {
     'rule-state': ['failed'],
@@ -62,7 +62,7 @@ const RuleResults = ({ reportTestResult }) => {
       total={ruleResults?.meta?.total}
       defaultTableView="rows"
       onSelect={true}
-      remediationsEnabled
+      remediationsEnabled={remediationsEnabled}
       reportTestResult={reportTestResult}
       skipValueDefinitions={true}
       options={{
@@ -75,7 +75,7 @@ const RuleResults = ({ reportTestResult }) => {
 };
 
 RuleResults.propTypes = {
-  hidePassed: propTypes.bool,
+  remediationsEnabled: propTypes.bool,
   reportTestResult: propTypes.object,
 };
 

--- a/src/SmartComponents/SystemDetails/SystemDetails.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.js
@@ -52,7 +52,12 @@ const SystemDetails = ({ route }) => {
           <InventoryDetails inventoryId={inventoryId} />
         </PageHeader>
         <PageSection hasBodyWrapper={false}>
-          <Details hidePassed inventoryId={inventoryId} system={data} />
+          <Details
+            hidePassed
+            inventoryId={inventoryId}
+            system={data}
+            remediationsEnabled
+          />
         </PageSection>
       </StateViewPart>
       <StateViewPart stateKey="loading">

--- a/src/SmartComponents/SystemDetails/SystemPoliciesAndRules.js
+++ b/src/SmartComponents/SystemDetails/SystemPoliciesAndRules.js
@@ -8,6 +8,7 @@ const SystemPoliciesAndRules = ({
   systemId,
   reportTestResults,
   hidePassed,
+  remediationsEnabled,
 }) => {
   // FYI: test result ID and policy ID are not the same, but test result ID only identifies each tab here.
   const [selectedPolicy, setSelectedPolicy] = useState(
@@ -32,6 +33,7 @@ const SystemPoliciesAndRules = ({
               systemId={systemId}
               reportTestResult={reportTestResult}
               hidePassed={hidePassed}
+              remediationsEnabled={remediationsEnabled}
             />
           </Tab>
         ))}
@@ -44,6 +46,7 @@ SystemPoliciesAndRules.propTypes = {
   systemId: propTypes.string.isRequired,
   reportTestResults: propTypes.array.isRequired,
   hidePassed: propTypes.bool,
+  remediationsEnabled: propTypes.bool,
 };
 
 export default SystemPoliciesAndRules;


### PR DESCRIPTION
This fixes passing the remediationsEnabled prop to allow the inventory to not enable it.

This can/should be tested in combination with running the inventory alongside Compliance. https://github.com/RedHatInsights/insights-inventory-frontend/pull/2600

**How to test:**

1) ~Check out https://github.com/RedHatInsights/insights-inventory-frontend/pull/2600 from the inventory~
2) ~Start the inventory with `npm run static` with~
3) Check out this PR in compliance and add the inventory app[0] to the `routes` object in the `fec.config.js`
4) Start the compliance application with `npm run start:proxy`
5) Open a system reporting to Compliance in the Inventory
6) Open the "Compliance" tab in the InventoryDetails
7) Verify the "Remediation" button is not shown as requested in the Jira.


[0]
```
  '/apps/inventory': {
    host: 'http://localhost:8003',
  },
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fix the remediationsEnabled flag by passing it through SystemDetails into RuleResults, SystemPoliciesAndRules, and RulesTable instead of relying on a hardcoded default

Bug Fixes:
- Properly forward remediationsEnabled prop in SystemDetails Details component
- Pass remediationsEnabled to RuleResults and update its propTypes
- Include remediationsEnabled in SystemPoliciesAndRules and its propTypes
- Remove default true for remediationsEnabled in RulesTable to use the passed value instead

## Summary by Sourcery

Enable proper control of the remediationsEnabled feature by forwarding the flag from SystemDetails through all downstream components and removing its hardcoded default.

Bug Fixes:
- Forward remediationsEnabled prop from SystemDetails into Details, RuleResults, and SystemPoliciesAndRules.
- Remove the default true value for remediationsEnabled in RulesTable to respect the passed prop.