### PR TITLE
fix(SystemsTable): use group_id to filter workspaces

### DIFF
--- a/src/SmartComponents/SystemsTable/Filters.js
+++ b/src/SmartComponents/SystemsTable/Filters.js
@@ -136,7 +136,7 @@ export const group = {
       hostGroupFilter.length > 0
     ) {
       return `(${hostGroupFilter
-        .map((value) => `group_name = "${value}"`)
+        .map((value) => `group_id = "${value}"`)
         .join(' or ')})`;
     }
   },


### PR DESCRIPTION
Can be checked/merged after https://github.com/RedHatInsights/compliance-backend/pull/2743

Navigate to any compliance page that has system table and filter by workspaces.
For example, use Compliance Systems page, try to filter systems by workspace and see it works. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Fix workspace filtering by switching the host group filter from matching on group_name to matching on group_id.

## Summary by Sourcery

Bug Fixes:
- Correct workspace filtering by switching the host group filter condition from group name to group ID.