### PR TITLE
fix(RHINENG-20562): Fix rule tabs appearing and system count

### DIFF
--- a/src/PresentationalComponents/Tailorings/Tailorings.js
+++ b/src/PresentationalComponents/Tailorings/Tailorings.js
@@ -131,14 +131,11 @@ const Tailorings = ({
                         }}
                       />
                     </FlexItem>
-                    {typeof selectedVersionCounts?.[tab.os_minor_version] !==
-                      'undefined' && (
-                      <FlexItem>
-                        <Badge isRead>
-                          {` ${selectedVersionCounts[tab.os_minor_version]} `}
-                        </Badge>
-                      </FlexItem>
-                    )}
+                    <FlexItem>
+                      <Badge isRead>
+                        {` ${selectedVersionCounts[tab.os_minor_version] || 0} `}
+                      </Badge>
+                    </FlexItem>
                   </Flex>
                 }
                 ouiaId={`RHEL ${tab.os_major_version}.${tab.os_minor_version}`}

--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -44,12 +44,17 @@ const EditPolicyForm = ({
 
   const handleSystemSelect = useCallback(
     (newSelectedSystems) => {
+      // On some renderings we get system ids without os_minor_version
       const newOsMinorVersions = [
         ...new Set(
-          newSelectedSystems.map(
-            (system) => system.os_minor_version ?? system.osMinorVersion,
-          ),
-        ), // get unique values
+          newSelectedSystems
+            .filter(
+              (system) =>
+                system.os_minor_version != null ||
+                system.osMinorVersion != null,
+            )
+            .map((system) => system.os_minor_version ?? system.osMinorVersion),
+        ),
       ];
 
       const hasNewOsMinorVersions =

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -108,14 +108,15 @@ export const EditPolicyRulesTab = ({
         },
       };
     });
-
     setSelectedRules((prev) => ({
       ...prev,
       ...profilesRuleIds?.reduce((prevRuleIds, profile) => {
         return {
           ...prevRuleIds,
           [Number(profile.osMinorVersion)]:
-            prev?.[profile.osMinorVersion] || profile.ruleIds,
+            prev?.[profile.osMinorVersion].length > 0
+              ? prev?.[profile.osMinorVersion]
+              : profile.ruleIds,
         };
       }, {}),
     }));
@@ -151,12 +152,15 @@ export const EditPolicyRulesTab = ({
       stateValues={{
         data:
           policy &&
-          selectedOsMinorVersions.length > 0 &&
+          (selectedOsMinorVersions.length > 0 ||
+            tailoringOsMinorVersions.length > 0) &&
           (shouldSkipProfiles || (profilesRuleIds && !profilesRuleIdsLoading)),
         loading:
           assignedSystemCount === undefined ||
           (nonTailoringOsMinorVersions.length > 0 && profilesRuleIdsLoading),
-        empty: selectedOsMinorVersions.length === 0,
+        empty:
+          selectedOsMinorVersions.length === 0 &&
+          tailoringOsMinorVersions.length === 0,
         error: profilesRuleIdsError, // TODO: add the state view for error
       }}
     >

--- a/src/Utilities/hooks/usePolicyOsVersionCounts.js
+++ b/src/Utilities/hooks/usePolicyOsVersionCounts.js
@@ -24,11 +24,10 @@ const usePolicyOsVersionCounts = (policyId) => {
 
         for (const version of versions) {
           const minor = version.split('.')[1];
-          const { data: total } = await fetchPolicySystems({
+          const totalSystemsCount = await fetchPolicySystems({
             filter: `(os_minor_version = ${minor})`,
           });
-
-          newCounts[minor] = total;
+          newCounts[minor] = totalSystemsCount;
         }
 
         setCounts(newCounts);


### PR DESCRIPTION
### Description
While digging into original issue I found few more:

1. Edit policy: modal might show tab with `MajorVersion.undefined`
2. Edit policy: If you select new minor version and switch back to rules tab - Rules are not preselected
3. Edit policy: System count badge didn't appear in some cases
4. Edit policy: Tailoring tabs were not shown unless at least 1 system is associated
5. Policy details: Rules tab didn't show correct number of systems


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fix rule tabs appearing and system count handling

Bug Fixes:
- Always render system count badges with zero default when no count is defined
- Filter out systems without os_minor_version when constructing the selected versions list
- Update rule tabs rendering logic to include tailoringOsMinorVersions in data, loading, and empty state conditions

## Summary by Sourcery

Fix UI inconsistencies in the Edit Policy and Policy Details views by correcting system count badges, OS version selection, and rule tab rendering.

Bug Fixes:
- Always render system count badges with a default of zero when no count is defined
- Filter out systems lacking os_minor_version when computing selected OS minor versions
- Preserve previously selected rules when switching back to a minor version tab
- Include tailoring OS minor versions in rules tab rendering to properly display data and manage empty/loading states
- Prevent tabs from showing an 'undefined' minor version label in the Edit Policy modal