### PR TITLE
fix(RHINENG-24156): fix styling policy description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@tanstack/react-query": "^5.90.5",
         "@unleash/proxy-client-react": "^3.6.0",
         "axios": "^1.15.1",
-        "bastilian-tabletools": "^2.20.1",
+        "bastilian-tabletools": "^2.22.0",
         "linkify-html": "^4.3.2",
         "linkifyjs": "^4.3.2",
         "node-forge": "^1.4.0",
@@ -10523,9 +10523,9 @@
       "license": "MIT"
     },
     "node_modules/bastilian-tabletools": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.20.1.tgz",
-      "integrity": "sha512-beiMERLcaqzPMx5gT976LKRGFxmzah/7YCfsy6mqullZQoBbbaLr8M6QiOM9nUTIqC93bueyhk1EuszCR04erw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.22.0.tgz",
+      "integrity": "sha512-jDaEZmdMGk6mFJX9kXnPaXvT2240/U7TEZH9V6VsMO9wL6MasIq+5zrLXSpzdjArzA7PRuUtCTLl3p3GC+7L6A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@tanstack/react-query": "^5.90.5",
     "@unleash/proxy-client-react": "^3.6.0",
     "axios": "^1.15.1",
-    "bastilian-tabletools": "^2.20.1",
+    "bastilian-tabletools": "^2.22.0",
     "linkify-html": "^4.3.2",
     "linkifyjs": "^4.3.2",
     "node-forge": "^1.4.0",

--- a/src/PresentationalComponents/PolicyTypesTable/PolicyTypeTable.js
+++ b/src/PresentationalComponents/PolicyTypesTable/PolicyTypeTable.js
@@ -51,6 +51,9 @@ const PolicyTypeTable = ({
       columns={columns}
       options={{
         detailsComponent: PolicyTypeDetailsRow,
+        detailsProps: {
+          fullWidth: true,
+        },
         onRadioSelect: (_event, _value, _rowIdx, { item: { itemId } }) =>
           onChange && onChange(profiles.find(({ id }) => id === itemId)),
         emptyRows: emptyRows('policy types', columns.length),


### PR DESCRIPTION
Fix for policy type table description styling - reducing space.

### Before:
<img width="1848" height="1261" alt="image" src="https://github.com/user-attachments/assets/f1449b4d-b419-4f65-8b59-9d0de2814eff" />

### After:
<img width="1694" height="1148" alt="image" src="https://github.com/user-attachments/assets/55e9d103-f87d-4b38-9ef4-b938f0405263" />

## Summary by Sourcery

Adjust policy type table layout to render details rows in full width and align styling with the updated table tools dependency.

Enhancements:
- Enable full-width rendering for policy type details rows in the policy types table component.
- Update the bastilian-tabletools dependency to version ^2.22.0 to pick up layout and styling improvements.