### PR TITLE
chore: add APIKeyDev to analytics in deploy config

### DIFF
--- a/deployment_template.yaml
+++ b/deployment_template.yaml
@@ -87,7 +87,8 @@ objects:
       module:
         manifestLocation: /apps/compliance/fed-mods.json
         analytics:
-          APIKey: "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+          APIKey: apRCg9V6oMXCcnTingqRYW6m1er4hkCW
+          APIKeyDev: aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg
         config:
           supportCaseData:
             product: Red Hat Insights


### PR DESCRIPTION
## Summary
- Adds missing `APIKeyDev` to the `analytics` block in `deployment_template.yaml`
- Aligns with the pattern used by other frontends (inventory, advisor, tasks, ocp-advisor)

## Test plan
- [ ] Verify the YAML is valid and the deploy CRD parses correctly
- [ ] Confirm analytics events are sent in stage with the correct API key

## Summary by Sourcery

Build:
- Update deployment_template.yaml to include APIKeyDev in the analytics configuration and align formatting of APIKey value.