### PR TITLE
fix(RHINENG-28287): show all policies in the Systems page filter

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -118,3 +118,8 @@ button[data-ouia-component-id="InlineEditReset"] {
 .pf-v6-c-table__tree-view-title-cell.compliance-rule-details .pf-v6-c-table__check {
   visibility: hidden
 }
+
+[data-ouia-component-type="PF6/Select"] > .pf-v6-c-menu__content {
+  max-height: 18.75rem;
+  overflow-y: auto;
+}

--- a/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
+++ b/src/SmartComponents/ComplianceSystems/ComplianceSystems.js
@@ -21,7 +21,7 @@ const systemTableColumns = [
 
 const ComplianceSystems = () => {
   const navigateToInventory = useNavigate('inventory');
-  const { data, error, loading } = usePolicies();
+  const { data, error, loading } = usePolicies({ batched: true });
   const policies = data?.data;
 
   return (


### PR DESCRIPTION
The Policy filter on the Compliance > Systems page only shows 10 policies because `usePolicies()` is called without options, so the API applies its default limit of 10. This PR fetches all policies using batched requests and adds a scrollable cap to Select-based filter dropdowns.

## How to test:

1. Have insights-chrome and insert into webpack config
```
'/apps/compliance': {
  host: 'http://localhost:8004/',
},
'/apps/inventory': {
  host: 'http://localhost:8005/',
},
```
2. Run insights-chrome with `npm run dev`
3. Run insights-inventory-frontend with `npm run static -- -p=8005`
4. Checkout to this PR and run `npm run static -- -p=8004`
5. Log in as a user with more than 10 policies (e.g. insights-qa in stage)
6. Navigate to Compliance -> Systems
7. Click the Policy filter dropdown
8. Verify that all policies are listed (not just 10)
9. Verify that the dropdown is scrollable when there are many policies

## Summary

- Changed `usePolicies()` to `usePolicies({ batched: true })` in `ComplianceSystems.js` to fetch all policies via the existing `useFetchTotalBatched` mechanism instead of getting only the server default of 10
- Added a CSS rule in `App.scss` to cap Select-based filter dropdowns at `18.75rem` with `overflow-y: auto`, preventing long lists from overflowing the page

## Jira
https://redhat.atlassian.net/browse/RHINENG-28287

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fetch all compliance policies for the Systems page policy filter and constrain filter dropdown height to remain scrollable with long lists.

New Features:
- Display all available compliance policies in the Systems page policy filter instead of the default limited subset.

Enhancements:
- Enable batched fetching of compliance policies for the Systems page to remove the API default limit.
- Cap the height of Select-based filter dropdown menus and enable vertical scrolling to prevent them from overflowing the page layout.