### PR TITLE
fix(RHINENG-24133): improve save button disabled state visibility

### DIFF
--- a/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
+++ b/src/SmartComponents/EditPolicyDetails/EditPolicyDetailsInline.js
@@ -146,9 +146,7 @@ const EditPolicyDetailsInline = ({
                   onClick={() => onSave()}
                   style={{
                     marginLeft: '5px',
-                    color: validThreshold
-                      ? 'var(--pf-t--global--background--color--primary--default)'
-                      : 'var(--pf-v6-c-button--disabled--Color)',
+                    opacity: validThreshold ? 1 : 0.4,
                   }}
                 />
               </div>


### PR DESCRIPTION
When the compliance threshold field has a validation error, the save button (checkmark icon) is functionally disabled but doesn't look visually disabled. This causes confusion as users try to click it but nothing happens.

How to test:
1. set up local environment according to readme in https://github.com/RedHatInsights/compliance-frontend
2. navigate to Policy details page
3. click the edit (pencil) icon on the Compliance threshold field
4. enter an invalid value (e.g., "0999" or any text)
5. the save button (checkmark icon) should now visibly appear disabled with reduced opacity

Closes https://redhat.atlassian.net/browse/RHINENG-24133

Before:
_Light_:
<img width="714" height="340" alt="image" src="https://github.com/user-attachments/assets/80e9d09a-ded4-49c9-bbfc-a07763d9e058" />
<img width="714" height="340" alt="image" src="https://github.com/user-attachments/assets/2c716615-49a6-441d-a844-3b36fe0cdc61" />

_Dark_:
<img width="714" height="340" alt="image" src="https://github.com/user-attachments/assets/70b4a75b-64b2-44d7-bfce-e1eab6d3c994" />
<img width="714" height="340" alt="image" src="https://github.com/user-attachments/assets/d218c9f2-4549-4a23-a61e-f628b13c47e2" />


After:
_Light_:
<img width="714" height="340" alt="image" src="https://github.com/user-attachments/assets/81cc3ae2-f577-46cf-b86e-cf554006a2cd" />
<img width="714" height="340" alt="image" src="https://github.com/user-attachments/assets/53232745-3725-4351-a7cb-79c5d05beb34" />

_Dark_:
<img width="714" height="340" alt="image" src="https://github.com/user-attachments/assets/bf757a22-6cc6-42f0-8666-a9f8b63325d0" />
<img width="714" height="340" alt="image" src="https://github.com/user-attachments/assets/558c6e49-16cd-4c9c-9dd2-744b966e6818" />


## Summary by Claude
Bug Fixes:
- Make the disabled state of the save button more visually obvious by using opacity instead of subtle color changes when the compliance threshold field has validation errors.

## Summary by Sourcery

Bug Fixes:
- Make the inline save button visibly appear disabled via reduced opacity when the compliance threshold has an invalid value.