### PR TITLE
feat(RHINENG-24167): make policy cards selectable and sync with tabs

### DIFF
--- a/src/PresentationalComponents/SystemPolicyCard/SystemPolicyCard.js
+++ b/src/PresentationalComponents/SystemPolicyCard/SystemPolicyCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Card,
+  CardHeader,
   CardBody,
   CardFooter,
   Content,
@@ -13,7 +14,13 @@ import Truncate from '@redhat-cloud-services/frontend-components/Truncate';
 import UnsupportedSSGVersionAlert from './components/UnsupportedSSGVersionAlert';
 import CompliantIcon from './components/CompliantIcon';
 
-const SystemPolicyCard = ({ policy, style }) => {
+const SystemPolicyCard = ({
+  policy,
+  isClickable,
+  isClicked,
+  onClickAction,
+  selectableActionAriaLabel,
+}) => {
   const {
     failed_rule_count: failedRuleCount,
     compliant,
@@ -30,8 +37,18 @@ const SystemPolicyCard = ({ policy, style }) => {
   const truncateDefaults = { expandOnMouseOver: true, hideExpandText: true };
 
   return (
-    <Card ouiaId="PolicyCard" style={style}>
-      <CardBody>
+    <Card
+      ouiaId="PolicyCard"
+      isClickable={isClickable}
+      isClicked={isClicked}
+      style={{ height: '100%' }}
+    >
+      <CardHeader
+        selectableActions={{
+          onClickAction,
+          selectableActionAriaLabel,
+        }}
+      >
         <Content className="margin-bottom-md">
           <Content
             ouiaId="PolicyCardName"
@@ -44,6 +61,8 @@ const SystemPolicyCard = ({ policy, style }) => {
             <Truncate text={profileTitle} length={110} {...truncateDefaults} />
           </Content>
         </Content>
+      </CardHeader>
+      <CardBody>
         <div className="margin-bottom-md">
           {supported && <CompliantIcon compliant={compliant} />}
           <Content
@@ -111,7 +130,10 @@ SystemPolicyCard.propTypes = {
     compliant: PropTypes.bool,
     supported: PropTypes.bool,
   }),
-  style: PropTypes.object,
+  isClickable: PropTypes.bool,
+  isClicked: PropTypes.bool,
+  onClickAction: PropTypes.func,
+  selectableActionAriaLabel: PropTypes.string,
 };
 
 export default SystemPolicyCard;

--- a/src/SmartComponents/SystemDetails/Cells.js
+++ b/src/SmartComponents/SystemDetails/Cells.js
@@ -6,8 +6,7 @@ import {
   ExclamationCircleIcon,
 } from '@patternfly/react-icons';
 import RemediationCell from '@/PresentationalComponents/RemediationCell/RemediationCell';
-import { Policy, Severity } from '@/PresentationalComponents/RulesTable/Cells';
-import { FAILED_RULE_STATES } from '@/constants';
+import { Severity } from '@/PresentationalComponents/RulesTable/Cells';
 import { t_global_text_color_subtle } from '@patternfly/react-tokens';
 
 const ruleResultProps = {
@@ -18,18 +17,9 @@ const ruleResultProps = {
   remediation_issue_id: propTypes.string,
 };
 
-export const Rule = ({ title, identifier, result = 'pass' }) => {
+export const Rule = ({ title, identifier }) => {
   return (
-    <Content
-      style={{
-        ...(FAILED_RULE_STATES.includes(result)
-          ? {
-              fontWeight: 'bold',
-              color: 'var(--pf-t--global--color--status--danger--100)',
-            }
-          : {}),
-      }}
-    >
+    <Content className="pf-v6-u-font-weight-bold">
       {title}
       {identifier ? (
         <Content
@@ -72,4 +62,4 @@ export const RemediationColumnCell = ({ remediation_issue_id }) => (
 );
 RemediationColumnCell.propTypes = ruleResultProps;
 
-export { Severity, Policy };
+export { Severity };

--- a/src/SmartComponents/SystemDetails/Columns.js
+++ b/src/SmartComponents/SystemDetails/Columns.js
@@ -1,7 +1,6 @@
 import { Passed as PassedCell, RemediationColumnCell, Rule } from './Cells';
 import {
   Passed,
-  Policy,
   Remediation,
   Severity,
 } from '@/PresentationalComponents/RulesTable/Columns';
@@ -27,10 +26,4 @@ export const RemediationSystemDetails = {
   Component: RemediationColumnCell,
 };
 
-export default [
-  Name,
-  Policy,
-  Severity,
-  PassedSystemDetails,
-  RemediationSystemDetails,
-];
+export default [Name, PassedSystemDetails, Severity, RemediationSystemDetails];

--- a/src/SmartComponents/SystemDetails/SystemPoliciesAndRules.js
+++ b/src/SmartComponents/SystemDetails/SystemPoliciesAndRules.js
@@ -10,14 +10,17 @@ const SystemPoliciesAndRules = ({
   hidePassed,
   remediationsEnabled,
 }) => {
-  // FYI: test result ID and policy ID are not the same, but test result ID only identifies each tab here.
   const [selectedPolicy, setSelectedPolicy] = useState(
     reportTestResults[0].report_id,
   );
 
   return (
     <>
-      <SystemPolicyCards reportTestResults={reportTestResults} />
+      <SystemPolicyCards
+        reportTestResults={reportTestResults}
+        selectedPolicy={selectedPolicy}
+        onSelectPolicy={setSelectedPolicy}
+      />
       <br />
       <Tabs activeKey={selectedPolicy}>
         {reportTestResults.map((reportTestResult, idx) => (

--- a/src/SmartComponents/SystemDetails/SystemPoliciesAndRules.test.js
+++ b/src/SmartComponents/SystemDetails/SystemPoliciesAndRules.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import SystemPoliciesAndRules from './SystemPoliciesAndRules';
+import testResults from '../../__factories__/testResults';
+
+jest.mock('./RuleResults', () => ({
+  __esModule: true,
+  default: ({ reportTestResult }) => (
+    <div data-testid={`rules-${reportTestResult.report_id}`}>
+      Rules for {reportTestResult.title}
+    </div>
+  ),
+}));
+
+describe('SystemPoliciesAndRules', () => {
+  const testResultsData = testResults.buildList(2);
+  const testResultsMock = testResultsData.map((testResult, index) => ({
+    ...testResult,
+    report_id: `report-${index}`,
+    title: `Policy ${index}`,
+    profile_title: `Profile ${index}`,
+  }));
+
+  const defaultProps = {
+    systemId: 'test-system-id',
+    reportTestResults: testResultsMock,
+    hidePassed: false,
+    remediationsEnabled: true,
+  };
+
+  it('synchronizes tab selection when a card is clicked', async () => {
+    const user = userEvent.setup();
+    render(<SystemPoliciesAndRules {...defaultProps} />);
+
+    const clickableButtons = screen.getAllByLabelText(/Select Policy/i);
+    await user.click(clickableButtons[1]);
+
+    expect(screen.getByRole('tab', { name: /Policy 1/i })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('synchronizes card selection when a tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<SystemPoliciesAndRules {...defaultProps} />);
+
+    await user.click(screen.getByRole('tab', { name: /Policy 1/i }));
+
+    const clickableButtons = screen.getAllByLabelText(/Select Policy/i);
+    expect(clickableButtons[1].closest('.pf-v6-c-card')).toHaveClass(
+      'pf-m-current',
+    );
+  });
+});

--- a/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.js
+++ b/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.js
@@ -3,21 +3,35 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import SystemPolicyCardPresentational from 'PresentationalComponents/SystemPolicyCard';
 import propTypes from 'prop-types';
 
-export const SystemPolicyCards = ({ reportTestResults }) => (
+export const SystemPolicyCards = ({
+  reportTestResults,
+  selectedPolicy,
+  onSelectPolicy,
+}) => (
   <Grid hasGutter>
-    {reportTestResults.map((testResult) => (
-      <GridItem sm={12} md={12} lg={6} xl={4} key={testResult.report_id}>
-        <SystemPolicyCardPresentational
-          policy={testResult}
-          style={{ height: '100%' }}
-        />
-      </GridItem>
-    ))}
+    {reportTestResults.map((testResult) => {
+      const isClicked = selectedPolicy === testResult.report_id;
+      return (
+        <GridItem sm={12} md={12} lg={6} xl={4} key={testResult.report_id}>
+          <SystemPolicyCardPresentational
+            policy={testResult}
+            isClickable
+            isClicked={isClicked}
+            onClickAction={() =>
+              onSelectPolicy && onSelectPolicy(testResult.report_id)
+            }
+            selectableActionAriaLabel={`Select ${testResult.title}`}
+          />
+        </GridItem>
+      );
+    })}
   </Grid>
 );
 
 SystemPolicyCards.propTypes = {
   reportTestResults: propTypes.array.isRequired,
+  selectedPolicy: propTypes.string,
+  onSelectPolicy: propTypes.func,
 };
 
 export default SystemPolicyCards;

--- a/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.test.js
+++ b/src/SmartComponents/SystemPolicyCards/SystemPolicyCards.test.js
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { SystemPolicyCards } from './SystemPolicyCards';
@@ -10,12 +11,12 @@ jest.mock('Utilities/hooks/api/useReportTestResults');
 jest.mock('react-router-dom');
 
 describe('SystemPolicyCards', () => {
-  const testResultsData = testResults.buildList(1);
-  const testResultsMock = testResultsData.map((testResult) => ({
+  const testResultsData = testResults.buildList(2);
+  const testResultsMock = testResultsData.map((testResult, index) => ({
     ...testResult,
-    report_id: 'abc',
-    title: 'xyz',
-    profile_title: 'xyz',
+    report_id: `report-${index}`,
+    title: `Policy ${index}`,
+    profile_title: `Profile ${index}`,
   }));
 
   beforeEach(() => {
@@ -25,24 +26,57 @@ describe('SystemPolicyCards', () => {
   });
 
   it('shows card with data for loaded policy', () => {
-    render(<SystemPolicyCards reportTestResults={testResultsMock} />);
+    const singlePolicyMock = [testResultsMock[0]];
+    render(<SystemPolicyCards reportTestResults={singlePolicyMock} />);
 
     screen.getByRole('heading', {
-      name: testResultsMock[0].title,
+      name: singlePolicyMock[0].title,
     });
     screen.getByText(
-      testResultsMock[0].compliant ? 'Compliant' : 'Not compliant',
+      singlePolicyMock[0].compliant ? 'Compliant' : 'Not compliant',
     );
     screen.getByText(
-      `${testResultsMock[0].failed_rule_count} rule${
-        testResultsMock[0].failed_rule_count > 1 ||
-        testResultsMock[0].failed_rule_count === 0
+      `${singlePolicyMock[0].failed_rule_count} rule${
+        singlePolicyMock[0].failed_rule_count > 1 ||
+        singlePolicyMock[0].failed_rule_count === 0
           ? 's'
           : ''
       } failed`,
     );
     screen.getByText(
-      `SSG version: ${testResultsMock[0].security_guide_version}`,
+      `SSG version: ${singlePolicyMock[0].security_guide_version}`,
     );
+  });
+
+  it('calls onSelectPolicy when a card is clicked', async () => {
+    const onSelectPolicy = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <SystemPolicyCards
+        reportTestResults={testResultsMock}
+        selectedPolicy="report-0"
+        onSelectPolicy={onSelectPolicy}
+      />,
+    );
+
+    const clickableButtons = screen.getAllByLabelText(/Select Policy/i);
+
+    await user.click(clickableButtons[1]);
+
+    expect(onSelectPolicy).toHaveBeenCalledWith('report-1');
+  });
+
+  it('renders multiple policy cards', () => {
+    render(
+      <SystemPolicyCards
+        reportTestResults={testResultsMock}
+        selectedPolicy="report-1"
+        onSelectPolicy={jest.fn()}
+      />,
+    );
+
+    screen.getByRole('heading', { name: testResultsMock[0].title });
+    screen.getByRole('heading', { name: testResultsMock[1].title });
   });
 });


### PR DESCRIPTION
This PR makes policy cards selectable and synchronizes them with the existing tab navigation in System Details, improving the user experience while reducing repetitive information.

## How to test:
You need to have a system that has reported to at least two policies to see the interaction. Consider using iqe to get it - for example, you can set a breakpoint in test `test_system_details_duplicated_rules` and operate on the created entity while the test hangs.

Otherwise:
1. Have insights-chrome and insert into webpack config
```
'/apps/compliance': {
  host: 'http://localhost:8004/',
},
'/apps/inventory': {
  host: 'http://localhost:8005/',
}, 
```
2. Run insights-chrome with `npm run dev`
3. Run insights-inventory-frontend with `npm run static -- -p=8005`
4. Checkout to this PR and run `npm run static -- -p=8004`
5. Navigate to Compliance -> Systems -> System details of your special system
6. Check that the interaction works - both cards and tabs should stay in sync
7. Switch between policies using either cards or tabs, apply filters, etc.

## Changes
- **Selectable policy cards**: Policy cards at the top are now clickable and synchronized with tabs
- **Dual navigation**: Both cards and tabs control which policy's rules are displayed - clicking either updates both
- **Reordered columns**: Rule State column moved next to Rule Name for better readability
- **Removed Policy column**: The Policy column in the rules table was redundant since only one policy is shown at a time
- **Uniform rule styling**: All rule titles now have consistent bold styling

Before:
<img width="2446" height="1411" alt="Screenshot From 2026-06-30 11-46-47" src="https://github.com/user-attachments/assets/64100f13-e61c-4a16-a0cf-20be4d0bc2dc" />
<img width="2446" height="1411" alt="Screenshot From 2026-06-30 11-46-50" src="https://github.com/user-attachments/assets/96a93b99-8465-483d-87e7-28d85c16fe24" />

After:
<img width="2446" height="1411" alt="Screenshot From 2026-06-30 11-45-58" src="https://github.com/user-attachments/assets/4d0d5ff5-c0e0-4b83-8497-330fe7a5df0c" />
<img width="2446" height="1411" alt="Screenshot From 2026-06-30 11-46-02" src="https://github.com/user-attachments/assets/7333a9d3-f1f7-44c6-8ad5-904a5a8bb483" />


## Implementation Details
- Added \`isClickable\`, \`isClicked\`, \`onClickAction\`, and \`selectableActionAriaLabel\` props to \`SystemPolicyCard\`
- Updated \`SystemPolicyCards\` to accept \`selectedPolicy\` and \`onSelectPolicy\` props
- Modified \`SystemPoliciesAndRules\` to share selection state between cards and tabs
- Reordered columns in \`SystemDetails/Columns.js\` so Rule State appears next to Rule Name
- Removed \`Policy\` column from default column list
- Simplified \`Rule\` component in \`SystemDetails/Cells.js\` to apply uniform bold styling
- Added tests for card selection behavior and tab/card synchronization

## Jira
https://redhat.atlassian.net/browse/RHINENG-24167

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Synchronize selectable system policy cards with System Details tabs and streamline rule table presentation.

New Features:
- Make system policy cards clickable and keep their selection state in sync with the policy tabs in System Details.

Enhancements:
- Simplify rule title styling and adjust System Details columns by moving Rule State next to Rule Name and removing the Policy column.

Tests:
- Extend SystemPolicyCards tests for multi-policy scenarios and add coverage for card selection behavior and tab/card synchronization.
- Add tests for SystemPoliciesAndRules to validate behavior of synchronized policy selection.