### PR TITLE
fix(RHINENG-24148): correct Spinners appearance

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 import { KESSEL_API_BASE_URL } from '@/constants';
 import { useFlagsStatus } from '@unleash/proxy-client-react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { CenteredSpinner } from 'PresentationalComponents';
 
 import Routes from './Routes';
 import './App.scss';
@@ -26,11 +26,7 @@ const App = (props) => {
   }, [chrome]);
 
   if (!flagsReady) {
-    return (
-      <Bullseye>
-        <Spinner size="xl" />
-      </Bullseye>
-    );
+    return <CenteredSpinner />;
   }
 
   return (

--- a/src/Modules/ComplianceDetails.js
+++ b/src/Modules/ComplianceDetails.js
@@ -8,7 +8,7 @@ import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
 import { KESSEL_API_BASE_URL } from '@/constants';
 import { useFlagsStatus } from '@unleash/proxy-client-react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { CenteredSpinner } from 'PresentationalComponents';
 
 const queryClient = new QueryClient();
 
@@ -18,11 +18,7 @@ const ComplianceDetails = (props) => {
   const { flagsReady } = useFlagsStatus();
 
   if (!flagsReady) {
-    return (
-      <Bullseye>
-        <Spinner size="xl" />
-      </Bullseye>
-    );
+    return <CenteredSpinner />;
   }
 
   return (

--- a/src/PresentationalComponents/CenteredSpinner/CenteredSpinner.js
+++ b/src/PresentationalComponents/CenteredSpinner/CenteredSpinner.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+
+const CenteredSpinner = () => (
+  <Bullseye>
+    <Spinner />
+  </Bullseye>
+);
+
+export default CenteredSpinner;

--- a/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.js
+++ b/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.js
@@ -2,16 +2,15 @@ import React from 'react';
 import propTypes from 'prop-types';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import {
-  Content,
   Button,
+  Content,
   EmptyState,
   EmptyStateBody,
   EmptyStateActions,
   EmptyStateFooter,
 } from '@patternfly/react-core';
 import { CloudSecurityIcon } from '@patternfly/react-icons';
-import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
-import { ErrorCard } from 'PresentationalComponents';
+import { ErrorCard, CenteredSpinner } from 'PresentationalComponents';
 import usePolicies from 'Utilities/hooks/api/usePolicies';
 import { emptyStateLink } from '@/constants';
 
@@ -20,7 +19,7 @@ const ComplianceEmptyState = ({ title = 'No policies', mainButton }) => {
   const policiesCount = data?.meta?.total || 0;
 
   if (loading) {
-    return <Spinner />;
+    return <CenteredSpinner />;
   }
 
   if (error) {

--- a/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.test.js
+++ b/src/PresentationalComponents/ComplianceEmptyState/ComplianceEmptyState.test.js
@@ -21,8 +21,10 @@ describe('ComplianceEmptyState', () => {
         <ComplianceEmptyState />
       </TestWrapper>,
     );
-
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByLabelText('Contents')).toHaveAttribute(
+      'aria-valuetext',
+      'Loading...',
+    );
   });
 
   it('expect to render error state', () => {

--- a/src/PresentationalComponents/Tailorings/Tailorings.js
+++ b/src/PresentationalComponents/Tailorings/Tailorings.js
@@ -1,10 +1,11 @@
 import React, { useCallback } from 'react';
 import propTypes from 'prop-types';
-import { Badge, Flex, FlexItem, Spinner, Tab } from '@patternfly/react-core';
+import { Badge, Flex, FlexItem, Tab } from '@patternfly/react-core';
 import {
   RoutedTabs,
   StateViewWithError,
   StateViewPart,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import useTailorings from 'Utilities/hooks/api/useTailorings';
 import OsVersionText from './osVersionText';
@@ -104,12 +105,12 @@ const Tailorings = ({
     <StateViewWithError
       stateValues={{
         error: tailoringsError,
-        data: tabs && (tailoringsData || profiles),
         loading: tailoringsLoading,
+        data: !tailoringsLoading && tabs && (tailoringsData || profiles),
       }}
     >
       <StateViewPart stateKey="loading">
-        <Spinner />
+        <CenteredSpinner />
       </StateViewPart>
       <StateViewPart stateKey="data">
         {tabs.length > 0 ? (

--- a/src/PresentationalComponents/index.js
+++ b/src/PresentationalComponents/index.js
@@ -38,6 +38,7 @@ export { default as SubPageTitle } from './SubPageTitle/SubPageTitle';
 export { default as NoSystemsTableWithWarning } from './NoSystemsTableWithWarning/NoSystemsTableWithWarning';
 export { default as RulesTable } from './RulesTable/RulesTable';
 export { default as ConditionalLink } from './ConditionalLink/ConditionalLink';
+export { default as CenteredSpinner } from './CenteredSpinner/CenteredSpinner';
 export { default as ComplianceModal } from './ComplianceModal/ComplianceModal';
 export { default as WithPermission } from './WithPermission/WithPermission';
 export { default as LinkWithPermission } from './LinkWithPermission/LinkWithPermission';

--- a/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
+++ b/src/SmartComponents/CompliancePolicies/CompliancePolicies.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Spinner } from '@patternfly/react-core';
+import { Grid } from '@patternfly/react-core';
 import {
   ErrorPage,
   LinkButton,
@@ -8,6 +8,7 @@ import {
   PoliciesTable,
   StateView,
   StateViewPart,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import usePolicies from 'Utilities/hooks/api/usePolicies';
 import ComplianceEmptyState from 'PresentationalComponents/ComplianceEmptyState';
@@ -89,7 +90,7 @@ const CompliancePoliciesContent = ({ usePermissionsHook }) => {
             <ErrorPage error={error} />
           </StateViewPart>
           <StateViewPart stateKey="loading">
-            <Spinner />
+            <CenteredSpinner />
           </StateViewPart>
           <StateViewPart stateKey="showTable">
             {totalPolicies === 0 ? (

--- a/src/SmartComponents/CreatePolicy/components/CreateSCAPPolicyStep.js
+++ b/src/SmartComponents/CreatePolicy/components/CreateSCAPPolicyStep.js
@@ -11,7 +11,6 @@ import {
   Flex,
   Form,
   FormGroup,
-  Spinner,
   Content,
   ContentVariants,
 } from '@patternfly/react-core';
@@ -24,6 +23,7 @@ import {
   StateViewWithError,
   PolicyTypesTable,
   PolicyTypeTooltip,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 
 const serialiseOsVersions = (profiles = []) =>
@@ -89,7 +89,7 @@ const CreateSCAPPolicyStepContent = ({
       }}
     >
       <StateViewPart stateKey="loading">
-        <Spinner />
+        <CenteredSpinner />
       </StateViewPart>
       <StateViewPart stateKey="data">
         <Content>

--- a/src/SmartComponents/CreatePolicy/components/CreateSCAPPolicyStep.test.js
+++ b/src/SmartComponents/CreatePolicy/components/CreateSCAPPolicyStep.test.js
@@ -18,7 +18,11 @@ jest.mock('bastilian-tabletools', () => ({
 
 jest.mock('PresentationalComponents', () => {
   const React = require('react');
+  const CenteredSpinner = jest.requireActual(
+    'PresentationalComponents/CenteredSpinner/CenteredSpinner',
+  ).default;
   return {
+    CenteredSpinner,
     StateViewPart: ({ children }) => <>{children}</>,
     StateViewWithError: ({ stateValues, children }) => {
       if (stateValues.error) {

--- a/src/SmartComponents/CreatePolicy/components/RulesStep.js
+++ b/src/SmartComponents/CreatePolicy/components/RulesStep.js
@@ -1,13 +1,7 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { xor, isEqual } from 'lodash';
 import { useDeepCompareEffect } from 'use-deep-compare';
-import {
-  Bullseye,
-  EmptyState,
-  Spinner,
-  Content,
-  ContentVariants,
-} from '@patternfly/react-core';
+import { Content, ContentVariants } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import {
   useFormApi,
@@ -18,6 +12,7 @@ import {
   StateViewPart,
   StateViewWithError,
   Tailorings,
+  CenteredSpinner,
 } from '@/PresentationalComponents';
 import * as Columns from '@/PresentationalComponents/RulesTable/Columns';
 import useProfileRuleIds from 'Utilities/hooks/useProfileRuleIds';
@@ -208,9 +203,7 @@ const RulesStepContent = ({
   };
 
   return !preselected ? (
-    <Bullseye>
-      <Spinner />
-    </Bullseye>
+    <CenteredSpinner />
   ) : (
     <React.Fragment>
       <Content className="pf-v6-u-pb-md">
@@ -233,9 +226,7 @@ const RulesStepContent = ({
         }}
       >
         <StateViewPart stateKey="loading">
-          <EmptyState>
-            <Spinner />
-          </EmptyState>
+          <CenteredSpinner />
         </StateViewPart>
         <StateViewPart stateKey="data">
           {profilesAndRuleIds &&

--- a/src/SmartComponents/DeletePolicy/DeletePolicy.js
+++ b/src/SmartComponents/DeletePolicy/DeletePolicy.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
-import { Button, Checkbox, Content, Spinner } from '@patternfly/react-core';
+import { Button, Checkbox, Content } from '@patternfly/react-core';
 import { ModalVariant } from '@patternfly/react-core/deprecated';
 import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
@@ -9,6 +9,7 @@ import {
   ComplianceModal,
   StateViewWithError,
   StateViewPart,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import usePolicy from 'Utilities/hooks/api/usePolicy';
 import { apiInstance } from 'Utilities/hooks/useQuery';
@@ -77,7 +78,7 @@ const DeletePolicy = () => {
     >
       <StateViewWithError stateValues={{ error, data: policy, loading }}>
         <StateViewPart stateKey="loading">
-          <Spinner />
+          <CenteredSpinner />
         </StateViewPart>
         <StateViewPart stateKey="data">
           <Content component="p" className="policy-delete-body-text">

--- a/src/SmartComponents/EditPolicy/EditPolicy.js
+++ b/src/SmartComponents/EditPolicy/EditPolicy.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import propTypes from 'prop-types';
-import { Button, Spinner } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import { useLocation, useParams } from 'react-router-dom';
 import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
@@ -8,6 +8,7 @@ import {
   ComplianceModal,
   StateViewWithError,
   StateViewPart,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import usePolicy from 'Utilities/hooks/api/usePolicy';
 import useSupportedProfiles from 'Utilities/hooks/api/useSupportedProfiles';
@@ -145,7 +146,7 @@ const EditPolicy = ({ route }) => {
     >
       <StateViewWithError stateValues={statusValues}>
         <StateViewPart stateKey="loading">
-          <Spinner />
+          <CenteredSpinner />
         </StateViewPart>
         <StateViewPart stateKey="data">
           <EditPolicyForm

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -7,8 +7,11 @@ import {
 } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import xor from 'lodash/xor';
-import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
-import { StateView, StateViewPart } from 'PresentationalComponents';
+import {
+  StateView,
+  StateViewPart,
+  CenteredSpinner,
+} from 'PresentationalComponents';
 import * as Columns from '@/PresentationalComponents/RulesTable/Columns';
 import Tailorings from '@/PresentationalComponents/Tailorings/Tailorings';
 import useProfileRuleIds from 'Utilities/hooks/useProfileRuleIds';
@@ -184,9 +187,7 @@ export const EditPolicyRulesTab = ({
       }}
     >
       <StateViewPart stateKey="loading">
-        <EmptyState>
-          <Spinner />
-        </EmptyState>
+        <CenteredSpinner />
       </StateViewPart>
       <StateViewPart stateKey="data">
         <Content>

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.test.js
@@ -59,6 +59,9 @@ describe('EditPolicyRulesTab', () => {
       </TestWrapper>,
     );
 
-    expect(screen.queryByText('Loading...')).toBeVisible();
+    expect(screen.getByLabelText('Contents')).toHaveAttribute(
+      'aria-valuetext',
+      'Loading...',
+    );
   });
 });

--- a/src/SmartComponents/ExportPDF/ExportPDF.js
+++ b/src/SmartComponents/ExportPDF/ExportPDF.js
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Button, Spinner } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 
 import {
   ComplianceModal,
   StateViewWithError,
   StateViewPart,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
@@ -97,7 +98,7 @@ export const ExportPDF = () => {
     >
       <StateViewWithError stateValues={{ error, data: reportData, loading }}>
         <StateViewPart stateKey="loading">
-          <Spinner />
+          <CenteredSpinner />
         </StateViewPart>
         <StateViewPart stateKey="data">
           <ExportPDFForm

--- a/src/SmartComponents/ImportRules/ImportRules.js
+++ b/src/SmartComponents/ImportRules/ImportRules.js
@@ -1,13 +1,8 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
-import {
-  Content,
-  ContentVariants,
-  Skeleton,
-  Spinner,
-  Bullseye,
-} from '@patternfly/react-core';
+import { Content, ContentVariants, Skeleton } from '@patternfly/react-core';
+import { CenteredSpinner } from 'PresentationalComponents';
 
 import VersionSelector from './components/VersionSelector';
 import RuleComparison from './components/RuleComparison';
@@ -86,9 +81,7 @@ const ImportRules = () => {
         <>
           <Content component={ContentVariants.hr} />
           {initialSelectionLoading || !initialSelection || !selection ? (
-            <Bullseye>
-              <Spinner />
-            </Bullseye>
+            <CenteredSpinner />
           ) : (
             <RuleComparison
               policy={policy}

--- a/src/SmartComponents/ImportRules/components/ImportRulesModal.js
+++ b/src/SmartComponents/ImportRules/components/ImportRulesModal.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import propTypes from 'prop-types';
-import { Button, Bullseye, Spinner } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import { ModalVariant } from '@patternfly/react-core/deprecated';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 
@@ -8,6 +8,7 @@ import {
   ComplianceModal,
   StateViewWithError,
   StateViewPart,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 
 const ImportRulesModal = ({
@@ -52,9 +53,7 @@ const ImportRulesModal = ({
     >
       <StateViewWithError stateValues={stateValues}>
         <StateViewPart stateKey="loading">
-          <Bullseye>
-            <Spinner />
-          </Bullseye>
+          <CenteredSpinner />
         </StateViewPart>
         <StateViewPart stateKey="data">{children}</StateViewPart>
       </StateViewWithError>

--- a/src/SmartComponents/PolicyDetails/PolicyDetails.js
+++ b/src/SmartComponents/PolicyDetails/PolicyDetails.js
@@ -8,7 +8,6 @@ import {
   Grid,
   GridItem,
   Tab,
-  Spinner,
 } from '@patternfly/react-core';
 import PageHeader, {
   PageHeaderTitle,
@@ -24,6 +23,7 @@ import {
   BreadcrumbLinkItem,
   Tailorings,
   LinkButton,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
 import useFeatureFlag from 'Utilities/hooks/useFeatureFlag';
@@ -96,7 +96,7 @@ const PolicyDetailsContent = ({ route, usePermissionsHook }) => {
           <PolicyDetailsContentLoader />
         </PageHeader>
         <section className="pf-v6-c-page__main-section">
-          <Spinner />
+          <CenteredSpinner />
         </section>
       </StateViewPart>
       <StateViewPart stateKey="data">

--- a/src/SmartComponents/ReportDetails/ReportDetails.js
+++ b/src/SmartComponents/ReportDetails/ReportDetails.js
@@ -4,10 +4,8 @@ import { useParams } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
-  EmptyState,
   Grid,
   GridItem,
-  Spinner,
   Tab,
   Tabs,
 } from '@patternfly/react-core';
@@ -24,6 +22,7 @@ import {
   StateViewPart,
   SubPageTitle,
   LinkButton,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import { SystemsTable } from 'SmartComponents';
 import { useTitleEntity } from 'Utilities/hooks/useDocumentTitle';
@@ -73,9 +72,7 @@ const ReportDetails = ({ route }) => {
           <ReportDetailsContentLoader />
         </PageHeader>
         <section className="pf-v6-c-page__main-section">
-          <EmptyState>
-            <Spinner />
-          </EmptyState>
+          <CenteredSpinner />
         </section>
       </StateViewPart>
       <StateViewPart stateKey="report">

--- a/src/SmartComponents/Reports/Reports.js
+++ b/src/SmartComponents/Reports/Reports.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Spinner } from '@patternfly/react-core';
 import {
   ReportsTable,
   StateViewPart,
   StateViewWithError,
   ReportsEmptyState,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import { TableStateProvider } from 'bastilian-tabletools';
 
@@ -61,7 +61,7 @@ const Reports = () => {
           }}
         >
           <StateViewPart stateKey="loading">
-            <Spinner />
+            <CenteredSpinner />
           </StateViewPart>
           <StateViewPart stateKey="showTable">
             {totalReports === 0 ? (

--- a/src/SmartComponents/SystemDetails/Details.js
+++ b/src/SmartComponents/SystemDetails/Details.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { Bullseye } from '@patternfly/react-core';
-import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
+import { CenteredSpinner } from 'PresentationalComponents';
 import './compliance.scss';
 import useTestResults from './useTestResults';
 import SystemPoliciesAndRules from './SystemPoliciesAndRules';
@@ -21,9 +20,7 @@ export const Details = ({
   return (
     <div className="ins-c-compliance__scope">
       {testResultsLoading && connectedToInsights !== false ? (
-        <Bullseye>
-          <Spinner />
-        </Bullseye>
+        <CenteredSpinner />
       ) : testResults?.length === 0 || connectedToInsights === false ? (
         <EmptyState
           inventoryId={inventoryId}

--- a/src/SmartComponents/SystemDetails/EmptyState.js
+++ b/src/SmartComponents/SystemDetails/EmptyState.js
@@ -4,7 +4,7 @@ import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConn
 import NoPoliciesState from './NoPoliciesState';
 import NoReportsState from './NoReportsState';
 import useSystem from 'Utilities/hooks/api/useSystem';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { CenteredSpinner } from 'PresentationalComponents';
 
 const EmptyState = ({ inventoryId: systemId, system, connectedToInsights }) => {
   // request system data in case Inventory details Compliance opened
@@ -24,11 +24,7 @@ const EmptyState = ({ inventoryId: systemId, system, connectedToInsights }) => {
   }
 
   if (systemLoading === true) {
-    return (
-      <Bullseye>
-        <Spinner />
-      </Bullseye>
-    );
+    return <CenteredSpinner />;
   }
 
   if (policiesCount === 0) {

--- a/src/SmartComponents/SystemDetails/SystemDetails.test.js
+++ b/src/SmartComponents/SystemDetails/SystemDetails.test.js
@@ -42,6 +42,9 @@ describe('SystemDetails', () => {
     expect(
       screen.getByLabelText('Inventory Details Wrapper'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByLabelText('Contents')).toHaveAttribute(
+      'aria-valuetext',
+      'Loading...',
+    );
   });
 });

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -1,7 +1,6 @@
 import React, { useLayoutEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { Spinner } from '@patternfly/react-core';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import { TableStateProvider } from 'bastilian-tabletools';
 import {
@@ -9,6 +8,7 @@ import {
   ErrorPage,
   StateView,
   StateViewPart,
+  CenteredSpinner,
 } from 'PresentationalComponents';
 import {
   useGetEntities,
@@ -123,7 +123,7 @@ export const SystemsTable = ({
           disableDefaultColumns
           columns={mergedColumns(columns)}
           noSystemsTable={noSystemsTable}
-          fallback={<Spinner />}
+          fallback={<CenteredSpinner />}
           getEntities={getEntities}
           fetchCustomOSes={fetchOperatingSystems}
           hideFilters={{


### PR DESCRIPTION
What changed:
1. No need to set size XL as it's xl size by default
2. Correct Spinner place by wrapping with Bullseye component
3. Use Spinner component from Patternfly only (not FEC)
4. Replace EmptySpace Component wrapper for Spinner as it's incorrect.

How to test:
Check few Compliance pages like, Policies, Reports, Export PDF modal, Edit modal, etc and see that spinner is placed in the middle instead of left top corner

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Standardize loading spinner usage and alignment across compliance UI views.

Enhancements:
- Center loading spinners using PatternFly Bullseye in multiple views.
- Replace frontend-components spinners with PatternFly Spinner for consistency.
- Rely on default Spinner sizing instead of explicitly requesting XL size.

## Summary by Sourcery

Align loading spinner appearance and positioning across compliance views using PatternFly components.

Enhancements:
- Center loading spinners by wrapping them in PatternFly Bullseye across multiple compliance screens and flows.
- Standardize on PatternFly Spinner instead of frontend-components spinners and rely on default sizing.
- Adjust loading-state tests to assert against Spinner accessibility attributes rather than plain text labels.

Tests:
- Update ComplianceEmptyState and SystemDetails tests to validate the new spinner markup and ARIA attributes.