### PR TITLE
fix(RHINENG-24715): correct create policy permissions

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -75,7 +75,11 @@ const policiesRoutes = [
   {
     path: 'scappolicies/new',
     title: defaultPoliciesTitle,
-    requiredPermissions: [...defaultPermissions, 'compliance:policy:create'],
+    requiredPermissions: [
+      ...defaultPermissions,
+      'compliance:policy:create',
+      'compliance:policy:write',
+    ],
     component: lazy(
       () =>
         import(

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -64,8 +64,8 @@ const CompliancePoliciesContent = ({ usePermissionsHook }) => {
   const createPolicyButton = (
     <LinkWithPermission
       {...createPolicyLinkProps}
-      hasAccess={createPermission.hasAccess}
-      isLoading={createPermission.isLoading}
+      hasAccess={createPermission.hasAccess && editPermission.hasAccess}
+      isLoading={createPermission.isLoading || editPermission.isLoading}
     >
       Create new policy
     </LinkWithPermission>


### PR DESCRIPTION
How to test:

1. Use `comp-user-3-non-admin` user which has pre-configured permissions for policy create only
2. Navigte to Policies or Reports page and see that button is disabled

### Before
Policy create button is enabled but creation will fail if write permission is missing
<img width="1134" height="738" alt="Screenshot 2026-06-10 at 10 54 20" src="https://github.com/user-attachments/assets/c95af76f-3318-41b4-ab44-08be56b7c19f" />


### After
Button is disabled until user has create & write permissions
<img width="1134" height="738" alt="Screenshot 2026-06-10 at 10 55 32" src="https://github.com/user-attachments/assets/a56d8792-5446-45be-a0f4-188e1fcf36ce" />



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Prevent users with only create permission but without write permission from seeing an enabled policy creation button that would fail on submission.