### PR TITLE
fix(SPUR): fix styling & wording

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@patternfly/react-tokens": "^6.4.0",
         "@project-kessel/react-kessel-access-check": "^0.5.0",
         "@redhat-cloud-services/compliance-client": "^3.0.7",
-        "@redhat-cloud-services/frontend-components": "^7.0.44",
+        "@redhat-cloud-services/frontend-components": "^7.3.0",
         "@redhat-cloud-services/frontend-components-config-utilities": "^4.7.31",
         "@redhat-cloud-services/frontend-components-notifications": "^6.2.0",
         "@redhat-cloud-services/frontend-components-remediations": "^4.0.56",
@@ -5738,9 +5738,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "7.0.44",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-7.0.44.tgz",
-      "integrity": "sha512-F54dJSNGdAZVTYtoX7FsD9AYwxOYrVvBgX2Ohx4ZUv4luivOtenuaYvhzsG7q8bdje7dbdTbr5ovsEmuwqmLAg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-7.3.0.tgz",
+      "integrity": "sha512-kURKbJnyC78MYtBzCIShABUBWPiRb2WLuI19AAQskVeOuJ6f4YuD/7wfVASRBlyA2sRTRge92NOC+UfdY5M8dQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@patternfly/react-tokens": "^6.4.0",
     "@project-kessel/react-kessel-access-check": "^0.5.0",
     "@redhat-cloud-services/compliance-client": "^3.0.7",
-    "@redhat-cloud-services/frontend-components": "^7.0.44",
+    "@redhat-cloud-services/frontend-components": "^7.3.0",
     "@redhat-cloud-services/frontend-components-config-utilities": "^4.7.31",
     "@redhat-cloud-services/frontend-components-notifications": "^6.2.0",
     "@redhat-cloud-services/frontend-components-remediations": "^4.0.56",

