### PR TITLE
chore(deps): RHINENG-20575 - Bump tabletools for column manager fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@tanstack/react-query": "^5.86.0",
         "@unleash/proxy-client-react": "^3.6.0",
         "axios": "^1.11.0",
-        "bastilian-tabletools": "^2.9.0",
+        "bastilian-tabletools": "^2.12.3",
         "linkify-html": "^4.3.2",
         "linkifyjs": "^4.3.2",
         "p-all": "^5.0.0",
@@ -9328,9 +9328,9 @@
       "license": "MIT"
     },
     "node_modules/bastilian-tabletools": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.12.1.tgz",
-      "integrity": "sha512-NLvu5pS5pCwtSFVbP1aZ1lM08ZmhXKV4KV5LKxw13w/gTuL54USJSW6Z3OhVQDfE4uhLe0jc57aqI9u1mb1qHQ==",
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.12.3.tgz",
+      "integrity": "sha512-KYWm7GrH4ppl8M2N6Mha/H24SJCMPye6rU187WnVIHdbktM51t50JtDnXmEHwktVslXVzWBogiES2a9L0J0l+A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@tanstack/react-query": "^5.86.0",
     "@unleash/proxy-client-react": "^3.6.0",
     "axios": "^1.11.0",
-    "bastilian-tabletools": "^2.9.0",
+    "bastilian-tabletools": "^2.12.3",
     "linkify-html": "^4.3.2",
     "linkifyjs": "^4.3.2",
     "p-all": "^5.0.0",


### PR DESCRIPTION
This bump includes a fix for the issue we are seeing on the reports page with the columns manager.


**Before:**


<img width="563" height="366" alt="Screenshot 2025-09-05 at 17 58 41" src="https://github.com/user-attachments/assets/794cd8ec-b508-4b91-8b1c-f1d5428d0a2f" />


**After:**

<img width="568" height="335" alt="Screenshot 2025-09-05 at 17 53 14" src="https://github.com/user-attachments/assets/424cc7e1-16f5-423b-b66a-fccf593acc42" />

## How to test

1) Open the Reports page
2) Verify the "Download" column is excluded from the manager and the policy column is untoggleable. 


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Upgrade tabletools dependency to incorporate fix for columns manager issue on Reports page

Bug Fixes:
- Exclude Download column and make policy column untoggleable in the columns manager on the Reports page

Chores:
- Bump bastilian-tabletools from 2.9.0 to 2.12.3