### PR TITLE
fix(RHINENG-24175): do not truncate pdf column

### DIFF
--- a/src/SmartComponents/ExportPDF/TopFailedRulesSection.js
+++ b/src/SmartComponents/ExportPDF/TopFailedRulesSection.js
@@ -15,10 +15,16 @@ const TopFailedRulesSection = ({ rulesData, styles }) => {
       <Table borders={false} style={{ width: '100%' }}>
         <Thead>
           <Tr>
-            <Th style={styles.header}>ID</Th>
+            <Th modifier="fitContent" style={styles.header}>
+              ID
+            </Th>
             <Th style={styles.header}>Name</Th>
-            <Th style={styles.header}>Severity</Th>
-            <Th style={styles.noWrapHeader}>Failed systems</Th>
+            <Th modifier="fitContent" style={styles.header}>
+              Severity
+            </Th>
+            <Th modifier="nowrap" style={styles.header}>
+              Failed systems
+            </Th>
           </Tr>
         </Thead>
         <Tbody>


### PR DESCRIPTION
###What
Fixing truncated column in pdf generator

How to test:

1. Run pdf generator:
`PROXY_AGENT=http://squid.corp.redhat.com:3128/ ASSETS_HOST=https://localhost:1337/ API_HOST=https://console.stage.redhat.com/ npm run start:server`
`podman compose up`
3. insights-chrome: `npm run dev` with webpack config:
```
      '/api/crc-pdf-generator/': {
        host: 'http://localhost:8000/',
      },
      '/apps/compliance': {
        host: 'http://localhost:8003/',
      },
```
4. compliance: `npm run static`

### Before
<img width="954" height="547" alt="Screenshot 2026-06-17 at 14 50 19" src="https://github.com/user-attachments/assets/f107cfdc-94fc-4b68-89a8-5296ec22deb5" />

### After
<img width="954" height="547" alt="Screenshot 2026-06-17 at 14 50 10" src="https://github.com/user-attachments/assets/02f8f7b9-e61c-4c9a-8dcc-d6d7827257eb" />


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Adjust PDF export table column settings to prevent truncation of the top failed rules columns.

Bug Fixes:
- Ensure the ID and Severity columns in the top failed rules PDF table use fit-content sizing to avoid truncation.
- Prevent wrapping/truncation of the Failed systems column in the top failed rules PDF table by using a no-wrap modifier.