### PR TITLE
fix(RHINENG-20542): Handle systems selection correctly

### DIFF
--- a/src/SmartComponents/CreatePolicy/CreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/CreatePolicy.js
@@ -4,7 +4,6 @@ import { formValueSelector, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import { Wizard } from '@patternfly/react-core/deprecated';
-import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 import CreateSCAPPolicy from './CreateSCAPPolicy';
 import { default as EditPolicyRules } from './EditPolicyProfilesRules/EditPolicyProfilesRules';
 import EditPolicySystems from './EditPolicySystems';
@@ -16,7 +15,6 @@ import {
   validateSecurityGuidePage,
   validateDetailsPage,
   validateRulesPage,
-  validateSystemsPage,
 } from './validate';
 
 export const CreatePolicyForm = ({
@@ -26,12 +24,10 @@ export const CreatePolicyForm = ({
   profile,
   refId,
   selectedRuleRefIds,
-  systemIds,
   reset,
   formHasAsyncErrors,
   detailsStepLoaded,
 }) => {
-  const allowNoSystems = useFeatureFlag('image-builder.compliance.enabled');
   const navigate = useNavigate();
   const [stepIdReached, setStepIdReached] = useState(1);
   const resetAnchor = () => {
@@ -75,16 +71,14 @@ export const CreatePolicyForm = ({
     {
       id: 3,
       name: 'Systems',
-      component: <EditPolicySystems allowNoSystems={allowNoSystems} />,
+      component: <EditPolicySystems />,
       canJumpTo: stepIdReached >= 3,
-      enableNext: validateSystemsPage(systemIds, allowNoSystems),
     },
     {
       id: 4,
       name: 'Rules',
       component: <EditPolicyRules />,
-      canJumpTo:
-        validateSystemsPage(systemIds, allowNoSystems) && stepIdReached >= 4,
+      canJumpTo: stepIdReached >= 4,
       enableNext: validateRulesPage(selectedRuleRefIds),
     },
     {
@@ -92,18 +86,14 @@ export const CreatePolicyForm = ({
       name: 'Review',
       component: <ReviewCreatedPolicy />,
       nextButtonText: 'Finish',
-      canJumpTo:
-        validateRulesPage(selectedRuleRefIds) &&
-        validateSystemsPage(systemIds, allowNoSystems) &&
-        stepIdReached >= 5,
+      canJumpTo: validateRulesPage(selectedRuleRefIds) && stepIdReached >= 5,
     },
     {
       id: 6,
       name: 'Finished',
       component: <FinishedCreatePolicy onWizardFinish={onClose} />,
       isFinishedStep: true,
-      canJumpTo:
-        validateSystemsPage(systemIds, allowNoSystems) && stepIdReached >= 6,
+      canJumpTo: stepIdReached >= 6,
     },
   ];
 

--- a/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import xor from 'lodash/xor';
+import { xor, isEqual } from 'lodash';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { useDeepCompareEffect } from 'use-deep-compare';
@@ -116,8 +116,14 @@ const EditPolicyProfilesRules = ({
           ({ osMinorVersion: _osMinorVersion }) =>
             _osMinorVersion === osMinorVersion,
         );
-
-        updatedSelectedRuleRefIds[index].ruleRefIds = newSelectedRuleIds;
+        if (
+          isEqual(
+            updatedSelectedRuleRefIds[index].ruleRefIds,
+            newSelectedRuleIds,
+          )
+        ) {
+          return;
+        }
       }
       change('selectedRuleRefIds', updatedSelectedRuleRefIds);
     },

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import {
   propTypes as reduxFormPropTypes,
   reduxForm,
@@ -66,13 +66,15 @@ PrependComponent.propTypes = {
   osMajorVersion: propTypes.string,
 };
 
-const useOnSelect = (change) => {
+const useOnSelect = (change, profile) => {
   const onSelect = useCallback(
     (newSelectedSystems) => {
+      let foo = countOsMinorVersions(newSelectedSystems, profile);
+      console.log('DEBUG foo', foo);
       change('systems', newSelectedSystems);
-      change('osMinorVersionCounts', countOsMinorVersions(newSelectedSystems));
+      change('osMinorVersionCounts', foo);
     },
-    [change],
+    [change, profile],
   );
 
   return onSelect;
@@ -82,31 +84,17 @@ export const EditPolicySystems = ({
   profile,
   change,
   osMajorVersion,
-  osMinorVersionCounts,
   selectedSystems = [],
   allowNoSystems,
 }) => {
-  const onSelect = useOnSelect(change);
+  const onSelect = useOnSelect(change, profile);
 
   const defaultFilter =
-    osMajorVersion && osMinorVersionCounts
+    osMajorVersion && profile.os_minor_versions
       ? `os_major_version = ${osMajorVersion} AND ` +
-        `os_minor_version ^ (${osMinorVersionCounts.map(({ osMinorVersion }) => osMinorVersion).join(' ')}) AND ` +
+        `os_minor_version ^ (${profile.os_minor_versions.map((osMinorVersion) => osMinorVersion).join(' ')}) AND ` +
         `profile_ref_id !^ (${profile.ref_id})`
       : '';
-
-  useEffect(() => {
-    const osMinorVersions = profile.supportedOsVersions.map(
-      (version) => version.split('.')[1],
-    );
-    change(
-      'osMinorVersionCounts',
-      osMinorVersions.map((version) => ({
-        osMinorVersion: version,
-        count: 0,
-      })),
-    );
-  }, [change, profile]);
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -69,10 +69,11 @@ PrependComponent.propTypes = {
 const useOnSelect = (change, profile) => {
   const onSelect = useCallback(
     (newSelectedSystems) => {
-      let foo = countOsMinorVersions(newSelectedSystems, profile);
-      console.log('DEBUG foo', foo);
       change('systems', newSelectedSystems);
-      change('osMinorVersionCounts', foo);
+      change(
+        'osMinorVersionCounts',
+        countOsMinorVersions(newSelectedSystems, profile),
+      );
     },
     [change, profile],
   );

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -86,7 +86,6 @@ export const EditPolicySystems = ({
   change,
   osMajorVersion,
   selectedSystems = [],
-  allowNoSystems,
 }) => {
   const onSelect = useOnSelect(change, profile);
 
@@ -107,9 +106,7 @@ export const EditPolicySystems = ({
           <SystemsTable
             apiEndpoint="systems"
             prependComponent={
-              allowNoSystems ? undefined : (
-                <PrependComponent osMajorVersion={osMajorVersion} />
-              )
+              <PrependComponent osMajorVersion={osMajorVersion} />
             }
             emptyStateComponent={<EmptyState osMajorVersion={osMajorVersion} />}
             columns={[
@@ -147,7 +144,6 @@ EditPolicySystems.propTypes = {
   osMinorVersionCounts: propTypes.array,
   selectedSystems: propTypes.array,
   change: reduxFormPropTypes.change,
-  allowNoSystems: propTypes.bool,
 };
 
 const selector = formValueSelector('policyForm');

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicy.js
@@ -62,7 +62,7 @@ export const useUpdatePolicy = () => {
 
       const { id: newPolicyId } = createPolicyResponse.data;
 
-      if (hosts) {
+      if (hosts && hosts.length > 0) {
         await assignSystems([
           newPolicyId,
           undefined,

--- a/src/SmartComponents/CreatePolicy/validate.js
+++ b/src/SmartComponents/CreatePolicy/validate.js
@@ -39,11 +39,3 @@ export const validateDetailsPage = (
 
 export const validateRulesPage = (selectedRuleRefIds) =>
   selectedRuleRefIds?.length > 0;
-
-export const validateSystemsPage = (systemIds, allowNoSystems) => {
-  if (allowNoSystems) {
-    return true;
-  } else {
-    return systemIds?.length > 0;
-  }
-};

--- a/src/SmartComponents/SystemsTable/hooks/useSystemsBulkSelect.js
+++ b/src/SmartComponents/SystemsTable/hooks/useSystemsBulkSelect.js
@@ -1,7 +1,6 @@
 import { useCallback, useRef, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useBulkSelect } from 'bastilian-tabletools';
-import xor from 'lodash/xor';
 import { setDisabledSelection } from 'Store/Actions/SystemActions';
 
 const useSystemsBulkSelect = ({
@@ -35,30 +34,28 @@ const useSystemsBulkSelect = ({
 
   const onSelectCallback = useCallback(
     (selectedIds) => {
-      if (selectedIds.length === 0 || xor(selectedIds, selected).length) {
-        const selectedItems = selectedIds.map((id) => ({
-          id,
-          ...resultCache.data?.find(({ id: itemId }) => id === itemId),
-          ...itemIdsOnPage?.find(({ id: itemId }) => id === itemId),
-        }));
+      const selectedItems = selectedIds.map((id) => ({
+        id,
+        ...resultCache.data?.find(({ id: itemId }) => id === itemId),
+        ...itemIdsOnPage?.find(({ id: itemId }) => id === itemId),
+      }));
 
-        // Ensures rows are marked as selected in the inventory table
-        dispatch({
-          type: 'SELECT_ENTITIES',
-          payload: {
-            selected: selectedIds,
-          },
-        });
+      // Ensures rows are marked as selected in the inventory table
+      dispatch({
+        type: 'SELECT_ENTITIES',
+        payload: {
+          selected: selectedIds,
+        },
+      });
 
-        itemCache.current = selectedItems;
-        dispatch(setDisabledSelection(false));
+      itemCache.current = selectedItems;
+      dispatch(setDisabledSelection(false));
 
-        if (typeof onSelect === 'function') {
-          onSelect?.(selectedItems);
-        }
+      if (typeof onSelect === 'function') {
+        onSelect?.(selectedItems);
       }
     },
-    [dispatch, onSelect, itemIdsOnPage, resultCache, selected],
+    [dispatch, onSelect, itemIdsOnPage, resultCache],
   );
 
   const bulkSelect = useBulkSelect({

--- a/src/SmartComponents/SystemsTable/hooks/useSystemsBulkSelect.js
+++ b/src/SmartComponents/SystemsTable/hooks/useSystemsBulkSelect.js
@@ -36,7 +36,7 @@ const useSystemsBulkSelect = ({
     (selectedIds) => {
       const selectedItems = selectedIds.map((id) => ({
         id,
-        ...resultCache.data?.find(({ id: itemId }) => id === itemId),
+        ...resultCache?.data?.find(({ id: itemId }) => id === itemId),
         ...itemIdsOnPage?.find(({ id: itemId }) => id === itemId),
       }));
 

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -35,9 +35,15 @@ export const entitiesReducer = () =>
     }),
   });
 
-export const mapCountOsMinorVersions = (systems) => {
-  if (!systems) {
-    return {};
+export const mapCountOsMinorVersions = (systems, profile) => {
+  if (!systems || systems.length === 0) {
+    return profile.os_minor_versions.reduce((acc, version) => {
+      acc[version] = {
+        osMinorVersion: version,
+        count: 0,
+      };
+      return acc;
+    }, {});
   }
 
   return systems.reduce((acc, { osMinorVersion }) => {
@@ -52,7 +58,7 @@ export const mapCountOsMinorVersions = (systems) => {
   }, {});
 };
 
-export const countOsMinorVersions = (systems) =>
-  Object.values(mapCountOsMinorVersions(systems)).sort(
+export const countOsMinorVersions = (systems, profile) =>
+  Object.values(mapCountOsMinorVersions(systems, profile)).sort(
     sortingByProp('osMinorVersion', 'desc'),
   );


### PR DESCRIPTION
### This PR does few things:

1. System selection on Wizard - if you select systems, Rules step will show tabs with selected only systems. If you have no systems selected - rules step shows all available rule tabs
2. Removes image builder feature flag since it's already exposed for all in prod
3. Fixes filter for systems table in wizard so now it respects minor versions
4. Fixes tailoring creation when you have 0 systems selected
5. Fixes rules selection on Create policy wizard
6. Fixes bulk select issue for systems table when 0 systems pre-selected


### How to test:

1. Navigate to create policy wizard and select any policy that has at least 2 minor version supported
2. Go to systems tab
3. Select minor version X and Y
4. Move next to Rules tab and try unselect/select some rules. Also check if tabs do show correct numbers (for N of selected systems)
5. Finish policy creation
6. Check if policy created with applied selection
7. Repeat step 1-2, but when selecting systems - select nothing and move to rules page
8. Select/unselect rules there and create policy
9. Check if created policy has tailorings created and selection has been applied

