### PR TITLE
chore(deps): bump @redhat-cloud-services/frontend-components from 7.4.2 to 7.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@patternfly/react-tokens": "^6.4.0",
         "@project-kessel/react-kessel-access-check": "^0.5.0",
         "@redhat-cloud-services/compliance-client": "^3.0.7",
-        "@redhat-cloud-services/frontend-components": "^7.4.2",
+        "@redhat-cloud-services/frontend-components": "^7.8.0",
         "@redhat-cloud-services/frontend-components-config-utilities": "^4.8.3",
         "@redhat-cloud-services/frontend-components-notifications": "^6.5.1",
         "@redhat-cloud-services/frontend-components-remediations": "^4.4.0",
@@ -6317,9 +6317,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-7.7.1.tgz",
-      "integrity": "sha512-KpmSAI1EdNWsE4ZMcVsKpGAsrAj1SnpUPLDRZOImygFAVeg6GvAvTqfmPYy3DrcGzT+IIgkJqC3Oy+hhyuZllA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-7.8.0.tgz",
+      "integrity": "sha512-1xv//2x43FL0jjvT5Guh5PnfvkrS4kTWeX5HsRtbA3fO1eG24NfCX/t83Y908Q3NNhU7O36LLkW3QstOON+D9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@patternfly/react-tokens": "^6.4.0",
     "@project-kessel/react-kessel-access-check": "^0.5.0",
     "@redhat-cloud-services/compliance-client": "^3.0.7",
-    "@redhat-cloud-services/frontend-components": "^7.4.2",
+    "@redhat-cloud-services/frontend-components": "^7.8.0",
     "@redhat-cloud-services/frontend-components-config-utilities": "^4.8.3",
     "@redhat-cloud-services/frontend-components-notifications": "^6.5.1",
     "@redhat-cloud-services/frontend-components-remediations": "^4.4.0",


### PR DESCRIPTION
Updates @redhat-cloud-services/frontend-components to 7.8.0 to include bulk select sizing fixes for RHINENG-24158.

## Changes
- Bump @redhat-cloud-services/frontend-components from 7.4.2 to 7.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)