### PR TITLE
fix(SystemsTable): correct table loading

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -126,7 +126,7 @@ export const SystemsTable = ({
             tags: false,
             hostGroupFilter: !showGroupsFilter,
           }}
-          onLoad={defaultOnLoad(columns, { perPage })}
+          onLoad={defaultOnLoad(columns, { perPage, sortBy })}
           sortBy={sortBy}
           hasCheckbox={selectionEnabled}
           tableProps={{

--- a/src/SmartComponents/SystemsTable/helpers.js
+++ b/src/SmartComponents/SystemsTable/helpers.js
@@ -27,13 +27,16 @@ export const mergedColumns = (columns) => (defaultColumns) =>
   }, []);
 
 export const defaultOnLoad =
-  (columns, { perPage } = {}) =>
+  (columns, { perPage, sortBy } = {}) =>
   ({ INVENTORY_ACTION_TYPES, mergeWithEntities }) => {
     getRegistry().register({
       ...mergeWithEntities(entitiesReducer(INVENTORY_ACTION_TYPES, columns)),
     });
     getRegistry().store.dispatch({
       type: 'INVENTORY_INIT',
-      ...(perPage ? { payload: { perPage } } : {}),
+      payload: {
+        ...(perPage ? { perPage } : {}),
+        ...(sortBy ? { sortBy } : {}),
+      },
     });
   };

--- a/src/SmartComponents/SystemsTable/hooks/useSystemsFilterConfig.js
+++ b/src/SmartComponents/SystemsTable/hooks/useSystemsFilterConfig.js
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useDeepCompareEffect } from 'use-deep-compare';
 import debounce from '@redhat-cloud-services/frontend-components-utilities/debounce';
@@ -12,6 +12,8 @@ const useSystemsFilterConfig = ({
 }) => {
   const dispatch = useDispatch();
   const serialiseredTableState = useSerialisedTableState();
+  const tableFilters = serialiseredTableState?.filters;
+  const isInitialFilterState = useRef(true);
   const filterConfig = useMemo(
     () => [
       ...(policies?.length ? [filters.policies(policies)] : []),
@@ -40,8 +42,13 @@ const useSystemsFilterConfig = ({
   }, 150);
 
   useDeepCompareEffect(() => {
+    if (isInitialFilterState.current) {
+      isInitialFilterState.current = false;
+      return;
+    }
+
     debounceResetPage();
-  }, [serialiseredTableState]);
+  }, [tableFilters]);
 
   return filterConfigReturn;
 };

--- a/src/store/Reducers/SystemStore.js
+++ b/src/store/Reducers/SystemStore.js
@@ -10,10 +10,14 @@ const selectRows = (rows, selected) =>
 
 export const entitiesReducer = () =>
   applyReducerHash({
-    ['INVENTORY_INIT']: (_state, { payload: { perPage } = {} } = {}) => ({
+    ['INVENTORY_INIT']: (
+      _state,
+      { payload: { perPage, sortBy } = {} } = {},
+    ) => ({
       rows: [],
       total: 0,
       perPage,
+      ...(sortBy ? { sortBy } : {}),
     }),
     ['RESET_PAGE']: (state) => ({
       ...state,


### PR DESCRIPTION
Few improvements to systems table (follow up for https://github.com/RedHatInsights/compliance-frontend/pull/2898):

1. Avoid calling dispatch `RESET PAGE` on initial load since inventory table takes care of filters initially
2. Only refresh Inventory when filters actually change
3. Seed default sortBy into Redux via INVENTORY_INIT so the first Inventory fetch already uses the correct sort.

### How to test:

1. Navigate to any page that has systems table (Compliance->Systems, for example)
2. Check if table loads well initially
3. Open network tab and navigate to any other page
4. Now navigate back to systems page and check you see only 1 api requests for systems endpoint

**Before** any system table would send 2 /systems API requests + table will show loading state twice

**After** only 1 systems API request sent and table loads only once. 


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Optimize systems table loading to prevent redundant refreshes and align initial inventory state with the configured sort and pagination.

Bug Fixes:
- Prevent the systems table from triggering an extra reset and duplicate loading on initial render.
- Refresh the inventory table only when its filters actually change to avoid unnecessary API calls.

Enhancements:
- Initialize the inventory store with both per-page and sort configuration so the first data fetch uses the correct sort order.