### PR TITLE
fix(CI): correct cypress col mgmt tests

### DIFF
--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.cy.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.cy.js
@@ -388,18 +388,23 @@ describe('Policies table tests API V2', () => {
 
     describe('Manage columns', () => {
       it('Manage reports columns', () => {
-        cy.ouiaId('BulkActionsToggle', 'button').click();
+        cy.wait('@getPolicies');
 
-        cy.ouiaType('PF6/DropdownItem', 'li')
-          .contains('Manage columns')
-          .should('be.visible')
-          .click();
+        cy.ouiaId('BulkActionsToggle', 'button').click();
+        cy.ouiaId('BulkActionsList').within(() => {
+          cy.ouiaType('PF6/DropdownItem', 'li')
+            .contains('Manage columns')
+            .should('be.visible')
+            .click();
+        });
+        cy.ouiaId('ColumnManagementModal').should('be.visible');
         cy.get('li input[checked]')
           .not('[disabled]')
           .each(($checkbox) => {
             cy.wrap($checkbox).click();
           });
         cy.ouiaId('ColumnManagementModal-save-button', 'button').click();
+        cy.ouiaId('ColumnManagementModal').should('not.exist');
 
         cy.get('th[data-label="Operating system"]').should('not.exist');
         cy.get('th[data-label="Systems"]').should('not.exist');
@@ -407,13 +412,17 @@ describe('Policies table tests API V2', () => {
         cy.get('th[data-label="Compliance threshold"]').should('not.exist');
 
         cy.ouiaId('BulkActionsToggle', 'button').click();
-        cy.ouiaType('PF6/DropdownItem', 'li')
-          .contains('Manage columns')
-          .should('be.visible')
-          .click();
+        cy.ouiaId('BulkActionsList').within(() => {
+          cy.ouiaType('PF6/DropdownItem', 'li')
+            .contains('Manage columns')
+            .should('be.visible')
+            .click();
+        });
+        cy.ouiaId('ColumnManagementModal').should('be.visible');
         cy.ouiaId('BulkSelect-toggle', 'button').click();
         cy.get('button').contains('Select all').click();
         cy.ouiaId('ColumnManagementModal-save-button', 'button').click();
+        cy.ouiaId('ColumnManagementModal').should('not.exist');
 
         cy.get('th[data-label="Operating system"]').should('exist');
         cy.get('th[data-label="Systems"]').should('exist');

--- a/src/SmartComponents/Reports/Reports.cy.js
+++ b/src/SmartComponents/Reports/Reports.cy.js
@@ -511,14 +511,23 @@ describe('Reports table tests', () => {
 
     describe('Manage columns', () => {
       it('Manage reports columns', () => {
+        cy.wait('@getReports');
+
         cy.ouiaId('BulkActionsToggle', 'button').click();
-        cy.ouiaType('PF6/DropdownItem', 'li').first().find('button').click();
+        cy.ouiaId('BulkActionsList').within(() => {
+          cy.ouiaType('PF6/DropdownItem', 'li')
+            .contains('Manage columns')
+            .should('be.visible')
+            .click();
+        });
+        cy.ouiaId('ColumnManagementModal').should('be.visible');
         cy.get('li input[checked]')
           .not('[disabled]')
           .each(($checkbox) => {
             cy.wrap($checkbox).click();
           });
         cy.ouiaId('ColumnManagementModal-save-button', 'button').click();
+        cy.ouiaId('ColumnManagementModal').should('not.exist');
 
         cy.get('th[data-label="Operating system"]').should('not.exist');
         cy.get('th[data-label="Systems meeting compliance"]').should(
@@ -526,10 +535,17 @@ describe('Reports table tests', () => {
         );
 
         cy.ouiaId('BulkActionsToggle', 'button').click();
-        cy.ouiaType('PF6/DropdownItem', 'li').first().find('button').click();
+        cy.ouiaId('BulkActionsList').within(() => {
+          cy.ouiaType('PF6/DropdownItem', 'li')
+            .contains('Manage columns')
+            .should('be.visible')
+            .click();
+        });
+        cy.ouiaId('ColumnManagementModal').should('be.visible');
         cy.ouiaId('BulkSelect-toggle', 'button').click();
         cy.get('button').contains('Select all').click();
         cy.ouiaId('ColumnManagementModal-save-button', 'button').click();
+        cy.ouiaId('ColumnManagementModal').should('not.exist');
 
         cy.get('th[data-label="Operating system"]', { timeout: 10000 }).should(
           'exist',


### PR DESCRIPTION
From time to time I could see that mgmt column test can fail with `AssertionError: Timed out retrying after 4000ms: Expected to find element: 'li[data-ouia-component-type="PF6/DropdownItem"]', but never found it.` https://github.com/RedHatInsights/compliance-frontend/actions/runs/27707282522/job/81959009714

Fix should help to be more specific about what items to click. It's not easy to test as issue doesn't happen every time


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Improve stability of manage columns Cypress tests for policies and reports tables.

Tests:
- Make manage columns tests wait for policies and reports data to load before interacting with bulk actions.
- Scope dropdown item selection to the bulk actions list and assert column management modal visibility to reduce test flakiness.