### PR TITLE
fix(EditPolicy): check prev item exist before calling length

### DIFF
--- a/.tekton/compliance-frontend-pull-request.yaml
+++ b/.tekton/compliance-frontend-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "master" || target_branch == "hotfix")
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: insights-compliance

--- a/.tekton/compliance-frontend-push.yaml
+++ b/.tekton/compliance-frontend-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && (target_branch == "master" || target_branch == "hotfix")
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: insights-compliance

--- a/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
+++ b/src/SmartComponents/EditPolicy/EditPolicyRulesTab.js
@@ -118,7 +118,8 @@ export const EditPolicyRulesTab = ({
         return {
           ...prevRuleIds,
           [Number(profile.osMinorVersion)]:
-            prev?.[profile.osMinorVersion].length > 0
+            Array.isArray(prev?.[profile.osMinorVersion]) &&
+            prev[profile.osMinorVersion].length > 0
               ? prev?.[profile.osMinorVersion]
               : profile.ruleIds,
         };


### PR DESCRIPTION
### How to test:

1. Create any SCAP policy but with API so you don't get any systems assigned to it and it will not have tailorings
2. Navigate to edit policy modal and try to associate any system
3. Observe no errors

Before it was failing with:
```
installHook.js:1 TypeError: Cannot read properties of undefined (reading 'length')
    at EditPolicy.eaada4494ad6bcc4a9a1.js:1:3773
    at Array.reduce (<anonymous>)
    at EditPolicy.eaada4494ad6bcc4a9a1.js:1:3704
    at wi (chrome-root.c9a3d4eb74aa04b1.js:2:139823)
    at Ei (chrome-root.c9a3d4eb74aa04b1.js:2:140281)
    at Object.useState (chrome-root.c9a3d4eb74aa04b1.js:2:146635)
    at t.useState (chrome-root.c9a3d4eb74aa04b1.js:2:225631)
    at T (EditPolicy.eaada4494ad6bcc4a9a1.js:1:2927)
    at mi (chrome-root.c9a3d4eb74aa04b1.js:2:139005)
    at Tc (chrome-root.c9a3d4eb74aa04b1.js:2:153058)
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Fix TypeError in Edit Policy rules tab by safely checking previous profile rule arrays before accessing their length.