--- a/src/App.scss
+++ b/src/App.scss
@@ -50,7 +50,7 @@
 }
 
 .grey-icon {
-  color: var(--pf-v6-global--Color--200);
+  color: var(--pf-t--global--icon--color--subtle);
 }
 
 button.pf-v6-c-button.pf-m-tertiary {
@@ -80,18 +80,6 @@ button.pf-v6-c-button.pf-m-tertiary {
 .ins-c-non-bold-h2 {
   font-size: var(--pf-v6-c-content--h2--FontSize);
   font-weight: normal;
-}
-
-.ins-u-passed {
-  color: var(--pf-v6-global--success-color--200);
-}
-
-.ins-u-failed {
-  color: var(--pf-v6-global--danger-color--100);
-}
-
-.ins-u-warning {
-  color: var(--pf-v6-global--warning-color--100);
 }
 
 button[data-ouia-component-id="InlineEditPencil"],

--- a/src/PresentationalComponents/CompliancePageHeader/CompliancePageHeader.js
+++ b/src/PresentationalComponents/CompliancePageHeader/CompliancePageHeader.js
@@ -3,6 +3,7 @@ import propTypes from 'prop-types';
 import PageHeader, {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
+import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
 import {
   Popover,
   Flex,
@@ -31,16 +32,14 @@ const CompliancePageHeader = ({ mainTitle, popoverData }) => {
                       {popoverData.bodyContent}
                     </Content>
                     <Content component={ContentVariants.p}>
-                      <a
-                        rel="noreferrer"
+                      <Link
+                        to={popoverData.bodyLink}
+                        rel="noopener noreferrer"
                         target="_blank"
-                        href={popoverData.bodyLink}
                       >
                         Learn more
-                        <Icon className="pf-v6-u-ml-xs">
-                          <ExternalLinkAltIcon />
-                        </Icon>
-                      </a>
+                        <ExternalLinkAltIcon className="pf-v6-u-ml-xs" />
+                      </Link>
                     </Content>
                   </Flex>
                 </Content>

--- a/src/PresentationalComponents/CompliancePageHeader/CompliancePageHeader.test.js
+++ b/src/PresentationalComponents/CompliancePageHeader/CompliancePageHeader.test.js
@@ -1,8 +1,13 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import CompliancePageHeader from './CompliancePageHeader';
+
+const TestWrapper = ({ children }) => <MemoryRouter>{children}</MemoryRouter>;
+TestWrapper.propTypes = { children: propTypes.node };
 
 describe('CompliancePageHeader', () => {
   const mockMainTitle = 'My Compliance Policy';
@@ -15,10 +20,12 @@ describe('CompliancePageHeader', () => {
 
   test('renders the main title correctly', () => {
     render(
-      <CompliancePageHeader
-        mainTitle={mockMainTitle}
-        popoverData={mockPopoverData}
-      />,
+      <TestWrapper>
+        <CompliancePageHeader
+          mainTitle={mockMainTitle}
+          popoverData={mockPopoverData}
+        />
+      </TestWrapper>,
     );
 
     expect(screen.getByText(mockMainTitle)).toBeInTheDocument();
@@ -26,10 +33,12 @@ describe('CompliancePageHeader', () => {
 
   test('opens and displays popover content on icon click', async () => {
     render(
-      <CompliancePageHeader
-        mainTitle={mockMainTitle}
-        popoverData={mockPopoverData}
-      />,
+      <TestWrapper>
+        <CompliancePageHeader
+          mainTitle={mockMainTitle}
+          popoverData={mockPopoverData}
+        />
+      </TestWrapper>,
     );
 
     const questionIcon = screen.getByTestId('compliance-header-popover-icon');

--- a/src/PresentationalComponents/PoliciesTable/PoliciesTable.js
+++ b/src/PresentationalComponents/PoliciesTable/PoliciesTable.js
@@ -21,8 +21,8 @@ export const PoliciesTable = ({
   const complianceTableDefaults = useComplianceTableDefaults();
   const filters = Object.values(Filters);
   const actionResolver = useActionResolver({
-    deletePermission,
     editPermission,
+    deletePermission,
   });
 
   return (

--- a/src/PresentationalComponents/PoliciesTable/hooks/useActionResolvers.js
+++ b/src/PresentationalComponents/PoliciesTable/hooks/useActionResolvers.js
@@ -2,28 +2,28 @@ import useNavigate from '@redhat-cloud-services/frontend-components-utilities/us
 
 const useActionResolver = ({ deletePermission = {}, editPermission = {} }) => {
   const navigate = useNavigate();
-
-  const {
-    hasAccess: hasDeleteAccess = false,
-    isLoading: isDeleteAccessLoading = false,
-  } = deletePermission;
   const {
     hasAccess: hasEditAccess = false,
     isLoading: isEditAccessLoading = false,
   } = editPermission;
 
+  const {
+    hasAccess: hasDeleteAccess = false,
+    isLoading: isDeleteAccessLoading = false,
+  } = deletePermission;
+
   return () => [
-    {
-      title: 'Delete policy',
-      isDisabled: !isDeleteAccessLoading && !hasDeleteAccess,
-      onClick: (_event, _index, { item }) =>
-        navigate(`/scappolicies/${item.itemId}/delete`),
-    },
     {
       title: 'Edit policy',
       isDisabled: !isEditAccessLoading && !hasEditAccess,
       onClick: (_event, _index, { item }) =>
         navigate(`/scappolicies/${item.itemId}/edit`),
+    },
+    {
+      title: 'Delete policy',
+      isDisabled: !isDeleteAccessLoading && !hasDeleteAccess,
+      onClick: (_event, _index, { item }) =>
+        navigate(`/scappolicies/${item.itemId}/delete`),
     },
   ];
 };

--- a/src/PresentationalComponents/PolicyDetailsDescription/PolicyDetailsDescription.js
+++ b/src/PresentationalComponents/PolicyDetailsDescription/PolicyDetailsDescription.js
@@ -61,7 +61,13 @@ const PolicyDetailsDescription = ({ policy, refetch, hasEditPermission }) => {
               hasEditPermission={hasEditPermission}
             />
           </Content>
-          <Content component="p">
+          <Content
+            component="p"
+            style={{
+              maxWidth: '40%',
+              overflowWrap: 'anywhere',
+            }}
+          >
             <EditPolicyDetailsInline
               policy={policy}
               refetch={refetch}

--- a/src/PresentationalComponents/RulesTable/Cells.js
+++ b/src/PresentationalComponents/RulesTable/Cells.js
@@ -60,13 +60,19 @@ Severity.propTypes = ruleProps;
 
 export const Passed = ({ compliant }) =>
   compliant ? (
-    <Icon status="success">
-      <CheckCircleIcon />
-    </Icon>
+    <div>
+      <Icon status="success" className="pf-v6-u-mr-xs">
+        <CheckCircleIcon />
+      </Icon>
+      Passed
+    </div>
   ) : (
-    <Icon status="danger">
-      <ExclamationCircleIcon />
-    </Icon>
+    <div>
+      <Icon status="danger" className="pf-v6-u-mr-xs">
+        <ExclamationCircleIcon />
+      </Icon>
+      Failed
+    </div>
   );
 Passed.propTypes = ruleProps;
 

--- a/src/PresentationalComponents/RulesTable/Filters.js
+++ b/src/PresentationalComponents/RulesTable/Filters.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import {
-  HighSeverity,
-  MediumSeverity,
-  LowSeverity,
-  UnknownSeverity,
+  HighSeverityChipIcon,
+  MediumSeverityChipIcon,
+  LowSeverityChipIcon,
+  UnknownSeverityChipIcon,
 } from './components/SeverityIcons';
 import { FAILED_RULE_STATES } from '@/constants';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
@@ -27,10 +27,26 @@ const BASE_FILTER_CONFIGURATION = [
     label: 'Severity',
     filterAttribute: 'severity',
     items: [
-      { label: <HighSeverity />, value: 'high' },
-      { label: <MediumSeverity />, value: 'medium' },
-      { label: <LowSeverity />, value: 'low' },
-      { label: <UnknownSeverity />, value: 'unknown' },
+      {
+        label: 'High',
+        value: 'high',
+        chipIcon: <HighSeverityChipIcon />,
+      },
+      {
+        label: 'Medium',
+        value: 'medium',
+        chipIcon: <MediumSeverityChipIcon />,
+      },
+      {
+        label: 'Low',
+        value: 'low',
+        chipIcon: <LowSeverityChipIcon />,
+      },
+      {
+        label: 'Unknown',
+        value: 'unknown',
+        chipIcon: <UnknownSeverityChipIcon />,
+      },
     ],
   },
 ];
@@ -70,10 +86,10 @@ export const policiesFilterConfig = (policies) => ({
 
 export const ANSIBLE_SUPPORT_FILTER_CONFIG = {
   type: conditionalFilterType.checkbox,
-  label: 'Ansible support',
+  label: 'Remediation type',
   items: [
-    { label: 'Ansible remediation support', value: 'true' },
-    { label: 'No Ansible remediation support', value: 'false' },
+    { label: 'Playbook', value: 'true' },
+    { label: 'Manual', value: 'false' },
   ],
   filterSerialiser: (_filterConfig, values) =>
     `(${values

--- a/src/PresentationalComponents/RulesTable/components/SeverityIcons.js
+++ b/src/PresentationalComponents/RulesTable/components/SeverityIcons.js
@@ -2,47 +2,88 @@ import React from 'react';
 import { Icon } from '@patternfly/react-core';
 
 import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  QuestionCircleIcon,
+  SeverityCriticalIcon,
+  SeverityMinorIcon,
+  SeverityModerateIcon,
+  SeverityUndefinedIcon,
 } from '@patternfly/react-icons';
 
-const LowSeverityIcon = () => (
-    <svg width="1em" height="1em" viewBox="0 0 18 18" role="img" style={ { verticalAlign: '-0.125em' } } xmlns="http://www.w3.org/2000/svg"><path d="M2 0h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2zm6.67 10.46a1.67 1.67 0 1 0 0 3.338 1.67 1.67 0 0 0 0-3.338zm-1.586-6l.27 4.935a.435.435 0 0 0 .434.411H9.55c.232 0 .422-.18.435-.411l.27-4.936A.435.435 0 0 0 9.818 4h-2.3c-.25 0-.448.21-.435.46z" fill="#3A9CA6" fillRule="evenodd"/></svg> // eslint-disable-line
+export const HighSeverityChipIcon = () => (
+  <Icon
+    style={{
+      '--pf-v6-c-icon__content--Color':
+        'var(--pf-t--global--icon--color--severity--critical--default)',
+    }}
+    className="pf-v6-u-mr-xs"
+    isInline
+  >
+    <SeverityCriticalIcon />
+  </Icon>
 );
 
 export const HighSeverity = () => (
   <>
-    <Icon status="danger" className="pf-v6-u-mr-xs" isInline>
-      <ExclamationCircleIcon />
-    </Icon>
+    <HighSeverityChipIcon />
     High
   </>
 );
 
+export const MediumSeverityChipIcon = () => (
+  <Icon
+    style={{
+      '--pf-v6-c-icon__content--Color':
+        'var(--pf-t--global--icon--color--severity--moderate--default)',
+    }}
+    className="pf-v6-u-mr-xs"
+    isInline
+  >
+    <SeverityModerateIcon />
+  </Icon>
+);
+
 export const MediumSeverity = () => (
   <>
-    <Icon status="warning" className="pf-v6-u-mr-xs" isInline>
-      <ExclamationTriangleIcon />
-    </Icon>
+    <MediumSeverityChipIcon />
     Medium
   </>
 );
 
+export const LowSeverityChipIcon = () => (
+  <Icon
+    style={{
+      '--pf-v6-c-icon__content--Color':
+        'var(--pf-t--global--icon--color--severity--minor--default)',
+    }}
+    className="pf-v6-u-mr-xs minor"
+    isInline
+  >
+    <SeverityMinorIcon />
+  </Icon>
+);
+
 export const LowSeverity = () => (
   <>
-    <Icon className="pf-v6-u-mr-xs" isInline>
-      <LowSeverityIcon />
-    </Icon>
+    <LowSeverityChipIcon />
     Low
   </>
 );
 
+export const UnknownSeverityChipIcon = () => (
+  <Icon
+    style={{
+      '--pf-v6-c-icon__content--Color':
+        'var(--pf-t--global--icon--color--severity--undefined--default)',
+    }}
+    className="pf-v6-u-mr-xs undefined"
+    isInline
+  >
+    <SeverityUndefinedIcon />
+  </Icon>
+);
+
 export const UnknownSeverity = () => (
   <>
-    <Icon className="pf-v6-u-mr-xs" isInline>
-      <QuestionCircleIcon />
-    </Icon>
+    <UnknownSeverityChipIcon />
     Unknown
   </>
 );

--- a/src/PresentationalComponents/SupportedSSGVersionsLink/SupportedSSGVersionsLink.js
+++ b/src/PresentationalComponents/SupportedSSGVersionsLink/SupportedSSGVersionsLink.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { supportedConfigsLink } from '@/constants';
+import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 const SupportedSSGVersionsLink = () => (
-  <a target="_blank" rel="noopener noreferrer" href={supportedConfigsLink}>
-    Supported SSG versions <ExternalLinkAltIcon />
-  </a>
+  <Link to={supportedConfigsLink} rel="noopener noreferrer" target="_blank">
+    Supported SSG versions
+    <ExternalLinkAltIcon className="pf-v6-u-ml-xs" />
+  </Link>
 );
 
 export default SupportedSSGVersionsLink;

--- a/src/PresentationalComponents/SystemPolicyCard/components/UnsupportedSSGVersionAlert.js
+++ b/src/PresentationalComponents/SystemPolicyCard/components/UnsupportedSSGVersionAlert.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Popover, Alert } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import {
+  OutlinedQuestionCircleIcon,
+  ExternalLinkAltIcon,
+} from '@patternfly/react-icons';
 import { supportedConfigsLink } from '@/constants';
 import { unsupportedSystemWarningMessage } from '@/constants';
+import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 const UnsupportedSSGVersionAlert = ({ ssgVersion, style, ...props }) => {
   const footerContent = (
-    <a target="_blank" rel="noopener noreferrer" href={supportedConfigsLink}>
+    <Link to={supportedConfigsLink} rel="noopener noreferrer" target="_blank">
       Supported SSG versions
-    </a>
+      <ExternalLinkAltIcon className="pf-v6-u-ml-xs" />
+    </Link>
   );
 
   return (

--- a/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyBase.js
+++ b/src/SmartComponents/CreatePolicy/FinishedCreatePolicy/FinishedCreatePolicyBase.js
@@ -51,7 +51,9 @@ export const FinishedCreatePolicyBase = ({
 }) => {
   const addNotification = useAddNotification();
   const [percent, setPercent] = useState(0);
-  const [message, setMessage] = useState('This usually takes a minute or two.');
+  const [message, setMessage] = useState(
+    'We’re setting up your SCAP policy. Stay on this page until the process is complete',
+  );
   const [errors, setErrors] = useState(null);
   const [failed, setFailed] = useState(false);
 

--- a/src/SmartComponents/CreatePolicyDDF/components/FinishedStep.js
+++ b/src/SmartComponents/CreatePolicyDDF/components/FinishedStep.js
@@ -44,7 +44,9 @@ const FinishedStep = ({ values, onClose }) => {
   const addNotification = useAddNotification();
 
   const [percent, setPercent] = useState(0);
-  const [message, setMessage] = useState('This usually takes a minute or two.');
+  const [message, setMessage] = useState(
+    'We’re setting up your SCAP policy. Stay on this page until the process is complete',
+  );
   const [errors, setErrors] = useState(null);
   const [failed, setFailed] = useState(false);
   const [policyCreated, setPolicyCreated] = useState(false);

--- a/src/SmartComponents/EditPolicy/EditPolicyForm.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyForm.js
@@ -88,6 +88,7 @@ const EditPolicyForm = ({
 
   return (
     <Form>
+      {newRulesAlert && <NewRulesAlert />}
       <RoutedTabs ouiaId="EditSystems" defaultTab="rules" id="policy-tabs">
         <Tab
           eventKey="rules"
@@ -116,7 +117,6 @@ const EditPolicyForm = ({
             supportedOsVersions={supportedOsVersions}
             setIsSystemsDataLoading={setIsSystemsDataLoading}
           />
-          {newRulesAlert && <NewRulesAlert />}
         </Tab>
       </RoutedTabs>
     </Form>

--- a/src/SmartComponents/ExportPDF/PolicyDetailsSection.js
+++ b/src/SmartComponents/ExportPDF/PolicyDetailsSection.js
@@ -37,7 +37,7 @@ const PolicyDetailsSection = ({ reportData, styles }) => {
 
   const chartColorScale = [
     paletteColors.blue300,
-    paletteColors.blue100,
+    paletteColors.orange400,
     paletteColors.gold300,
     paletteColors.black200,
   ];

--- a/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/RuleRow.js
+++ b/src/SmartComponents/ImportRules/components/RuleComparison/components/ComparisonTable/components/RuleRow.js
@@ -16,12 +16,18 @@ const RuleRow = ({
       ...(available_in_version &&
       !available_in_version.includes(targetVersion.ssg_version) &&
       available_in_version.includes(sourceVersion.ssg_version)
-        ? { backgroundColor: 'var(--pf-v5-global--palette--black-150)' }
+        ? {
+            backgroundColor:
+              'var(--pf-t--global--background--color--secondary--default)',
+          }
         : {}),
       ...(available_in_version &&
       available_in_version?.includes(targetVersion.ssg_version) &&
       !available_in_version?.includes(sourceVersion.ssg_version)
-        ? { backgroundColor: 'var(--pf-v5-global--palette--blue-50)' }
+        ? {
+            backgroundColor:
+              'var(--pf-t--global--color--nonstatus--blue--default)',
+          }
         : {}),
     }}
   >

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.scss
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.scss
@@ -2,10 +2,6 @@
     margin-bottom: var(--pf-v6-global--spacer--md);
 }
 
-.grey-icon {
-    color: var(--pf-v6-global--Color--200);
-}
-
 .policy-description {
     padding-top: 10px;
 }

--- a/src/SmartComponents/PolicyRules/PolicyRulesHeader.js
+++ b/src/SmartComponents/PolicyRules/PolicyRulesHeader.js
@@ -8,11 +8,11 @@ import propTypes from 'prop-types';
 
 const PolicyRulesHeader = ({ name, securityGuideVersion, osMajorVersion }) => {
   return (
-    <PageHeader className="pf-v5-u-pt-xl pf-v5-u-pl-xl">
+    <PageHeader className="pf-v6-u-pt-xl pf-v6-u-pl-xl">
       <PageHeaderTitle
         title={`Compliance | Default rules for ${name} policy`}
       />
-      <Content className="pf-v5-u-mb-md pf-v5-u-mt-md">
+      <Content className="pf-v6-u-mb-md pf-v6-u-mt-md">
         <Content component="p">
           This is a read-only view of the full set of rules and their
           description for

--- a/src/SmartComponents/ReportDetails/Components/ReportChart.js
+++ b/src/SmartComponents/ReportDetails/Components/ReportChart.js
@@ -17,7 +17,7 @@ const ReportChart = ({ report = {}, hasLegend = true, chartClass }) => {
       {hasLegend ? (
         <GridItem
           span={6}
-          className="pf-v5-u-display-flex pf-v5-u-align-items-center"
+          className="pf-v6-u-display-flex pf-v6-u-align-items-center"
           style={{
             fontSize: '.85em',
             height: '100%',

--- a/src/SmartComponents/ReportDetails/Components/TabTitleWithData.js
+++ b/src/SmartComponents/ReportDetails/Components/TabTitleWithData.js
@@ -4,12 +4,12 @@ import propTypes from 'prop-types';
 
 const TabTitleWithData = ({ text, data, isLoading, color }) => (
   <TabTitleText>
-    <span className="pf-v5-u-mr-sm">{text}</span>
+    <span className="pf-v6-u-mr-sm">{text}</span>
     {isLoading ? (
       <Spinner size="md" />
     ) : data ? (
       <Label color={color} isCompact>
-        {data}
+        {data} Systems
       </Label>
     ) : (
       <></>

--- a/src/SmartComponents/ReportDetails/Components/__snapshots__/ReportChart.test.js.snap
+++ b/src/SmartComponents/ReportDetails/Components/__snapshots__/ReportChart.test.js.snap
@@ -32,7 +32,7 @@ exports[`ReportChart expect to render with 0 unsupported & 0 never reported host
               d="M-89.99477384980764,-30.429273401150716A95,95,0,0,1,-1.1300442297705369,-94.99327870980537L-1.1300442297705169,-87.99274401925855A88,88,0,0,0,-83.3368697148128,-28.265989212060408Z"
               role="presentation"
               shape-rendering="auto"
-              style="fill: #92c5f9; padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+              style="fill: #9e4a06; padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
               transform="translate(115, 115)"
             />
             <path
@@ -89,7 +89,7 @@ exports[`ReportChart expect to render with 0 unsupported & 0 never reported host
       </div>
     </div>
     <div
-      class="pf-v6-l-grid__item pf-m-6-col pf-v5-u-display-flex pf-v5-u-align-items-center"
+      class="pf-v6-l-grid__item pf-m-6-col pf-v6-u-display-flex pf-v6-u-align-items-center"
       style="font-size: 0.85em; height: 100%;"
     >
       <ul
@@ -122,7 +122,7 @@ exports[`ReportChart expect to render with 0 unsupported & 0 never reported host
             class="pf-v6-c-list__item-icon"
           >
             <span
-              style="width: 10px; height: 10px; display: inline-block; background: rgb(146, 197, 249);"
+              style="width: 10px; height: 10px; display: inline-block; background: rgb(158, 74, 6);"
             >
                
             </span>
@@ -171,7 +171,7 @@ exports[`ReportChart expect to render with 2 unsupported & 3 never reported host
               d="M54.921423306252464,77.51540016032574A95,95,0,0,1,1.130044229770525,94.99327870980537L1.1300442297705258,87.99274401925855A88,88,0,0,0,50.806612256987194,71.851848625962Z"
               role="presentation"
               shape-rendering="auto"
-              style="fill: #92c5f9; padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+              style="fill: #9e4a06; padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
               transform="translate(115, 115)"
             />
             <path
@@ -228,7 +228,7 @@ exports[`ReportChart expect to render with 2 unsupported & 3 never reported host
       </div>
     </div>
     <div
-      class="pf-v6-l-grid__item pf-m-6-col pf-v5-u-display-flex pf-v5-u-align-items-center"
+      class="pf-v6-l-grid__item pf-m-6-col pf-v6-u-display-flex pf-v6-u-align-items-center"
       style="font-size: 0.85em; height: 100%;"
     >
       <ul
@@ -261,7 +261,7 @@ exports[`ReportChart expect to render with 2 unsupported & 3 never reported host
             class="pf-v6-c-list__item-icon"
           >
             <span
-              style="width: 10px; height: 10px; display: inline-block; background: rgb(146, 197, 249);"
+              style="width: 10px; height: 10px; display: inline-block; background: rgb(158, 74, 6);"
             >
                
             </span>
@@ -463,7 +463,7 @@ exports[`ReportChart expect to render without error with zero counts 1`] = `
       </div>
     </div>
     <div
-      class="pf-v6-l-grid__item pf-m-6-col pf-v5-u-display-flex pf-v5-u-align-items-center"
+      class="pf-v6-l-grid__item pf-m-6-col pf-v6-u-display-flex pf-v6-u-align-items-center"
       style="font-size: 0.85em; height: 100%;"
     >
       <ul
@@ -496,7 +496,7 @@ exports[`ReportChart expect to render without error with zero counts 1`] = `
             class="pf-v6-c-list__item-icon"
           >
             <span
-              style="width: 10px; height: 10px; display: inline-block; background: rgb(146, 197, 249);"
+              style="width: 10px; height: 10px; display: inline-block; background: rgb(158, 74, 6);"
             >
                
             </span>

--- a/src/SmartComponents/ReportDetails/Components/hooks/useDonutChart.js
+++ b/src/SmartComponents/ReportDetails/Components/hooks/useDonutChart.js
@@ -66,7 +66,7 @@ const useDonutChart = (report) => {
     paletteColors.black100,
   ]) || [
     paletteColors.blue300,
-    paletteColors.blue100,
+    paletteColors.orange400,
     paletteColors.gold300,
     paletteColors.black200,
   ];

--- a/src/SmartComponents/ReportDetails/Components/hooks/useLegendData.js
+++ b/src/SmartComponents/ReportDetails/Components/hooks/useLegendData.js
@@ -27,7 +27,7 @@ const useLegendData = (donutValues) => {
     },
     {
       name: `${pluralize(nonCompliantSystemCount, 'system')} non-compliant`,
-      symbol: { fill: paletteColors.blue100 },
+      symbol: { fill: paletteColors.orange400 },
     },
     ...(unsupportedSystemCount > 0
       ? [

--- a/src/SmartComponents/ReportDetails/ReportDetails.scss
+++ b/src/SmartComponents/ReportDetails/ReportDetails.scss
@@ -1,11 +1,3 @@
-.threshold-tooltip {
-    margin-bottom: var(--pf-v5-global--spacer--md);
-}
-
-.grey-icon {
-    color: var(--pf-v5-global--Color--200);
-}
-
 .policy-details{
     padding-top: 10px;
 }

--- a/src/SmartComponents/SystemDetails/Cells.js
+++ b/src/SmartComponents/SystemDetails/Cells.js
@@ -50,13 +50,19 @@ Rule.propTypes = ruleResultProps;
 
 export const Passed = ({ result }) =>
   result === 'pass' ? (
-    <Icon status="success">
-      <CheckCircleIcon className="ins-u-passed" />
-    </Icon>
+    <div>
+      <Icon status="success" className="pf-v6-u-mr-xs">
+        <CheckCircleIcon />
+      </Icon>
+      Passed
+    </div>
   ) : (
-    <Icon status="danger">
-      <ExclamationCircleIcon className="ins-u-failed" />
-    </Icon>
+    <div>
+      <Icon status="danger" className="pf-v6-u-mr-xs">
+        <ExclamationCircleIcon />
+      </Icon>
+      Failed
+    </div>
   );
 Passed.propTypes = ruleResultProps;
 

--- a/src/SmartComponents/SystemDetails/NoReportsState.js
+++ b/src/SmartComponents/SystemDetails/NoReportsState.js
@@ -14,8 +14,8 @@ const NoReportsState = ({ policiesCount }) => {
         icon={CloudSecurityIcon}
         titleText="No results reported"
         style={{
-          '--pf-v5-c-empty-state__icon--FontSize':
-            'var(--pf-v5-c-empty-state--m-xl__icon--FontSize)',
+          '--pf-v6-c-empty-state__icon--FontSize':
+            'var(--pf-v6-c-empty-state--m-xl__icon--FontSize)',
         }}
       >
         <EmptyStateBody>{bodyTextMain}</EmptyStateBody>

--- a/src/SmartComponents/SystemDetails/compliance.scss
+++ b/src/SmartComponents/SystemDetails/compliance.scss
@@ -4,65 +4,24 @@
     }
 
     .ins-c-policy-card {
-        font-size: var(--pf-v5-global--FontSize--lg);
+        font-size: var(--pf-v6-global--FontSize--lg);
     }
 
     .ins-c-policy-card.ins-m-compliant,
     .ins-c-policy-card.ins-m-noncompliant {
-      font-size: var(--pf-v5-global--FontSize--sm);
+      font-size: var(--pf-v6-global--FontSize--sm);
       font-weight: bold;
     }
 
     .ins-c-policy-card.ins-m-compliant {
-        color: var(--pf-v5-global--success-color--200);
+        color: var(--pf-t--global--icon--color--status--success--default);
     }
 
     .ins-c-policy-card.ins-m-noncompliant {
-        color: var(--pf-v5-global--danger-color--100);
+        color: var(--pf-t--global--color--status--danger--default);
     }
 
     .ins-c-compliance-system-rule-check {
-        color: var(--pf-v5-global--success-color--200)
-    }
-
-    .margin-bottom, %margin-bottom {
-        &-none {
-            margin-bottom: 0;
-        }
-
-        &-sm {
-            margin-bottom: var(--pf-v5-global--spacer--sm);
-        }
-
-        &-md {
-            margin-bottom: var(--pf-v5-global--spacer--md);
-        }
-
-        &-lg {
-            margin-bottom: var(--pf-v5-global--spacer--lg);
-        }
-    }
-
-    .margin-top, %margin-top {
-        &-none {
-            margin-top: 0;
-        }
-
-        &-lg {
-            margin-top: var(--pf-v5-global--spacer--lg);
-        }
-    }
-
-    .margin-bottom-top-none {
-        @extend %margin-top-none;
-        @extend %margin-bottom-none;
-    }
-
-    .wrap-break-word {
-        overflow-wrap: break-word;
-    }
-
-    .compliance-rules-table td[data-label=Severity] {
-        text-transform: capitalize;
+        color: var(--pf-t--global--icon--color--status--success--default)
     }
 }

--- a/src/SmartComponents/SystemsTable/Filters.js
+++ b/src/SmartComponents/SystemsTable/Filters.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { coerce, valid } from 'semver';
 import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  QuestionCircleIcon,
-} from '@patternfly/react-icons';
+  HighSeverity,
+  MediumSeverity,
+  LowSeverity,
+  UnknownSeverity,
+} from '../../PresentationalComponents/RulesTable/components/SeverityIcons';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 
 export const name = {
@@ -36,7 +37,7 @@ export const ssgVersions = (ssgVersions) => ({
 
 export const compliant = {
   type: conditionalFilterType.checkbox,
-  label: 'Compliance',
+  label: 'Compliant status',
   filterSerialiser: (_filterConfig, values) =>
     values
       .map((value) => {
@@ -79,48 +80,6 @@ export const complianceScore = {
     { label: 'Less than 50%', value: '0-50' },
   ],
 };
-
-// TODO These should be in some component folder
-const HighSeverity = () => (
-  <>
-    <ExclamationCircleIcon className="ins-u-failed" /> High
-  </>
-);
-
-const MediumSeverity = () => (
-  <>
-    <ExclamationTriangleIcon className="ins-u-warning" /> Medium
-  </>
-);
-
-const LowSeverityIcon = () => (
-  <svg
-    width="1em"
-    height="1em"
-    viewBox="0 0 18 18"
-    role="img"
-    style={{ verticalAlign: '-0.125em' }}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M2 0h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2zm6.67 10.46a1.67 1.67 0 1 0 0 3.338 1.67 1.67 0 0 0 0-3.338zm-1.586-6l.27 4.935a.435.435 0 0 0 .434.411H9.55c.232 0 .422-.18.435-.411l.27-4.936A.435.435 0 0 0 9.818 4h-2.3c-.25 0-.448.21-.435.46z"
-      fill="#3A9CA6"
-      fillRule="evenodd"
-    />
-  </svg>
-);
-
-const LowSeverity = () => (
-  <>
-    <LowSeverityIcon /> Low
-  </>
-);
-
-const UnknownSeverity = () => (
-  <>
-    <QuestionCircleIcon /> Unknown
-  </>
-);
 
 export const severity = {
   type: conditionalFilterType.checkbox,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,12 +1,9 @@
 /* eslint max-len: 0 */
-import packageJson from './../package.json';
-
 export const APP_ID = 'compliance';
 export const DEFAULT_TITLE = 'Compliance';
 
 export const API_BASE_URL = '/api/compliance/v2';
 export const KESSEL_API_BASE_URL = '/api/kessel/v1beta2';
-export const RBAC_API_BASE_V2 = '/api/rbac/v2';
 
 export const SEVERITY_LEVELS = ['high', 'medium', 'low', 'unknown'];
 
@@ -16,15 +13,9 @@ import {
   chart_color_black_100,
   chart_color_black_200,
   chart_color_yellow_300,
-  chart_color_blue_100,
+  chart_color_orange_400,
   chart_color_blue_300,
 } from '@patternfly/react-tokens';
-
-export const API_HEADERS = {
-  'X-Insights-Compliance': packageJson.version,
-  'Content-Type': 'application/json',
-  Accept: 'application/json',
-};
 
 export const supportedConfigsLink =
   'https://access.redhat.com/articles/6644131';
@@ -32,13 +23,9 @@ export const supportedConfigsLink =
 export const paletteColors = {
   black100: chart_color_black_100.value,
   black200: chart_color_black_200.value,
-  blue100: chart_color_blue_100.value,
+  orange400: chart_color_orange_400.value,
   blue300: chart_color_blue_300.value,
   gold300: chart_color_yellow_300.value,
-};
-
-export const backgroundColors = {
-  light300: '#f0f0f0', //'--pf-global--BackgroundColor--light-300',
 };
 
 export const unsupportedSystemWarningMessage =


### PR DESCRIPTION
## What & How to test:

**feel free to use `comp-user-3`** account that has compliance data

1. **Navigate to Report details page**

- check if tab labels have now `X Systems` instead of just `X` https://redhat.atlassian.net/browse/RHINENG-24055

<img width="830" height="248" alt="Screenshot 2026-04-13 at 11 32 18" src="https://github.com/user-attachments/assets/3579e0ae-e146-4f90-9263-5be5d56fc222" />

- Check if Non-compliant systems have new red color now in legend and donut https://redhat.atlassian.net/browse/RHINENG-24093

<img width="833" height="383" alt="Screenshot 2026-04-13 at 11 33 36" src="https://github.com/user-attachments/assets/c4562321-bc3a-47b5-9983-4c5db173d3a0" />

- Check if table filter uses `Compliance status` instead of `Compliance`,  same as table column name https://redhat.atlassian.net/browse/RHINENG-24127

- Open table filters and check filter `Failed rule severity`, there should be new colored icons like in [mocks](https://www.figma.com/design/r97CXZ3uUrw06Lhr0WitHl/Compliance-Mockups-v2?node-id=1218-646&t=V5R78U66ooQdOwcQ-0)  https://redhat.atlassian.net/browse/RHINENG-24128

2. Navigate to "Reports" and check if Page header tooltip has blue external link icon (screenshot shows old style) https://redhat.atlassian.net/browse/RHINENG-24129
<img width="620" height="237" alt="Screenshot 2026-04-13 at 11 42 43" src="https://github.com/user-attachments/assets/ef409ed7-b495-4eab-88ae-a04e50d373b0" />

3. Navigate to policy details Systems page, click on Edit systems and select a system with a new minor version - observe alert on top of the table instead of bottom (screenshot has old bottom alert) https://redhat.atlassian.net/browse/RHINENG-24138
<img width="1076" height="425" alt="Screenshot 2026-04-13 at 11 46 27" src="https://github.com/user-attachments/assets/f3f565a3-29bf-4da6-954b-d25ef4d11406" />

4. Navigate to SCAP Policies page, click on Kebab for one of rows and see that button order starts with Edit policy and then Delete policy https://redhat.atlassian.net/browse/RHINENG-24147

5. Go to Policies page and start policy creation, select whatever you want and when you click submit/create observe `We’re setting up your SCAP policy. Stay on this page until the process is complete.` message when policy is creating https://redhat.atlassian.net/browse/RHINENG-24151

6. Go to policy details page Rules tab 

- see that filter has consistent name with table column `Remediation type` https://redhat.atlassian.net/browse/RHINENG-24163
- Check severity icons - they should be new https://redhat.atlassian.net/browse/RHINENG-24174

7. Navigate to System details (system has to be reported) and see that `Rule status` column has not only icons but also text `Failed`/`Success` https://redhat.atlassian.net/browse/RHINENG-24166

8. Navigate to Polict details Details tab and see that policy description is wrapped nicely ( it takes 1/3 of container) https://redhat.atlassian.net/browse/RHINENG-24162





## Closes
https://redhat.atlassian.net/browse/RHINENG-24055
https://redhat.atlassian.net/browse/RHINENG-24061
https://redhat.atlassian.net/browse/RHINENG-24093
https://redhat.atlassian.net/browse/RHINENG-24127
https://redhat.atlassian.net/browse/RHINENG-24128
https://redhat.atlassian.net/browse/RHINENG-24129
https://redhat.atlassian.net/browse/RHINENG-24138
https://redhat.atlassian.net/browse/RHINENG-24147
https://redhat.atlassian.net/browse/RHINENG-24151
https://redhat.atlassian.net/browse/RHINENG-24163
https://redhat.atlassian.net/browse/RHINENG-24166
https://redhat.atlassian.net/browse/RHINENG-24171
https://redhat.atlassian.net/browse/RHINENG-24174
https://redhat.atlassian.net/browse/RHINENG-24162

## Summary by Sourcery

Align compliance UI with updated design guidance and PatternFly v6 tokens, improving clarity of severity/status indicators, wording, and external links across reports, policies, systems, and creation flows.

New Features:
- Add explicit Passed/Failed text labels alongside status icons in rules and system details tables.
- Display system counts in report detail tabs using labeled chips (e.g., "X Systems").

Bug Fixes:
- Correct various labels and wording in filters and tooltips, including compliance status and remediation type naming, and the policy creation progress message.
- Fix policy action menu ordering so Edit appears before Delete in the SCAP policies kebab menu.

Enhancements:
- Update severity icons and colors to use PatternFly severity tokens and share them across rules and systems filters.
- Refresh donut chart and legend colors, especially for non-compliant systems, to match the latest visual spec.
- Adjust policy description layout and wrapping on the policy details page for better readability.
- Standardize external help/configuration links to use InsightsLink with external-link icons and update related tests.
- Migrate multiple components from PatternFly v5 to v6 spacing, color, and background tokens and remove obsolete utility styles.

Build:
- Bump @redhat-cloud-services/frontend-components dependency to a newer minor version.

Tests:
- Adapt CompliancePageHeader tests to render within a router context to support the new Link-based implementation.