### PR TITLE
feat(RHINENG-24168): remove download button from Edit Policy Systems tab

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -76,6 +76,7 @@ const EditPolicySystemsTab = ({
       preselectedSystems={selectedSystems}
       onSelect={onSystemSelect}
       setIsSystemsDataLoading={setIsSystemsDataLoading}
+      enableExport={false}
     />
   );
 };


### PR DESCRIPTION
The download CSV/JSON dropdown in Edit policy modal > Systems tab is redundant since it already exists on the systems page.

## How to test:

1. Have insights-chrome and insert into webpack config
```
'/apps/compliance': {
  host: 'http://localhost:8004/',
},
'/apps/inventory': {
  host: 'http://localhost:8005/',
}, 
```
2. Run insights-chrome with `npm run dev`
3. Run insights-inventory-frontend with `npm run static -- -p=8005`
4. Checkout to this PR and run `npm run static -- -p=8004`
5. Navigate to Compliance -> Reports
6. Click on any policy to view its details
7. Click "Edit policy" button
8. Navigate to the "Systems" tab
9. Verify that the download CSV/JSON button is no longer present

## Summary

- Disabled the export functionality in the Edit Policy modal's Systems tab by passing `enableExport={false}` to the SystemsTable component
- The download functionality remains available on the main systems page

## Summary by Sourcery

Enhancements:
- Disable the systems table export dropdown in the Edit Policy modal Systems tab by passing the appropriate flag.