### PR TITLE
feat(RHINENG-19592): Rebranding to Lightspeed

### DIFF
--- a/src/PresentationalComponents/ReportsTable/ReportsTable.test.js
+++ b/src/PresentationalComponents/ReportsTable/ReportsTable.test.js
@@ -11,9 +11,6 @@ import {
 } from './Filters';
 import { uniq } from 'Utilities/helpers';
 import { buildReports } from '../../__factories__/reports';
-// import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
-
-jest.mock('Utilities/hooks/useFeatureFlag', () => () => false);
 
 const reportsData = buildReports(1);
 

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -7,6 +7,7 @@ import * as Columns from '../SystemsTable/Columns';
 import usePolicies from 'Utilities/hooks/api/usePolicies';
 import CompliancePageHeader from 'PresentationalComponents/CompliancePageHeader/CompliancePageHeader';
 import { systemsPopoverData } from '@/constants';
+import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 
 const systemTableColumns = [
   Columns.customName(
@@ -27,11 +28,14 @@ const ComplianceSystems = () => {
   const { data, error, loading } = usePolicies();
   const policies = data?.data;
 
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+  const serviceName = isLightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights';
+
   return (
     <React.Fragment>
       <CompliancePageHeader
         mainTitle={'Systems'}
-        popoverData={systemsPopoverData}
+        popoverData={systemsPopoverData(serviceName)}
       />
       <section className="pf-v6-c-page__main-section">
         <StateViewWithError stateValues={{ error, data: policies, loading }}>

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.test.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.test.js
@@ -7,6 +7,7 @@ import { buildPolicies } from '../../__factories__/policies';
 
 jest.mock('Utilities/hooks/api/usePolicies', () => jest.fn());
 const policiesData = buildPolicies(2);
+jest.mock('Utilities/hooks/useFeatureFlag', () => () => true);
 
 describe('ComplianceSystems', () => {
   it('expect to render inventory table when policies are loaded', () => {

--- a/src/SmartComponents/CreatePolicy/EditPolicySystems.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicySystems.js
@@ -18,32 +18,37 @@ import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { countOsMinorVersions } from 'Store/Reducers/SystemStore';
 import * as Columns from '../SystemsTable/Columns';
+import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 
-const EmptyState = ({ osMajorVersion }) => (
-  <React.Fragment>
-    <Content className="pf-v6-u-mb-md">
-      <Content component="p">
-        You do not have any <b>RHEL {osMajorVersion}</b> systems connected to
-        Insights and enabled for Compliance.
-        <br />
-        Policies must be created with at least one system.
+const EmptyState = ({ osMajorVersion }) => {
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+  const serviceName = isLightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights';
+  return (
+    <React.Fragment>
+      <Content className="pf-v6-u-mb-md">
+        <Content component="p">
+          You do not have any <b>RHEL {osMajorVersion}</b> systems connected to
+          {serviceName} and enabled for Compliance.
+          <br />
+          Policies must be created with at least one system.
+        </Content>
       </Content>
-    </Content>
-    <Content className="pf-v6-u-mb-md">
-      <Content component="p">
-        Choose a different RHEL version, or connect <b>RHEL {osMajorVersion}</b>{' '}
-        systems to Insights.
+      <Content className="pf-v6-u-mb-md">
+        <Content component="p">
+          Choose a different RHEL version, or connect{' '}
+          <b>RHEL {osMajorVersion}</b> systems to {serviceName}.
+        </Content>
       </Content>
-    </Content>
-    <WizardContextConsumer>
-      {({ goToStepById }) => (
-        <Button onClick={() => goToStepById(1)}>
-          Choose a different RHEL version
-        </Button>
-      )}
-    </WizardContextConsumer>
-  </React.Fragment>
-);
+      <WizardContextConsumer>
+        {({ goToStepById }) => (
+          <Button onClick={() => goToStepById(1)}>
+            Choose a different RHEL version
+          </Button>
+        )}
+      </WizardContextConsumer>
+    </React.Fragment>
+  );
+};
 
 EmptyState.propTypes = {
   osMajorVersion: propTypes.string,

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -3,6 +3,7 @@ import { Content } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import SystemsTable from 'SmartComponents/SystemsTable/SystemsTable';
 import * as Columns from 'SmartComponents/SystemsTable/Columns';
+import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 
 const systemTableColumns = [
   Columns.Name,
@@ -10,21 +11,25 @@ const systemTableColumns = [
   Columns.OperatingSystem(),
 ];
 
-const EmptyState = ({ osMajorVersion }) => (
-  <div data-testid="empty-state">
-    <Content className="pf-v6-u-mb-md">
-      <Content component="p">
-        You do not have any <b>RHEL {osMajorVersion}</b> systems connected to
-        Insights and enabled for Compliance.
+const EmptyState = ({ osMajorVersion }) => {
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+  const serviceName = isLightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights';
+  return (
+    <div data-testid="empty-state">
+      <Content className="pf-v6-u-mb-md">
+        <Content component="p">
+          You do not have any <b>RHEL {osMajorVersion}</b> systems connected to
+          {serviceName} and enabled for Compliance.
+        </Content>
       </Content>
-    </Content>
-    <Content className="pf-v6-u-mb-md">
-      <Content component="p">
-        Connect RHEL {osMajorVersion} systems to Insights.
+      <Content className="pf-v6-u-mb-md">
+        <Content component="p">
+          Connect RHEL {osMajorVersion} systems to {serviceName}.
+        </Content>
       </Content>
-    </Content>
-  </div>
-);
+    </div>
+  );
+};
 
 EmptyState.propTypes = {
   osMajorVersion: propTypes.string,

--- a/src/SmartComponents/ExportPDF/ExportPDF.js
+++ b/src/SmartComponents/ExportPDF/ExportPDF.js
@@ -14,8 +14,11 @@ import useExportSettings from './hooks/useExportSettings';
 import useReport from 'Utilities/hooks/api/useReport';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { exportNotifications } from './constants';
+import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 
 export const ExportPDF = () => {
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+
   const addNotification = useAddNotification();
   const { report_id: reportId } = useParams();
   const [loadingPDF, setLoadingPDF] = useState(false);
@@ -50,6 +53,9 @@ export const ExportPDF = () => {
           fetchDataParams: {
             reportId: reportId,
             exportSettings: exportSettings,
+          },
+          additionalData: {
+            isLightspeedEnabled: isLightspeedEnabled,
           },
         },
       });

--- a/src/SmartComponents/ExportPDF/ExportPDF.test.js
+++ b/src/SmartComponents/ExportPDF/ExportPDF.test.js
@@ -38,6 +38,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () =>
     requestPdf: jest.fn(),
   })),
 );
+jest.mock('Utilities/hooks/useFeatureFlag', () => () => true);
 
 describe('ExportPDF', () => {
   it('renders the Compliance report modal title', () => {

--- a/src/SmartComponents/ExportPDF/ReportPDFBuild.js
+++ b/src/SmartComponents/ExportPDF/ReportPDFBuild.js
@@ -181,7 +181,7 @@ export const fetchData = async (createAsyncRequest, options) => {
   return { data: data, options };
 };
 
-const ReportPDFBuild = ({ asyncData }) => {
+const ReportPDFBuild = ({ asyncData, additionalData }) => {
   const { data, options } = asyncData.data;
   const reportData = data[0].report_details;
   const topFailedRules = data[1].top_failed_rules;
@@ -189,10 +189,13 @@ const ReportPDFBuild = ({ asyncData }) => {
   const nonCompliantSystems = data[3].non_compliant_systems;
   const nonReportingSystems = data[4].non_reporting_systems;
   const unsupportedSystems = data[5].unsupported_systems;
+  const { isLightspeedEnabled } = additionalData;
 
   return (
     <div style={styles.document}>
-      <span style={styles.insightsHeader}>Red Hat Insights</span>
+      <span style={styles.insightsHeader}>
+        Red Hat {isLightspeedEnabled ? 'Lightspeed' : 'Insights'}
+      </span>
       <br />
       <span style={styles.policyTitleHeader}>
         {`Compliance: ${reportData.title}`}
@@ -277,6 +280,7 @@ const ReportPDFBuild = ({ asyncData }) => {
 
 ReportPDFBuild.propTypes = {
   asyncData: PropTypes.object,
+  additionalData: PropTypes.object,
 };
 
 export default ReportPDFBuild;

--- a/src/SmartComponents/ExportPDF/ReportPDFBuild.test.js
+++ b/src/SmartComponents/ExportPDF/ReportPDFBuild.test.js
@@ -15,6 +15,8 @@ jest.mock('./helpers', () => ({
   fetchUnsupportedSystemsWithExpectedSSG: jest.fn(),
 }));
 
+jest.mock('Utilities/hooks/useFeatureFlag', () => () => true);
+
 import {
   fetchPaginatedList,
   fetchUnsupportedSystemsWithExpectedSSG,
@@ -320,10 +322,15 @@ describe('ReportPDFBuild', () => {
     },
   };
 
-  it('should render basic report details and Red Hat Insights title', () => {
-    render(<ReportPDFBuild asyncData={mockAsyncData} />);
+  it('should render basic report details and Red Hat Lightspeed title', () => {
+    render(
+      <ReportPDFBuild
+        asyncData={mockAsyncData}
+        additionalData={{ isLightspeedEnabled: true }}
+      />,
+    );
 
-    expect(screen.getByText('Red Hat Insights')).toBeInTheDocument();
+    expect(screen.getByText('Red Hat Lightspeed')).toBeInTheDocument();
     expect(
       screen.getByText(`Compliance: ${mockReportData.title}`),
     ).toBeInTheDocument();
@@ -351,9 +358,14 @@ describe('ReportPDFBuild', () => {
         },
       },
     };
-    render(<ReportPDFBuild asyncData={mockAsyncDataModified} />);
+    render(
+      <ReportPDFBuild
+        asyncData={mockAsyncDataModified}
+        additionalData={{ isLightspeedEnabled: true }}
+      />,
+    );
 
-    expect(screen.getByText('Red Hat Insights')).toBeInTheDocument();
+    expect(screen.getByText('Red Hat Lightspeed')).toBeInTheDocument();
     expect(
       screen.getByText(`Compliance: ${mockReportData.title}`),
     ).toBeInTheDocument();
@@ -386,9 +398,14 @@ describe('ReportPDFBuild', () => {
         },
       },
     };
-    render(<ReportPDFBuild asyncData={fullAsyncData} />);
+    render(
+      <ReportPDFBuild
+        asyncData={fullAsyncData}
+        additionalData={{ isLightspeedEnabled: true }}
+      />,
+    );
 
-    expect(screen.getByText('Red Hat Insights')).toBeInTheDocument();
+    expect(screen.getByText('Red Hat Lightspeed')).toBeInTheDocument();
     expect(
       screen.getByText(`Compliance: ${mockReportData.title}`),
     ).toBeInTheDocument();

--- a/src/SmartComponents/SystemDetails/EmptyState.js
+++ b/src/SmartComponents/SystemDetails/EmptyState.js
@@ -5,8 +5,10 @@ import NoPoliciesState from './NoPoliciesState';
 import NoReportsState from './NoReportsState';
 import useSystem from 'Utilities/hooks/api/useSystem';
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 
 const EmptyState = ({ inventoryId: systemId, system, connectedToInsights }) => {
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
   // request system data in case Inventory details Compliance opened
   const { data: { data } = {}, loading: systemLoading } = useSystem({
     params: { systemId },
@@ -16,7 +18,11 @@ const EmptyState = ({ inventoryId: systemId, system, connectedToInsights }) => {
   const policiesCount = system?.policies.length ?? data?.policies.length;
 
   if (connectedToInsights === false) {
-    return <NotConnected />;
+    return (
+      <NotConnected
+        titleText={`This system isn’t connected to ${isLightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'} yet`}
+      />
+    );
   }
 
   if (systemLoading === true) {

--- a/src/SmartComponents/SystemDetails/EmptyState.test.js
+++ b/src/SmartComponents/SystemDetails/EmptyState.test.js
@@ -6,6 +6,7 @@ import EmptyState from './EmptyState.js';
 import useSystem from 'Utilities/hooks/api/useSystem';
 
 jest.mock('Utilities/hooks/api/useSystem', () => jest.fn());
+jest.mock('Utilities/hooks/useFeatureFlag', () => () => true);
 
 describe('EmptyState for systemDetails', () => {
   it('expect to render loading state while waiting for data', () => {
@@ -39,7 +40,7 @@ describe('EmptyState for systemDetails', () => {
     );
 
     expect(
-      screen.getByText(`This system isn’t connected to Insights yet`),
+      screen.getByText(`This system isn’t connected to Red Hat Lightspeed yet`),
     ).toBeInTheDocument();
   });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -102,12 +102,11 @@ export const policiesPopoverData = {
     'index#compliance-managing-policies_intro-compliance',
 };
 
-export const systemsPopoverData = {
+export const systemsPopoverData = (serviceName) => ({
   headerContent: 'Systems list',
-  bodyContent:
-    'This list shows systems that have the necessary packages to successfully run Insights compliance scans.',
+  bodyContent: `This list shows systems that have the necessary packages to successfully run ${serviceName} compliance scans.`,
   bodyLink:
     'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html-single/' +
     'assessing_and_monitoring_security_policy_compliance_of_rhel_systems/' +
     'index#compliance-getting-started_intro-compliance',
-};
+});


### PR DESCRIPTION
PR takes care of Lightspeed rebranding depending on Feature flag

**How to test:**

1. Ensure that places that had `Insights` before have `Lightspeed` if feature flag is enabled.
2. To test PDF change here you have steps to run it https://github.com/RedHatInsights/compliance-frontend/pull/2515#issue-3178630283 

I double checked and PDF shows lighspeed if FF is enabled
<img width="1453" height="746" alt="Screenshot 2025-09-15 at 12 36 51" src="https://github.com/user-attachments/assets/00f9ab35-34b7-4a59-8dc3-9225493f4297" />



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce feature-flag controlled rebranding from Red Hat Insights to Red Hat Lightspeed across UI components and tests

Enhancements:
- Use the platform.lightspeed-rebrand flag to toggle service name in EmptyState components and PDF report headers
- Replace hardcoded "Insights" strings with conditional "Insights" or "Lightspeed" based on feature flag

Tests:
- Update test assertions to expect "Red Hat Lightspeed" and updated EmptyState messaging under the rebranding flag

## Summary by Sourcery

Apply feature-flag-driven rebranding of “Insights” to “Lightspeed” across UI components, PDF export, constants, and tests.

Enhancements:
- Integrate feature flag hook to toggle service name in EmptyState components for policy editing and system details
- Make ComplianceSystems popover messaging dynamic by passing serviceName from feature flag
- Extend constants.systemsPopoverData to accept a serviceName parameter for dynamic popover content
- Propagate feature flag through ExportPDF and ReportPDFBuild and render conditional “Red Hat Insights” or “Red Hat Lightspeed” headers

Tests:
- Mock feature flag in relevant tests and update assertions to expect “Red Hat Lightspeed” strings