### PR TITLE
build(image): add Dockerfile and IoP container publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/.github/workflows/iop-container-publish.yaml
+++ b/.github/workflows/iop-container-publish.yaml
@@ -1,0 +1,77 @@
+name: Container image build and publish
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+      - 'foreman-*.*'
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: "iop/compliance-frontend"
+
+jobs:
+  build:
+    concurrency:
+      group: "${{ github.workflow }}-${{ github.ref }}"
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20
+        with:
+          cosign-release: 'v2.2.4'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@3864d6aed8ff134b2ed894ce00c87695c709c870
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_IOP_BUILD_USERNAME }}
+          password: ${{ secrets.QUAY_IOP_BUILD_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ff26911fd365b0233252dfbd8eede1c0e9ef9a51
+        with:
+          platforms: linux/amd64
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            DIST_PATH=/srv/dist
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        if: github.event_name != 'pull_request'
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi9/nodejs-22:latest AS builder
+WORKDIR /opt/app-root/src
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+ARG DIST_PATH=/opt/app-root/src/dist
+COPY --from=builder /opt/app-root/src/dist ${DIST_PATH}


### PR DESCRIPTION
Adds a multi-stage Dockerfile and a GitHub Actions workflow to publish the image to quay.io/iop/compliance-frontend on push to master and foreman-* branches.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add a multi-stage Docker build and CI workflow to build, publish, and sign the compliance-frontend container image to quay.io on key branches.

Build:
- Introduce a multi-stage Dockerfile using UBI Node.js for building and UBI Micro for serving built assets.
- Add a GitHub Actions workflow to build, tag, and publish the container image to quay.io for master and foreman-* branches, including metadata, caching, and cosign-based signing.