### PR TITLE
feat(RHINENG-24169): change wrapping of Last Seen column

### DIFF
--- a/src/SmartComponents/SystemsTable/Columns.js
+++ b/src/SmartComponents/SystemsTable/Columns.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { nowrap } from '@patternfly/react-table';
 import { Tooltip } from '@patternfly/react-core';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { complianceScoreString } from 'PresentationalComponents';
 import { renderComponent } from 'Utilities/helpers';
 
@@ -178,6 +179,11 @@ export const Updated = inventoryColumn('updated', {
   title: 'Last seen',
   props: { isStatic: true },
   transforms: [nowrap],
+  renderFunc: (value) => (
+    <span className="pf-v6-u-text-nowrap">
+      <DateFormat date={value} />
+    </span>
+  ),
   renderExport: ({ updated }) => updated,
 });
 


### PR DESCRIPTION
Based on the UX review we want to change the wrapping of the Last seen column in the Systems table.

How to test:

1. Have insights-chrome and insert into webpack config
```
'/apps/compliance': {
  host: 'http://localhost:8004/',
},
'/apps/inventory': {
  host: 'http://localhost:8005/',
}, 
```
2. Run insights-chrome with `npm run dev`
3. Run insights-inventory-frontend with `npm run static -- -p=8005`
4. Checkout to this PR and run `npm run static -- -p=8004`
5. Navigate to Compliance -> Systems
6. The entries in the Last seen column should not wrap lines

## Summary by Sourcery

Enhancements:
- Ensure the Systems table "Last seen" column uses a non-wrapping layout for its date content.