### PR TITLE
feat(RHINENG-24160): unwrap text in Compliance wizard table

### DIFF
--- a/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
+++ b/src/SmartComponents/CreatePolicy/ReviewCreatedPolicy.js
@@ -16,10 +16,16 @@ const ReviewCreatedPolicy = ({
     <Content component={ContentVariants.h1}>Review</Content>
     <Content component="p">Review your SCAP policy before finishing.</Content>
     <Content component={ContentVariants.h3}>{name}</Content>
-    <Content component={ContentVariants.dl} className="pf-u-mt-md">
+    <Content
+      component={ContentVariants.dl}
+      className="pf-u-mt-md"
+      style={{ gridTemplateColumns: 'auto 1fr' }}
+    >
       <Content component={ContentVariants.dt}>Policy type</Content>
       <Content component={ContentVariants.dd}>{parentProfileName}</Content>
-      <Content component={ContentVariants.dt}>Compliance threshold</Content>
+      <Content component={ContentVariants.dt} className="pf-v6-u-text-nowrap">
+        Compliance threshold
+      </Content>
       <Content component={ContentVariants.dd}>{complianceThreshold}%</Content>
       {businessObjective && (
         <React.Fragment>

--- a/src/SmartComponents/CreatePolicyDDF/components/ReviewStep.js
+++ b/src/SmartComponents/CreatePolicyDDF/components/ReviewStep.js
@@ -15,11 +15,17 @@ const ReviewStep = () => {
       <Content component={ContentVariants.h1}>Review</Content>
       <Content component="p">Review your SCAP policy before finishing.</Content>
       <Content component={ContentVariants.h3}>{values.name}</Content>
-      <Content component={ContentVariants.dl} className="pf-u-mt-md">
+      <Content
+        component={ContentVariants.dl}
+        className="pf-u-mt-md"
+        style={{ gridTemplateColumns: 'auto 1fr' }}
+      >
         <Content component={ContentVariants.dt}>Policy type</Content>
         <Content component={ContentVariants.dd}>{profile?.title}</Content>
 
-        <Content component={ContentVariants.dt}>Compliance threshold</Content>
+        <Content component={ContentVariants.dt} className="pf-v6-u-text-nowrap">
+          Compliance threshold
+        </Content>
         <Content component={ContentVariants.dd}>
           {values.complianceThreshold || 100}%
         </Content>


### PR DESCRIPTION
Based on the UX review we want to display the column in the last step of the compliance creation wizard without unnecessary text wrapping.

How to test:
1. set up local environment according to readme in https://github.com/RedHatInsights/compliance-frontend
2. navigate to Create new policy modal
3. click through to the last step
4. Compliance threshold text should be in one line and the table should be adjusted accordingly

Closes https://redhat.atlassian.net/browse/RHINENG-24160

## Summary by Sourcery

Enhancements:
- Prevent text wrapping of the Compliance threshold label in the final review step of the policy creation wizard by updating its layout styling.