### PR TITLE
fix(RHINENG-25467): avoid wizard refresh on url hash update

### DIFF
--- a/src/SmartComponents/CreatePolicyDDF/CreatePolicyWizard.js
+++ b/src/SmartComponents/CreatePolicyDDF/CreatePolicyWizard.js
@@ -6,6 +6,10 @@ import useNavigate from '@redhat-cloud-services/frontend-components-utilities/us
 import schema from './schema';
 import componentMapper from './componentMapper';
 
+const CreatePolicyFormTemplate = (props) => (
+  <FormTemplate {...props} showFormControls={false} />
+);
+
 const CreatePolicyWizard = () => {
   const navigate = useNavigate();
 
@@ -17,9 +21,7 @@ const CreatePolicyWizard = () => {
     <FormRenderer
       schema={schema}
       componentMapper={componentMapper}
-      FormTemplate={(props) => (
-        <FormTemplate {...props} showFormControls={false} />
-      )}
+      FormTemplate={CreatePolicyFormTemplate}
       onCancel={handleCancel}
     />
   );


### PR DESCRIPTION
Fix will prevent wizard re-render when you switch between tabs on Rules step. Fix is for wizard that uses data driven forms - so it means that to test this ensure that https://insights-stage.unleash.devshift.net/projects/default/features/compliance.data-driven-forms flag is turned on

### How to test:

1. Open create policy wizard
2. Choose any profile on step 1 that has more than 1 supported minor version
3. Proceed to systems step
4. Select 2 systems but with different minor version
5. Proceed to rules step - here you should see 2 tabs
6. Try to switch between tabs and see that wizard is not jumping back on step 1


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Prevent unnecessary re-renders of the create policy data-driven-forms wizard when switching rule tabs by stabilizing the custom form template component reference.

Bug Fixes:
- Avoid the wizard jumping back to the first step when switching tabs on the Rules step in the data-driven-forms-based create policy wizard.

Enhancements:
- Extract the custom form template into a named component to provide a stable FormTemplate reference for the form renderer.