### PR TITLE
fix(RHINENG-24157): fix spacing in compliance threshold field

### DIFF
--- a/src/SmartComponents/CreatePolicy/components/DetailsStep.js
+++ b/src/SmartComponents/CreatePolicy/components/DetailsStep.js
@@ -160,7 +160,7 @@ const DetailsStepContent = ({ profile, name, input }) => {
           fieldId="policy-threshold"
           labelHelp={<PolicyThresholdTooltip />}
           label="Compliance threshold (%)"
-          style={{ width: '60%', display: 'block' }}
+          style={{ width: '60%' }}
         >
           <TextInput
             type="number"


### PR DESCRIPTION
In Create SCAP policy wizard, step 2 Details, the spacing between the title and the textbox for the Compliance threshold field is too tight compared to other fields.

The issue was caused by `display: 'block'` in the FormGroup style, which was carried over from the old redux-form implementation but is unnecessary with the current data-driven-forms implementation and causes improper spacing.

How to test:
1. set up local environment according to readme in https://github.com/RedHatInsights/compliance-frontend
2. navigate to Create SCAP policy wizard
3. go to step 2 (Details)
4. verify that the Compliance threshold field has proper spacing between the label and input box, matching the spacing of other fields

Closes https://redhat.atlassian.net/browse/RHINENG-24157

## Summary by Claude
Bug Fixes:
- Fix tight spacing in the Compliance threshold field by removing unnecessary `display: 'block'` style from the FormGroup component.

## Summary by Sourcery

Bug Fixes:
- Fix overly tight spacing between the Compliance threshold label and input by removing an unnecessary display style from its form group.