### PR TITLE
fix(RHINENG-20632): Set newSelectedRuleIds if it's new

### DIFF
--- a/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
+++ b/src/SmartComponents/CreatePolicy/EditPolicyProfilesRules/EditPolicyProfilesRules.js
@@ -124,6 +124,7 @@ const EditPolicyProfilesRules = ({
         ) {
           return;
         }
+        updatedSelectedRuleRefIds[index].ruleRefIds = newSelectedRuleIds;
       }
       change('selectedRuleRefIds', updatedSelectedRuleRefIds);
     },


### PR DESCRIPTION
When I was fixing multiple things on Create wizard I fixed selection itself but forgot to add functuonality to saving new selection. This fixes the issue so selection is respected when policy creation happens


### How to test:

1. Go to create policy wizard
2. Select any policy that has multiple minor versions support (on first step there is a column that shows how many versions are supported)
3. Proceed to Systems step
4. Do not select any systems
5. Go to rules step, unselect some rules for tabs and write down how many rules should be there per minor version
6. Finish policy creation
7. Navigate to policy details Rules tab and check if rules selection has been applied

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Persist newSelectedRuleIds in the selection state so rule selections are respected on policy creation.