### PR TITLE
feat(IoP): Investigating IoP

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -6,6 +6,11 @@ const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 
 const bundle = 'insights';
 const appName = packageJson[bundle].appname;
+const isIOP = process.env.IOP === 'true';
+
+if (isIOP) {
+  packageJson.insights.appname = 'vulnerability';
+}
 
 // TODO Move to fec webpack config similar to LOCAL_APPS
 const routes = {
@@ -15,9 +20,10 @@ const routes = {
 };
 
 module.exports = {
-  appName,
-  appUrl: `/${bundle}/${appName}`,
+  appName: isIOP ? 'vulnerability' : appName,
+  appUrl: isIOP ? '/insights/vulnerability' : `/${bundle}/${appName}`,
   useProxy: process.env.PROXY === 'true',
+  ...(isIOP ? { deployment: 'assets/apps' } : {}),
   devtool: 'hidden-source-map',
   plugins: [
     ...(process.env.ENABLE_SENTRY
@@ -59,6 +65,7 @@ module.exports = {
         __dirname,
         '/src/SmartComponents/ExportPDF/ReportPDFBuild',
       ),
+      './CveListPage': resolve(__dirname, './src/SmartComponents/CompliancePolicies/CompliancePolicies'),
     },
   },
   resolve: {


### PR DESCRIPTION
This PR so far is just for researching purposes. It fakes vulnerability and puts Compliance code so we can see how app is displayed in IoP.
This needs to be tested with these steps https://gist.github.com/bastilian/395f052a1c75110f0f471dbbd31ec2fd

## Summary by Sourcery

Add conditional configuration to run the app as the IoP "vulnerability" application when an IOP environment flag is enabled.

New Features:
- Introduce an IoP mode controlled by an environment variable that remaps the app to the "vulnerability" app and URL for testing in IoP.

Enhancements:
- Adjust webpack module federation exposes to include the compliance policies page under a CVE list page entry point when running in IoP mode.