### PR TITLE
feat(RHINENG-24130): add selected systems tab

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -1,8 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Content } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import SystemsTable from 'SmartComponents/SystemsTable/SystemsTable';
 import * as Columns from 'SmartComponents/SystemsTable/Columns';
+import SystemsViewToggle, { SYSTEMS_VIEW } from './SystemsViewToggle';
 
 const systemTableColumns = [
   Columns.Name,
@@ -54,7 +55,9 @@ const EditPolicySystemsTab = ({
   supportedOsVersions,
   setIsSystemsDataLoading,
 }) => {
-  const { os_major_version } = policy;
+  const { id: policyId, os_major_version } = policy;
+  const [systemsView, setSystemsView] = useState(SYSTEMS_VIEW.ALL);
+  const isAllSystemsView = systemsView === SYSTEMS_VIEW.ALL;
 
   const defaultFilter = useMemo(
     () =>
@@ -67,16 +70,29 @@ const EditPolicySystemsTab = ({
 
   return (
     <SystemsTable
-      apiEndpoint="systems"
+      key={systemsView}
+      apiEndpoint={isAllSystemsView ? 'systems' : 'policySystems'}
+      policyId={isAllSystemsView ? undefined : policyId}
       columns={systemTableColumns}
       prependComponent={<PrependComponent osMajorVersion={os_major_version} />}
-      emptyStateComponent={<EmptyState osMajorVersion={os_major_version} />}
+      emptyStateComponent={
+        isAllSystemsView ? (
+          <EmptyState osMajorVersion={os_major_version} />
+        ) : undefined
+      }
       compact
-      defaultFilter={defaultFilter}
+      defaultFilter={isAllSystemsView ? defaultFilter : undefined}
+      ignoreOsMajorVersion={!isAllSystemsView}
       preselectedSystems={selectedSystems}
       onSelect={onSystemSelect}
       setIsSystemsDataLoading={setIsSystemsDataLoading}
       enableExport={false}
+      dedicatedAction={
+        <SystemsViewToggle
+          systemsView={systemsView}
+          onSystemsViewChange={setSystemsView}
+        />
+      }
     />
   );
 };

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SystemsTable from 'SmartComponents/SystemsTable/SystemsTable';
 
@@ -9,21 +9,47 @@ import EditPolicySystemsTab from './EditPolicySystemsTab';
 
 describe('EditPolicySystemsTab', () => {
   const defaultProps = {
-    policy: { os_major_version: 8 },
+    policy: { id: 'test-policy-id', os_major_version: 8 },
     onSystemSelect: jest.fn(),
     selectedSystems: ['test-system-1', 'test-system-2'],
     supportedOsVersions: [1, 2],
   };
-  const mockSystemsTable = jest.fn(() => <div>Mock Systems Table</div>);
+  const mockSystemsTable = jest.fn(({ dedicatedAction }) => (
+    <div>
+      Mock Systems Table
+      {dedicatedAction}
+    </div>
+  ));
 
-  it('should render a SystemsTable with a default filter', () => {
+  beforeEach(() => {
+    mockSystemsTable.mockClear();
     SystemsTable.mockImplementation(mockSystemsTable);
+  });
+
+  it('should render a SystemsTable with a default filter for all systems', () => {
     render(<EditPolicySystemsTab {...defaultProps} />);
 
     expect(mockSystemsTable).toHaveBeenCalledWith(
       expect.objectContaining({
         apiEndpoint: 'systems',
         defaultFilter: 'os_major_version = 8 AND os_minor_version ^ (1 2)',
+        policyId: undefined,
+      }),
+      {},
+    );
+  });
+
+  it('should switch to policy systems when selected systems is chosen', () => {
+    render(<EditPolicySystemsTab {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Selected systems'));
+
+    expect(mockSystemsTable).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        apiEndpoint: 'policySystems',
+        policyId: 'test-policy-id',
+        defaultFilter: undefined,
+        ignoreOsMajorVersion: true,
       }),
       {},
     );

--- a/src/SmartComponents/EditPolicy/SystemsViewToggle.js
+++ b/src/SmartComponents/EditPolicy/SystemsViewToggle.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+
+export const SYSTEMS_VIEW = {
+  ALL: 'all',
+  SELECTED: 'selected',
+};
+
+const SystemsViewToggle = ({ systemsView, onSystemsViewChange }) => (
+  <ToggleGroup aria-label="Systems list view" className="pf-v6-u-ml-md">
+    <ToggleGroupItem
+      text="All systems"
+      isSelected={systemsView === SYSTEMS_VIEW.ALL}
+      onChange={() => onSystemsViewChange(SYSTEMS_VIEW.ALL)}
+      ouiaId="EditPolicySystemsViewAll"
+    />
+    <ToggleGroupItem
+      text="Selected systems"
+      isSelected={systemsView === SYSTEMS_VIEW.SELECTED}
+      onChange={() => onSystemsViewChange(SYSTEMS_VIEW.SELECTED)}
+      ouiaId="EditPolicySystemsViewSelected"
+    />
+  </ToggleGroup>
+);
+
+SystemsViewToggle.propTypes = {
+  systemsView: PropTypes.oneOf([SYSTEMS_VIEW.ALL, SYSTEMS_VIEW.SELECTED])
+    .isRequired,
+  onSystemsViewChange: PropTypes.func.isRequired,
+};
+
+export default SystemsViewToggle;


### PR DESCRIPTION
**upd:** change is approved by UX

Currently we are able to show two systems tabs:
1. All systems - that will show already associated systems + systems that can be associated
2. Selected systems - this tab will show systems that are already associated to policy. If you unselect system there - it will stay in the table until you click on save policy.

<img width="973" height="568" alt="Screenshot 2026-05-28 at 9 51 39" src="https://github.com/user-attachments/assets/56886e12-7c3c-403b-a5b9-54faef1ba6c2" />

<img width="973" height="568" alt="Screenshot 2026-05-28 at 9 51 46" src="https://github.com/user-attachments/assets/0b502049-2c15-4476-8b13-4941b0416d3a" />



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add a toggleable view in the Edit Policy systems tab to switch between all systems and systems associated with the current policy.

New Features:
- Introduce a systems view toggle component to switch between viewing all systems and only selected (policy-associated) systems in the Edit Policy page.

Enhancements:
- Adjust the systems table configuration to use different API endpoints, filters, and empty states depending on the selected systems view.

Tests:
- Extend EditPolicySystemsTab tests to cover the new systems view toggle behavior and policy systems API usage.

## Summary by Sourcery

Add a toggle in the Edit Policy systems tab to switch between viewing all systems and only systems associated with the current policy.

New Features:
- Introduce a SystemsViewToggle component to switch between all systems and selected (policy-associated) systems in the Edit Policy view.

Enhancements:
- Update EditPolicySystemsTab to use different APIs, filters, and empty states depending on the selected systems view.

Tests:
- Extend EditPolicySystemsTab tests to cover the new systems view toggle and policy systems API usage.