### PR TITLE
feat(RHINENG-24136): set per-page to 10 in Edit Policy Systems tab

### DIFF
--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.js
@@ -86,6 +86,7 @@ const EditPolicySystemsTab = ({
       preselectedSystems={selectedSystems}
       onSelect={onSystemSelect}
       setIsSystemsDataLoading={setIsSystemsDataLoading}
+      perPage={10}
       enableExport={false}
       dedicatedAction={
         <SystemsViewToggle

--- a/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
+++ b/src/SmartComponents/EditPolicy/EditPolicySystemsTab.test.js
@@ -39,6 +39,17 @@ describe('EditPolicySystemsTab', () => {
     );
   });
 
+  it('should render a SystemsTable with perPage set to 10', () => {
+    render(<EditPolicySystemsTab {...defaultProps} />);
+
+    expect(mockSystemsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        perPage: 10,
+      }),
+      {},
+    );
+  });
+
   it('should switch to policy systems when selected systems is chosen', () => {
     render(<EditPolicySystemsTab {...defaultProps} />);
 

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -1,6 +1,5 @@
-import React, { useLayoutEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
 import { Spinner } from '@patternfly/react-core';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import { TableStateProvider } from 'bastilian-tabletools';
@@ -37,10 +36,10 @@ export const SystemsTable = ({
   dedicatedAction,
   ignoreOsMajorVersion,
   setIsSystemsDataLoading,
+  perPage,
   ...inventoryTableProps
 }) => {
   const inventory = useRef(null);
-  const dispatch = useDispatch();
 
   const { toolbarProps: conditionalFilter } = useSystemsFilterConfig({
     filters,
@@ -94,14 +93,6 @@ export const SystemsTable = ({
   const noError = error === undefined && !isEmpty;
   const empty = emptyStateComponent && isEmpty ? true : undefined;
 
-  // Resets the Inventory to a loading state
-  // and prevents previously shown columns and rows to appear
-  useLayoutEffect(() => {
-    dispatch({
-      type: 'INVENTORY_INIT',
-    });
-  }, [dispatch]);
-
   return (
     <StateView
       stateValues={{
@@ -133,7 +124,7 @@ export const SystemsTable = ({
             tags: false,
             hostGroupFilter: !showGroupsFilter,
           }}
-          onLoad={defaultOnLoad(columns)}
+          onLoad={defaultOnLoad(columns, { perPage })}
           tableProps={{
             // TODO There must be a bug in the Inventory
             onSelect: undefined,
@@ -180,6 +171,7 @@ SystemsTable.propTypes = {
   ignoreOsMajorVersion: PropTypes.bool,
   reportId: PropTypes.string,
   setIsSystemsDataLoading: PropTypes.func,
+  perPage: PropTypes.number,
 };
 
 const SystemsTableWithTableState = (props) => (

--- a/src/SmartComponents/SystemsTable/helpers.js
+++ b/src/SmartComponents/SystemsTable/helpers.js
@@ -27,8 +27,13 @@ export const mergedColumns = (columns) => (defaultColumns) =>
   }, []);
 
 export const defaultOnLoad =
-  (columns) =>
-  ({ INVENTORY_ACTION_TYPES, mergeWithEntities }) =>
+  (columns, { perPage } = {}) =>
+  ({ INVENTORY_ACTION_TYPES, mergeWithEntities }) => {
     getRegistry().register({
       ...mergeWithEntities(entitiesReducer(INVENTORY_ACTION_TYPES, columns)),
     });
+    getRegistry().store.dispatch({
+      type: 'INVENTORY_INIT',
+      ...(perPage ? { payload: { perPage } } : {}),
+    });
+  };

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -10,9 +10,10 @@ const selectRows = (rows, selected) =>
 
 export const entitiesReducer = () =>
   applyReducerHash({
-    ['INVENTORY_INIT']: () => ({
+    ['INVENTORY_INIT']: (_state, { payload: { perPage } = {} } = {}) => ({
       rows: [],
       total: 0,
+      perPage,
     }),
     ['RESET_PAGE']: (state) => ({
       ...state,


### PR DESCRIPTION
The Edit Policy modal's Systems tab defaults to showing 50 systems per page, which is excessive for a modal context. This sets the default to 10.

## How to test:

1. Have insights-chrome and insert into webpack config
```
'/apps/compliance': {
  host: 'http://localhost:8004/',
},
'/apps/inventory': {
  host: 'http://localhost:8005/',
}, 
```
2. Run insights-chrome with `npm run dev`
3. Run insights-inventory-frontend with `npm run static -- -p=8005`
4. Checkout to this PR and run `npm run static -- -p=8004`
5. Navigate to Compliance -> Policies
6. Click on a policy that has 10+ systems associated (or create one)
7. Switch to Systems tab
8. Click "Edit policy" button
9. Navigate to the "Systems" tab
10. Verify that the systems table shows 10 items per page instead of 50

## Summary

- Added a `perPage` prop to `SystemsTable` that allows callers to override the default per-page count
- Pass `perPage={10}` in the Edit Policy Systems tab
- Updated `INVENTORY_INIT` reducer to accept and apply `perPage` from payload

## Summary by Sourcery

Set the Systems table in the Edit Policy modal to show 10 items per page instead of the previous default.

New Features:
- Allow SystemsTable consumers to configure the default per-page count via a new perPage prop.

Enhancements:
- Update the INVENTORY_INIT entities reducer to initialize state with a configurable perPage value derived from the action payload.